### PR TITLE
chore(storage): configure sqlc for type-safe database query generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: help up down logs ps clean db-shell db-logs otel-logs build-docker test test-integration coverage vuln lint build ci
+.PHONY: help up down logs ps clean db-shell db-logs otel-logs build-docker test test-integration coverage vuln lint build generate ci
 
-# GOBIN resolves to the user's GOPATH bin directory where tools like govulncheck live.
+# GOBIN resolves to the user's GOPATH bin directory where tools like govulncheck and sqlc live.
 # Install govulncheck once with: go install golang.org/x/vuln/cmd/govulncheck@latest
+# Install sqlc once with:        go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
 GOBIN ?= $(shell go env GOPATH)/bin
 
 # COVERAGE_THRESHOLD is the minimum acceptable unit test coverage percentage.
@@ -75,6 +76,9 @@ coverage: ## Run unit tests with coverage report and enforce COVERAGE_THRESHOLD 
 	    printf 'FAIL: coverage %s%% is below $(COVERAGE_THRESHOLD)%% threshold\n' "$$TOTAL"; \
 	    exit 1; \
 	  fi
+
+generate: ## Regenerate type-safe Go code from db/queries/ using sqlc (requires queries to exist)
+	$(GOBIN)/sqlc generate
 
 vuln: ## Run govulncheck vulnerability scan
 	$(GOBIN)/govulncheck ./...

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -1,0 +1,19 @@
+version: "2"
+sql:
+  - engine: "postgresql"
+    schema: "db/migrations"
+    queries: "db/queries"
+    gen:
+      go:
+        package: "postgres"
+        out: "internal/adapter/postgres"
+        emit_json_tags: true
+        emit_interface: false
+        sql_package: "pgx/v5"
+        overrides:
+          - db_type: "uuid"
+            go_type: "github.com/google/uuid.UUID"
+          - db_type: "pg_catalog.timestamptz"
+            go_type: "time.Time"
+          - db_type: "pg_catalog.numeric"
+            go_type: "github.com/jackc/pgx/v5/pgtype.Numeric"


### PR DESCRIPTION
## Summary
- Add `sqlc.yaml` with postgresql engine, pgx/v5 sql_package, `emit_json_tags=true`, `emit_interface=false`
- Configure type overrides: `uuid` → `github.com/google/uuid.UUID`, `timestamptz` → `time.Time`
- Set generated code output directory to `internal/adapter/postgres/`
- Add `make generate` target — runs `sqlc generate` to regenerate Go code from `db/queries/`
- No queries yet per scope boundary; type mappings enforce at compile time on first query in #15

## Test plan
- [x] `make ci` passes (lint + coverage gate + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all ACs and edge cases covered)
- [x] `/project:review` verdict: PASS (all 8 categories)
- [x] `sqlc generate` runs without config errors (fails only on empty queries dir — expected pre-#15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)