### PR TITLE
feat(storage): add accounts table migration

### DIFF
--- a/db/migrations/20260304000002_create_accounts.sql
+++ b/db/migrations/20260304000002_create_accounts.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+
+CREATE TABLE accounts (
+    id            UUID        NOT NULL DEFAULT uuidv7()  PRIMARY KEY,
+    household_id  UUID        NOT NULL REFERENCES households(id),
+    name          TEXT        NOT NULL,
+    account_type  TEXT        NOT NULL
+                              CHECK (account_type IN ('CHECKING', 'SAVINGS', 'CREDIT_CARD', 'INVESTMENT')),
+    currency_code TEXT        NOT NULL
+                              CHECK (currency_code IN ('USD', 'BRL', 'EUR')),
+    balance       BIGINT      NOT NULL DEFAULT 0,
+    status        TEXT        NOT NULL DEFAULT 'ACTIVE'
+                              CHECK (status IN ('ACTIVE', 'INACTIVE')),
+    version       INTEGER     NOT NULL DEFAULT 1,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by    UUID        REFERENCES users(id),
+    updated_by    UUID        REFERENCES users(id),
+    deleted_at    TIMESTAMPTZ
+);
+
+-- Name uniqueness is scoped to the household and is case-insensitive.
+-- The partial index means soft-deleted accounts do not block name reuse.
+-- No ON DELETE CASCADE on household_id — accounts must be explicitly managed.
+CREATE UNIQUE INDEX accounts_name_unique_active
+    ON accounts (household_id, lower(name))
+    WHERE deleted_at IS NULL;
+
+-- +goose Down
+
+DROP TABLE IF EXISTS accounts;

