### PR TITLE
chore(observe): enforce observability policies across all existing code

### DIFF
--- a/.claude/commands/project:review.md
+++ b/.claude/commands/project:review.md
@@ -40,7 +40,7 @@ Review the actual code — read every changed file, check imports, verify tests 
 - [ ] Log messages: sentence case, no period
 - [ ] slog attribute keys: `snake_case`
 
-## Logging
+## Observability — Logging
 - [ ] WARN logged for every recoverable failure: retries, fallbacks, degraded states — silence implies success
 - [ ] ERROR logged at the handler/entrypoint that catches and resolves the error, not in functions that return it
 - [ ] No double-logging: functions that return an error do not also log it
@@ -50,6 +50,23 @@ Review the actual code — read every changed file, check imports, verify tests 
 - [ ] Context-aware calls only: `slog.XxxContext(ctx, ...)` — never `slog.Xxx(...)` in production code
 - [ ] Attribute keys are `snake_case`
 - [ ] Errors included as structured attribute `"error", err` — never interpolated into the message string
+- [ ] No PII or secrets in log attributes (email, password hash, tokens, card numbers)
+
+## Observability — Tracing
+- [ ] Every adapter method (postgres repo, HTTP client, external service call) opens a span:
+      `ctx, span := otel.Tracer("package").Start(ctx, "Type.Method")`
+- [ ] Every span is closed: `defer span.End()` immediately after `Start`
+- [ ] Every error path records the error on the span before returning:
+      `span.RecordError(err)` + `span.SetStatus(codes.Error, err.Error())`
+- [ ] Happy paths set status OK: `span.SetStatus(codes.Ok, "")` (not strictly required by OTel spec but signals intent)
+- [ ] Span names follow `"Domain.Method"` convention — e.g. `"UserRepo.FindByID"`, `"HouseholdLogic.Create"`
+- [ ] Span attributes use `snake_case` keys and carry enough context to diagnose without the logs:
+      e.g. `"user_id"`, `"household_id"`, `"query_rows_affected"`
+- [ ] No PII or secrets in span attributes (same rule as logging)
+- [ ] Health check endpoints (`/healthz`, `/health/live`, `/health/ready`) are NOT traced —
+      they would pollute trace data with noise
+- [ ] `context.Context` is the first argument of every traced function so the span propagates
+- [ ] Domain logic does NOT create spans — tracing is adapter/platform concern only
 
 ## Testing
 - [ ] Table-driven format for 3+ cases testing same behavior
@@ -99,3 +116,18 @@ Review the actual code — read every changed file, check imports, verify tests 
 **Report format:** List each category as PASS or FAIL.
 For failures, state the specific violation and the file:line where it occurs.
 Do NOT suggest committing until every category passes.
+
+Categories:
+1. Error Handling
+2. Interface Design
+3. Concurrency
+4. Naming and Style
+5. Observability — Logging
+6. Observability — Tracing
+7. Testing
+8. Architecture
+9. Go-Specific Traps
+10. SQL & Database (when applicable)
+
+**Tracing scope:** Apply the Tracing category only to files in `internal/adapter/` and `internal/platform/`.
+Domain packages (`internal/domain/`) must NOT have tracing — flag it as a violation if they do.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,9 @@ deploy/docker/        -> Dockerfile, docker-compose.yml
 - Every goroutine has lifecycle management (`errgroup`, `WaitGroup`, context). No fire-and-forget.
 - Maps require `sync.RWMutex` for concurrent access. Fakes are thread-safe.
 
-## Logging Conventions
+## Observability
+
+### Logging
 
 - Levels: `DEBUG` (internal state), `INFO` (business events), `WARN` (recoverable), `ERROR` (action required).
 - Always context-aware: `slog.InfoContext(ctx, "message")`. Never create new `slog.Logger` in business logic.
@@ -194,6 +196,33 @@ deploy/docker/        -> Dockerfile, docker-compose.yml
 - **Errors are logged once — at the caller that handles them.** Functions that return an error do not log it. The handler or entrypoint that catches and resolves the error is responsible for logging at ERROR. This prevents double-logging of the same event.
 - **Exception: retry loops.** A function that internally retries logs each failed attempt at WARN (it handles each attempt itself). The final unrecoverable error is returned to the caller, which logs it at ERROR.
 - **INFO for lifecycle events.** Significant state transitions — service ready, connection established, shutdown started — must emit `slog.InfoContext`. These are the breadcrumbs operators use to understand startup and shutdown sequences.