--- a/internal/platform/database/accounts_migration_integration_test.go
+++ b/internal/platform/database/accounts_migration_integration_test.go
@@ -1,0 +1,260 @@
+//go:build integration
+
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccountsMigration_DefaultsOnCreate verifies AC1: a new account has name, type,
+// currency, zero balance, version=1, and status='ACTIVE'.
+func TestAccountsMigration_DefaultsOnCreate(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t, ctx)
+	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
+
+	var userID, householdID string
+	err := db.QueryRowContext(ctx,
+		"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3) RETURNING id::text",
+		"alice@example.com", testPasswordHash, "Alice",
+	).Scan(&userID)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		"INSERT INTO households (name, created_by, updated_by) VALUES ($1, $2::uuid, $2::uuid) RETURNING id::text",
+		"Personal", userID,
+	).Scan(&householdID)
+	require.NoError(t, err)
+
+	var status, accountType, currencyCode string
+	var balance int64
+	var version int
+	var createdOK, updatedOK bool
+
+	err = db.QueryRowContext(ctx,
+		`INSERT INTO accounts (household_id, name, account_type, currency_code, created_by, updated_by)
+		 VALUES ($1::uuid, $2, $3, $4, $5::uuid, $5::uuid)
+		 RETURNING status, account_type, currency_code, balance, version,
+		           created_at IS NOT NULL, updated_at IS NOT NULL`,
+		householdID, "Checking", "CHECKING", "USD", userID,
+	).Scan(&status, &accountType, &currencyCode, &balance, &version, &createdOK, &updatedOK)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ACTIVE", status, "default status must be ACTIVE")
+	assert.Equal(t, "CHECKING", accountType)
+	assert.Equal(t, "USD", currencyCode)
+	assert.Equal(t, int64(0), balance, "initial balance must be zero")
+	assert.Equal(t, 1, version, "version must default to 1")
+	assert.True(t, createdOK, "created_at must be set automatically")
+	assert.True(t, updatedOK, "updated_at must be set automatically")
+}
+
+// TestAccountsMigration_NameUniqueWithinHousehold verifies AC2: two accounts in the same
+// household cannot share the same name.
+func TestAccountsMigration_NameUniqueWithinHousehold(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t, ctx)
+	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
+
+	var userID, householdID string
+	err := db.QueryRowContext(ctx,
+		"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3) RETURNING id::text",
+		"bob@example.com", testPasswordHash, "Bob",
+	).Scan(&userID)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		"INSERT INTO households (name, created_by, updated_by) VALUES ($1, $2::uuid, $2::uuid) RETURNING id::text",
+		"Bob's Household", userID,
+	).Scan(&householdID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO accounts (household_id, name, account_type, currency_code, created_by, updated_by) VALUES ($1::uuid, $2, $3, $4, $5::uuid, $5::uuid)",
+		householdID, "Savings", "SAVINGS", "USD", userID,
+	)
+	require.NoError(t, err)
+
+	// Same name (case-insensitive) in same household must be rejected.
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO accounts (household_id, name, account_type, currency_code, created_by, updated_by) VALUES ($1::uuid, $2, $3, $4, $5::uuid, $5::uuid)",
+		householdID, "SAVINGS", "CHECKING", "BRL", userID,
+	)
+	assert.Error(t, err, "duplicate name in same household must be rejected")
+}
+
+// TestAccountsMigration_NameAllowedAcrossHouseholds verifies AC3: two accounts in different
+// households may share the same name.
+func TestAccountsMigration_NameAllowedAcrossHouseholds(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t, ctx)
+	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
+
+	var user1ID, user2ID, household1ID, household2ID string
+	err := db.QueryRowContext(ctx,
+		"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3) RETURNING id::text",
+		"carol@example.com", testPasswordHash, "Carol",
+	).Scan(&user1ID)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3) RETURNING id::text",
+		"dave@example.com", testPasswordHash, "Dave",
+	).Scan(&user2ID)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		"INSERT INTO households (name, created_by, updated_by) VALUES ($1, $2::uuid, $2::uuid) RETURNING id::text",
+		"Carol's Household", user1ID,
+	).Scan(&household1ID)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		"INSERT INTO households (name, created_by, updated_by) VALUES ($1, $2::uuid, $2::uuid) RETURNING id::text",
+		"Dave's Household", user2ID,
+	).Scan(&household2ID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO accounts (household_id, name, account_type, currency_code, created_by, updated_by) VALUES ($1::uuid, $2, $3, $4, $5::uuid, $5::uuid)",
+		household1ID, "Personal Savings", "SAVINGS", "USD", user1ID,
+	)
+	require.NoError(t, err)
+
+	// Same name in a different household must succeed.
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO accounts (household_id, name, account_type, currency_code, created_by, updated_by) VALUES ($1::uuid, $2, $3, $4, $5::uuid, $5::uuid)",
+		household2ID, "Personal Savings", "SAVINGS", "BRL", user2ID,
+	)
+	assert.NoError(t, err, "same name in a different household must be allowed")
+}
+
+// TestAccountsMigration_SoftDeleteReleasesName verifies AC4: after an account is soft-deleted,
+// its name becomes available for reuse within the same household.
+func TestAccountsMigration_SoftDeleteReleasesName(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t, ctx)
+	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
+
+	var userID, householdID string
+	err := db.QueryRowContext(ctx,
+		"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3) RETURNING id::text",
+		"eve@example.com", testPasswordHash, "Eve",
+	).Scan(&userID)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		"INSERT INTO households (name, created_by, updated_by) VALUES ($1, $2::uuid, $2::uuid) RETURNING id::text",
+		"Eve's Household", userID,
+	).Scan(&householdID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO accounts (household_id, name, account_type, currency_code, created_by, updated_by) VALUES ($1::uuid, $2, $3, $4, $5::uuid, $5::uuid)",
+		householdID, "Old Checking", "CHECKING", "USD", userID,
+	)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		"UPDATE accounts SET deleted_at = NOW() WHERE household_id = $1::uuid AND name = $2",
+		householdID, "Old Checking",
+	)
+	require.NoError(t, err)
+
+	// Same name must now be accepted after soft-delete.
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO accounts (household_id, name, account_type, currency_code, created_by, updated_by) VALUES ($1::uuid, $2, $3, $4, $5::uuid, $5::uuid)",
+		householdID, "Old Checking", "CHECKING", "EUR", userID,
+	)
+	assert.NoError(t, err, "name must be reusable after soft-delete")
+}
+
+// TestAccountsMigration_AccountTypeEnforced verifies AC5: only valid account_type values
+// are accepted; any other value is rejected by the CHECK constraint.
+func TestAccountsMigration_AccountTypeEnforced(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t, ctx)
+	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
+
+	var userID, householdID string
+	err := db.QueryRowContext(ctx,
+		"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3) RETURNING id::text",
+		"frank@example.com", testPasswordHash, "Frank",
+	).Scan(&userID)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		"INSERT INTO households (name, created_by, updated_by) VALUES ($1, $2::uuid, $2::uuid) RETURNING id::text",
+		"Frank's Household", userID,
+	).Scan(&householdID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO accounts (household_id, name, account_type, currency_code, created_by, updated_by) VALUES ($1::uuid, $2, $3, $4, $5::uuid, $5::uuid)",
+		householdID, "Bad Account", "BROKERAGE", "USD", userID,
+	)
+	assert.Error(t, err, "invalid account_type must be rejected by CHECK constraint")
+}
+
+// TestAccountsMigration_CurrencyCodeEnforced verifies AC6: only USD, BRL, and EUR are
+// valid currency codes; any other value is rejected by the CHECK constraint.
+func TestAccountsMigration_CurrencyCodeEnforced(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t, ctx)
+	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
+
+	var userID, householdID string
+	err := db.QueryRowContext(ctx,
+		"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3) RETURNING id::text",
+		"grace@example.com", testPasswordHash, "Grace",
+	).Scan(&userID)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		"INSERT INTO households (name, created_by, updated_by) VALUES ($1, $2::uuid, $2::uuid) RETURNING id::text",
+		"Grace's Household", userID,
+	).Scan(&householdID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO accounts (household_id, name, account_type, currency_code, created_by, updated_by) VALUES ($1::uuid, $2, $3, $4, $5::uuid, $5::uuid)",
+		householdID, "Bad Currency", "SAVINGS", "GBP", userID,
+	)
+	assert.Error(t, err, "invalid currency_code must be rejected by CHECK constraint")
+}
+
+// TestAccountsMigration_RollbackRemovesTable verifies AC7: rolling back the accounts
+// migration drops the table and all constraints cleanly.
+func TestAccountsMigration_RollbackRemovesTable(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t, ctx)
+	sub := usersMigrationsFS(t)
+	require.NoError(t, Migrate(ctx, db, sub))
+
+	var exists bool
+	err := db.QueryRowContext(ctx,
+		"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'accounts')",
+	).Scan(&exists)
+	require.NoError(t, err)
+	require.True(t, exists, "accounts table must exist after Up migration")
+
+	provider, err := goose.NewProvider(goose.DialectPostgres, db, sub,
+		goose.WithLogger(goose.NopLogger()),
+	)
+	require.NoError(t, err)
+
+	// Roll back only the accounts migration (version 20260304000002 → 20260304000001).
+	_, err = provider.DownTo(ctx, 20260304000001)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'accounts')",
+	).Scan(&exists)
+	require.NoError(t, err)
+	assert.False(t, exists, "accounts table must be absent after rollback")
+}


### PR DESCRIPTION
## Summary
- Add `accounts` table with `household_id` FK (no cascade), `name`, `account_type`, `currency_code`, `balance BIGINT DEFAULT 0`, `version=1`, and full audit columns
- Enforce `account_type CHECK ('CHECKING', 'SAVINGS', 'CREDIT_CARD', 'INVESTMENT')` and `currency_code CHECK ('USD', 'BRL', 'EUR')`
- Partial unique index `(household_id, lower(name)) WHERE deleted_at IS NULL` for case-insensitive per-household name uniqueness with soft-delete support

## Test plan
- [x] `make ci` passes (lint + coverage 89.4% + no vulns + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 7 ACs + 6 edge cases)
- [x] `/project:review` verdict: PASS (all 10 categories)
- [x] 7 integration tests, each with a fresh Postgres container via testcontainers

🤖 Generated with [Claude Code](https://claude.com/claude-code)