+
+### Tracing (OpenTelemetry)
+
+Tracing lives in `internal/adapter/` and `internal/platform/` only. Domain logic is never traced directly.
+
+**Every adapter method** (postgres repo method, HTTP client call, external service call) must:
+
+```go
+ctx, span := otel.Tracer("package").Start(ctx, "Type.Method")
+defer span.End()
+```
+
+**Every error path** must record the error before returning:
+
+```go
+span.RecordError(err)
+span.SetStatus(codes.Error, err.Error())
+return fmt.Errorf("context: %w", err)
+```
+
+**Rules:**
+- Span names: `"Domain.Method"` — e.g. `"UserRepo.FindByID"`, `"HouseholdLogic.Create"`
+- Span attributes: `snake_case` keys, carry enough context to diagnose without the logs (`"user_id"`, `"household_id"`, `"rows_affected"`)
+- No PII or secrets in span attributes (email, password hash, tokens, card numbers)
+- Health endpoints (`/healthz`, `/health/live`, `/health/ready`) must NOT be traced — noise
+- `context.Context` is always the first argument so spans propagate through the call chain
+- Import: `"go.opentelemetry.io/otel"` and `"go.opentelemetry.io/otel/codes"`
 
 ## Go Traps — Enforce on Every Review
 

--- a/cmd/pfm/main.go
+++ b/cmd/pfm/main.go
@@ -41,12 +41,12 @@ func run() error {
 
 	cfg, err := config.Load()
 	if err != nil {
-		return fmt.Errorf("load config: %w", err)
+		return fmt.Errorf(message.ErrRunLoadConfig, err)
 	}
 
 	var logLevel slog.Level
 	if err := logLevel.UnmarshalText([]byte(cfg.LogLevel)); err != nil {
-		return fmt.Errorf("parse log level %q: %w", cfg.LogLevel, err)
+		return fmt.Errorf(message.ErrRunLogLevel, cfg.LogLevel, err)
 	}
 	logger := observe.NewLogger(logLevel, nil)
 
@@ -62,14 +62,14 @@ func run() error {
 
 	tp, tracerShutdown, err := observe.NewTracerProvider(ctx, cfg, "pfm-go", Version)
 	if err != nil {
-		return fmt.Errorf("init tracer: %w", err)
+		return fmt.Errorf(message.ErrRunTracerInit, err)
 	}
 	_ = tp
 	slog.InfoContext(ctx, message.MsgTracerReady)
 
 	db, err := database.Open(ctx, cfg)
 	if err != nil {
-		return fmt.Errorf("open database: %w", err)
+		return fmt.Errorf(message.ErrRunOpenDB, err)
 	}
 
 	migrationsFS, err := fs.Sub(pfmdb.Migrations, "migrations")
@@ -78,7 +78,7 @@ func run() error {
 	}
 
 	if err := database.Migrate(ctx, db, migrationsFS); err != nil {
-		return fmt.Errorf("run migrations: %w", err)
+		return fmt.Errorf(message.ErrRunMigrate, err)
 	}
 
 	var shuttingDown atomic.Bool

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -64,6 +64,7 @@ const (
 	ErrDBOpen        = "database: open driver: %w"
 	ErrDBPing        = "database: ping after %d retries: %w"
 	ErrDBContextDone = "database: context cancelled during startup: %w"
+	ErrDBVerifyConn  = "database: verify connection: %w"
 )
 
 // Migration log messages.
@@ -78,4 +79,19 @@ const (
 	ErrMigrateSubFS    = "migrate: create sub filesystem: %w"
 	ErrMigrateProvider = "migrate: create provider: %w"
 	ErrMigrateUp       = "migrate: apply pending migrations: %w"
+)
+
+// Observe errors.
+const (
+	ErrTracerResource = "observe: build resource: %w"
+	ErrTracerExporter = "observe: create OTLP exporter: %w"
+)
+
+// Startup errors (used by cmd/pfm/main.go composition root).
+const (
+	ErrRunLoadConfig = "load config: %w"
+	ErrRunLogLevel   = "parse log level %q: %w"
+	ErrRunTracerInit = "init tracer: %w"
+	ErrRunOpenDB     = "open database: %w"
+	ErrRunMigrate    = "run migrations: %w"
 )

--- a/internal/platform/database/database.go
+++ b/internal/platform/database/database.go
@@ -64,7 +64,7 @@ func Open(ctx context.Context, cfg *config.Config) (*sql.DB, error) {
 	db.SetConnMaxIdleTime(time.Duration(cfg.DBConnMaxIdleTimeSec) * time.Second)
 
 	if err := pingWithRetry(ctx, db, cfg); err != nil {
-		return nil, fmt.Errorf("verify connection: %w", err)
+		return nil, fmt.Errorf(message.ErrDBVerifyConn, err)
 	}
 
 	slog.InfoContext(ctx, message.MsgDBReady)

--- a/internal/platform/observe/logger.go
+++ b/internal/platform/observe/logger.go
@@ -55,7 +55,6 @@ func addContextAttrs(ctx context.Context, record slog.Record) slog.Record {
 		record.AddAttrs(slog.String("span_id", spanCtx.SpanID().String()))
 	} else if traceId, ok := ctxutil.TraceID(ctx); ok && traceId != "" {
 		record.AddAttrs(slog.String("trace_id", traceId))
-		record.AddAttrs(slog.String("span_id", ""))
 	}
 
 	if userId, ok := ctxutil.UserID(ctx); ok {

--- a/internal/platform/observe/observe_test.go
+++ b/internal/platform/observe/observe_test.go
@@ -51,7 +51,7 @@ func TestNewLogger_InfoLog_IncludesRequestContextFields(t *testing.T) {
 	assert.Equal(t, "trace-123", entry["trace_id"])
 	assert.Equal(t, userId.String(), entry["user_id"])
 	assert.Equal(t, householdId.String(), entry["household_id"])
-	assert.Contains(t, entry, "span_id")
+	assert.NotContains(t, entry, "span_id") // ctxutil fallback has no OTel span — span_id must be absent, not empty
 }
 
 func TestNewLogger_WhenLevelInfo_DebugMessagesSuppressed(t *testing.T) {

--- a/internal/platform/observe/tracing.go
+++ b/internal/platform/observe/tracing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/zambone/pfm-go/internal/message"
 	"github.com/zambone/pfm-go/internal/platform/config"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -24,7 +25,7 @@ func NewTracerProvider(ctx context.Context, cfg *config.Config, serviceName, ser
 		),
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("observe: build resource: %w", err)
+		return nil, nil, fmt.Errorf(message.ErrTracerResource, err)
 	}
 
 	opts := []sdktrace.TracerProviderOption{
@@ -38,7 +39,7 @@ func NewTracerProvider(ctx context.Context, cfg *config.Config, serviceName, ser
 			otlptracegrpc.WithInsecure(),
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("observe: create OTLP exporter: %w", err)
+			return nil, nil, fmt.Errorf(message.ErrTracerExporter, err)
 		}
 		opts = append(opts, sdktrace.WithBatcher(exporter))
 	}


### PR DESCRIPTION
## Summary
- Add tracing rules to `/project:review` checklist (spans on every adapter method, `span.RecordError` + `span.SetStatus` on errors, no PII in span attributes, health endpoints excluded)
- Add tracing conventions to `CLAUDE.md` with canonical code pattern
- Add missing error constants: `ErrDBVerifyConn`, `ErrTracerResource`, `ErrTracerExporter`, `ErrRunLoadConfig`, `ErrRunLogLevel`, `ErrRunTracerInit`, `ErrRunOpenDB`, `ErrRunMigrate`
- Replace all inline error-wrapping strings in `database.go`, `tracing.go`, and `main.go` with `internal/message/` constants
- Remove empty `span_id: ""` attribute from logger when using ctxutil trace fallback — absent is correct, empty string is noise
- Update `observe_test` to assert `span_id` is absent (not empty) in the ctxutil trace path

## Test plan
- [x] `make ci` passes (lint + coverage gate + vuln scan + integration tests + build)
- [x] `TestNewLogger_InfoLog_IncludesRequestContextFields` updated: asserts `span_id` absent in ctxutil path
- [x] All existing observe tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)