### PR TITLE
feat(storage): add Transactor port for atomic multi-table operations

### DIFF
--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -87,6 +87,23 @@ const (
 	ErrTracerExporter = "observe: create OTLP exporter: %w"
 )
 
+// Pool errors.
+const (
+	ErrDBParsePoolConfig = "database: parse pool config: %w"
+	ErrDBNewPool         = "database: create pool: %w"
+)
+
+// Transactor log messages.
+const (
+	MsgTransactorRollbackFailed = "transaction rollback failed after fn error"
+)
+
+// Transactor errors.
+const (
+	ErrTransactorBegin  = "transactor: begin transaction: %w"
+	ErrTransactorCommit = "transactor: commit transaction: %w"
+)
+
 // Startup errors (used by cmd/pfm/main.go composition root).
 const (
 	ErrRunLoadConfig = "load config: %w"

--- a/internal/platform/database/database.go
+++ b/internal/platform/database/database.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/zambone/pfm-go/internal/message"
 	"github.com/zambone/pfm-go/internal/platform/config"
@@ -70,4 +71,36 @@ func Open(ctx context.Context, cfg *config.Config) (*sql.DB, error) {
 	slog.InfoContext(ctx, message.MsgDBReady)
 
 	return db, nil
+}
+
+// NewPool creates a pgx-native connection pool for application queries.
+// Unlike Open, which uses the database/sql adapter for goose migrations,
+// NewPool returns a *pgxpool.Pool suitable for use with pgx-native queries
+// and the PostgresTransactor.
+func NewPool(ctx context.Context, cfg *config.Config) (*pgxpool.Pool, error) {
+	slog.InfoContext(ctx, message.MsgDBConnecting)
+
+	poolCfg, err := pgxpool.ParseConfig(buildDSN(cfg))
+	if err != nil {
+		return nil, fmt.Errorf(message.ErrDBParsePoolConfig, err)
+	}
+
+	poolCfg.MaxConns = int32(cfg.DBMaxOpenConns)
+	poolCfg.MinConns = int32(cfg.DBMaxIdleConns)
+	poolCfg.MaxConnLifetime = time.Duration(cfg.DBConnMaxLifetimeSec) * time.Second
+	poolCfg.MaxConnIdleTime = time.Duration(cfg.DBConnMaxIdleTimeSec) * time.Second
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		return nil, fmt.Errorf(message.ErrDBNewPool, err)
+	}
+
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf(message.ErrDBVerifyConn, err)
+	}
+
+	slog.InfoContext(ctx, message.MsgDBReady)
+
+	return pool, nil
 }

--- a/internal/platform/database/fake_transactor.go
+++ b/internal/platform/database/fake_transactor.go
@@ -1,0 +1,43 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// FakeTransactor is a test double for Transactor that executes the callback
+// synchronously without a real database transaction. It records whether the
+// last call committed or rolled back, allowing test assertions on atomicity.
+//
+// FakeTransactor is safe for concurrent use.
+type FakeTransactor struct {
+	mu        sync.Mutex
+	committed bool
+}
+
+// NewFakeTransactor creates a FakeTransactor ready for use in tests.
+func NewFakeTransactor() *FakeTransactor {
+	return &FakeTransactor{}
+}
+
+// RunAtomic calls fn with the same context. If fn returns nil the call is
+// recorded as committed; if fn returns an error it is recorded as rolled back.
+func (f *FakeTransactor) RunAtomic(ctx context.Context, fn func(ctx context.Context) error) error {
+	err := fn(ctx)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.committed = err == nil
+	if err != nil {
+		return fmt.Errorf("transactor: run atomic: %w", err)
+	}
+	return nil
+}
+
+// CommittedLastCall reports whether the last RunAtomic call committed.
+// Returns false before any call has been made.
+func (f *FakeTransactor) CommittedLastCall() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.committed
+}

--- a/internal/platform/database/testhelper_test.go
+++ b/internal/platform/database/testhelper_test.go
@@ -5,12 +5,15 @@ package database
 import (
 	"context"
 	"database/sql"
+	"io/fs"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
+	pfmdb "github.com/zambone/pfm-go/db"
 	"github.com/zambone/pfm-go/internal/platform/config"
 )
 
@@ -58,4 +61,60 @@ func newTestDB(t *testing.T, ctx context.Context) *sql.DB {
 	t.Cleanup(func() { _ = db.Close() })
 
 	return db
+}
+
+// newTestPool spins up a real Postgres container, runs all migrations, and returns
+// a *pgxpool.Pool connected to it. Used by transactor integration tests.
+// Each call creates an isolated container — tests never share state.
+func newTestPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+
+	ctr, err := postgres.Run(ctx,
+		"postgres:18-alpine3.23",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2),
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ctr.Terminate(ctx) })
+
+	host, err := ctr.Host(ctx)
+	require.NoError(t, err)
+	mappedPort, err := ctr.MappedPort(ctx, "5432")
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		DatabaseHost:           host,
+		DatabasePort:           mappedPort.Int(),
+		DatabaseName:           "testdb",
+		DatabaseUser:           "testuser",
+		DatabasePassword:       "testpass",
+		DatabaseSSLMode:        "disable",
+		DBConnectTimeoutSec:    5,
+		DBStartupRetries:       3,
+		DBStartupRetryDelaySec: 1,
+		DBMaxOpenConns:         5,
+		DBMaxIdleConns:         2,
+		DBConnMaxLifetimeSec:   60,
+		DBConnMaxIdleTimeSec:   30,
+	}
+
+	// Run migrations using the database/sql adapter (required by goose).
+	sqlDB, err := Open(ctx, cfg)
+	require.NoError(t, err)
+	sub, err := fs.Sub(pfmdb.Migrations, "migrations")
+	require.NoError(t, err)
+	require.NoError(t, Migrate(ctx, sqlDB, sub))
+	require.NoError(t, sqlDB.Close())
+
+	// Open the pgx-native pool for application use.
+	pool, err := NewPool(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { pool.Close() })
+
+	return pool
 }

--- a/internal/platform/database/transactor.go
+++ b/internal/platform/database/transactor.go
@@ -1,0 +1,128 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/zambone/pfm-go/internal/message"
+)
+
+// Transactor executes a function atomically within a database transaction.
+// Domain logic calls RunAtomic and receives a derived context carrying the active
+// transaction. The domain never sees pgx.Tx — only context.Context.
+type Transactor interface {
+	RunAtomic(ctx context.Context, fn func(ctx context.Context) error) error
+}
+
+// DBTX is satisfied by both *pgxpool.Pool and pgx.Tx.
+// Repository implementations accept DBTX to transparently participate in transactions
+// without knowing whether a transaction is active.
+type DBTX interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// txContextKey is the unexported key used to store pgx.Tx in a context.
+type txContextKey struct{}
+
+// WithTxContext returns a new context carrying tx.
+// Called by PostgresTransactor before invoking the atomic function.
+func WithTxContext(ctx context.Context, tx pgx.Tx) context.Context {
+	return context.WithValue(ctx, txContextKey{}, tx)
+}
+
+// TxFromContext returns the pgx.Tx stored in ctx, if any.
+// Repository methods call this to check for an active transaction.
+func TxFromContext(ctx context.Context) (pgx.Tx, bool) {
+	tx, ok := ctx.Value(txContextKey{}).(pgx.Tx)
+	return tx, ok
+}
+
+// DBTXFromContext returns the pgx.Tx from ctx if present, otherwise returns pool.
+// Repositories call this at the top of every method to get the correct executor,
+// transparently participating in a transaction when one is active.
+func DBTXFromContext(ctx context.Context, pool *pgxpool.Pool) DBTX {
+	if tx, ok := TxFromContext(ctx); ok {
+		return tx
+	}
+	return pool
+}
+
+// PostgresTransactor implements Transactor using a pgx connection pool.
+type PostgresTransactor struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresTransactor creates a PostgresTransactor backed by pool.
+// Panics if pool is nil to catch misconfigured wiring at startup.
+func NewPostgresTransactor(pool *pgxpool.Pool) *PostgresTransactor {
+	if pool == nil {
+		panic("database: NewPostgresTransactor requires a non-nil pool")
+	}
+	return &PostgresTransactor{pool: pool}
+}
+
+// RunAtomic executes fn within a single database transaction.
+//
+// Nested calls: if ctx already carries a transaction, fn is called directly without
+// starting a new transaction — inner calls participate in the outer transaction.
+//
+// On panic inside fn: the transaction is rolled back and the panic is re-raised so
+// the caller's stack trace is preserved.
+//
+// On error from fn: the transaction is rolled back and the error is returned.
+//
+// On success: the transaction is committed.
+func (t *PostgresTransactor) RunAtomic(ctx context.Context, fn func(ctx context.Context) error) error {
+	// Nested call: already inside a transaction — participate without starting a new one.
+	if _, ok := TxFromContext(ctx); ok {
+		return fn(ctx)
+	}
+
+	ctx, span := otel.Tracer("database").Start(ctx, "Transactor.RunAtomic")
+	defer span.End()
+
+	tx, err := t.pool.Begin(ctx)
+	if err != nil {
+		err = fmt.Errorf(message.ErrTransactorBegin, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	// Rollback on panic: executed before span.End() due to LIFO defer order.
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback(ctx) // best-effort: rollback before re-panic
+			panic(p)             // re-raise with original value to preserve stack trace
+		}
+	}()
+
+	txCtx := WithTxContext(ctx, tx)
+	if err = fn(txCtx); err != nil {
+		if rbErr := tx.Rollback(ctx); rbErr != nil {
+			slog.WarnContext(ctx, message.MsgTransactorRollbackFailed, "error", rbErr)
+		}
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("transactor: run atomic: %w", err)
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		err = fmt.Errorf(message.ErrTransactorCommit, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return nil
+}

--- a/internal/platform/database/transactor_integration_test.go
+++ b/internal/platform/database/transactor_integration_test.go
@@ -1,0 +1,236 @@
+//go:build integration
+
+package database
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPostgresTransactor_CommitsOnSuccess verifies AC1+AC2: when fn returns nil,
+// all changes made inside the atomic block are visible after the call.
+func TestPostgresTransactor_CommitsOnSuccess(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	tr := NewPostgresTransactor(pool)
+
+	err := tr.RunAtomic(ctx, func(txCtx context.Context) error {
+		dbtx := DBTXFromContext(txCtx, pool)
+		_, err := dbtx.Exec(txCtx,
+			"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3)",
+			"alice@example.com", testPasswordHash, "Alice",
+		)
+		return err
+	})
+
+	require.NoError(t, err)
+
+	var count int
+	err = pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM users WHERE email = $1",
+		"alice@example.com",
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "committed row must be visible after RunAtomic")
+}
+
+// TestPostgresTransactor_RollsBackOnError verifies AC3: when fn returns an error,
+// all changes made inside the atomic block are not visible after the call.
+func TestPostgresTransactor_RollsBackOnError(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	tr := NewPostgresTransactor(pool)
+
+	want := errors.New("simulated business rule failure")
+
+	err := tr.RunAtomic(ctx, func(txCtx context.Context) error {
+		dbtx := DBTXFromContext(txCtx, pool)
+		_, execErr := dbtx.Exec(txCtx,
+			"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3)",
+			"bob@example.com", testPasswordHash, "Bob",
+		)
+		if execErr != nil {
+			return execErr
+		}
+		return want // trigger rollback
+	})
+
+	assert.ErrorIs(t, err, want)
+
+	var count int
+	err = pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM users WHERE email = $1",
+		"bob@example.com",
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "rolled-back row must not be visible")
+}
+
+// TestPostgresTransactor_RollsBackOnPanic verifies the panic edge case: when fn
+// panics, the transaction is rolled back and the panic is re-raised.
+func TestPostgresTransactor_RollsBackOnPanic(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	tr := NewPostgresTransactor(pool)
+
+	assert.Panics(t, func() {
+		_ = tr.RunAtomic(ctx, func(txCtx context.Context) error {
+			dbtx := DBTXFromContext(txCtx, pool)
+			_, _ = dbtx.Exec(txCtx,
+				"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3)",
+				"charlie@example.com", testPasswordHash, "Charlie",
+			)
+			panic("unexpected failure mid-transaction")
+		})
+	})
+
+	var count int
+	err := pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM users WHERE email = $1",
+		"charlie@example.com",
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "row inserted before panic must be rolled back")
+}
+
+// TestPostgresTransactor_RollsBackOnPanic_PreservesValue verifies that the panic
+// value is re-raised unchanged after rollback.
+func TestPostgresTransactor_RollsBackOnPanic_PreservesValue(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	tr := NewPostgresTransactor(pool)
+
+	type myPanic struct{ msg string }
+	want := myPanic{msg: "domain invariant violated"}
+
+	defer func() {
+		p := recover()
+		require.NotNil(t, p, "panic must be re-raised")
+		assert.Equal(t, want, p, "re-raised panic must have the original value")
+	}()
+
+	_ = tr.RunAtomic(ctx, func(txCtx context.Context) error {
+		panic(want)
+	})
+}
+
+// TestPostgresTransactor_NestedCallUsesOuterTransaction verifies the nested edge case:
+// when RunAtomic is called inside another RunAtomic, the inner call participates in
+// the outer transaction rather than starting a new one. Both inserts commit or roll back
+// together.
+func TestPostgresTransactor_NestedCallUsesOuterTransaction(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	tr := NewPostgresTransactor(pool)
+
+	err := tr.RunAtomic(ctx, func(outerCtx context.Context) error {
+		dbtx := DBTXFromContext(outerCtx, pool)
+		if _, err := dbtx.Exec(outerCtx,
+			"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3)",
+			"dave@example.com", testPasswordHash, "Dave",
+		); err != nil {
+			return err
+		}
+
+		// Nested RunAtomic must reuse the outer transaction.
+		return tr.RunAtomic(outerCtx, func(innerCtx context.Context) error {
+			inner := DBTXFromContext(innerCtx, pool)
+			_, err := inner.Exec(innerCtx,
+				"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3)",
+				"eve@example.com", testPasswordHash, "Eve",
+			)
+			return err
+		})
+	})
+
+	require.NoError(t, err)
+
+	for _, email := range []string{"dave@example.com", "eve@example.com"} {
+		var count int
+		err := pool.QueryRow(ctx,
+			"SELECT COUNT(*) FROM users WHERE email = $1", email,
+		).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count, "both rows from nested atomic calls must be committed")
+	}
+}
+
+// TestPostgresTransactor_NestedRollback verifies that when the outer transaction
+// is rolled back (outer fn returns error), both outer and inner inserts are undone
+// even though the inner RunAtomic succeeded.
+func TestPostgresTransactor_NestedRollback(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	tr := NewPostgresTransactor(pool)
+
+	err := tr.RunAtomic(ctx, func(outerCtx context.Context) error {
+		dbtx := DBTXFromContext(outerCtx, pool)
+		if _, err := dbtx.Exec(outerCtx,
+			"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3)",
+			"frank@example.com", testPasswordHash, "Frank",
+		); err != nil {
+			return err
+		}
+
+		// Inner call succeeds — but outer tx will be rolled back.
+		if err := tr.RunAtomic(outerCtx, func(innerCtx context.Context) error {
+			inner := DBTXFromContext(innerCtx, pool)
+			_, err := inner.Exec(innerCtx,
+				"INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3)",
+				"grace@example.com", testPasswordHash, "Grace",
+			)
+			return err
+		}); err != nil {
+			return err
+		}
+
+		return errors.New("outer failure after nested success")
+	})
+
+	require.Error(t, err)
+
+	for _, email := range []string{"frank@example.com", "grace@example.com"} {
+		var count int
+		err := pool.QueryRow(ctx,
+			"SELECT COUNT(*) FROM users WHERE email = $1", email,
+		).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count, "both rows must be rolled back when outer tx fails")
+	}
+}
+
+// TestPostgresTransactor_DBTXFromContext_NoTx_UsesPool verifies AC4: outside an
+// atomic block, DBTXFromContext returns the pool (regular connection).
+func TestPostgresTransactor_DBTXFromContext_NoTx_UsesPool(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+
+	dbtx := DBTXFromContext(ctx, pool)
+
+	// Pool satisfies DBTX — verify a query works directly.
+	var result int
+	err := dbtx.QueryRow(ctx, "SELECT 1").Scan(&result)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+}
+
+// TestPostgresTransactor_DBTXFromContext_WithTx_UsesTx verifies AC5: inside an
+// atomic block, DBTXFromContext returns the transaction executor.
+func TestPostgresTransactor_DBTXFromContext_WithTx_UsesTx(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	tr := NewPostgresTransactor(pool)
+
+	var dbtxInsideTx DBTX
+	_ = tr.RunAtomic(ctx, func(txCtx context.Context) error {
+		dbtxInsideTx = DBTXFromContext(txCtx, pool)
+		return nil
+	})
+
+	// Inside the atomic block we got a non-nil DBTX backed by the transaction.
+	assert.NotNil(t, dbtxInsideTx)
+}

--- a/internal/platform/database/transactor_test.go
+++ b/internal/platform/database/transactor_test.go
@@ -1,0 +1,66 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time assertion: FakeTransactor must satisfy the Transactor interface.
+var _ Transactor = (*FakeTransactor)(nil)
+
+// TestFakeTransactor_CommitsOnSuccess verifies that when fn returns nil,
+// RunAtomic reports committed and returns no error.
+func TestFakeTransactor_CommitsOnSuccess(t *testing.T) {
+	ft := NewFakeTransactor()
+
+	err := ft.RunAtomic(context.Background(), func(_ context.Context) error {
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, ft.CommittedLastCall(), "committed must be true when fn returns nil")
+}
+
+// TestFakeTransactor_RollsBackOnError verifies that when fn returns an error,
+// RunAtomic reports not committed and returns the same error.
+func TestFakeTransactor_RollsBackOnError(t *testing.T) {
+	ft := NewFakeTransactor()
+	want := errors.New("simulated failure")
+
+	err := ft.RunAtomic(context.Background(), func(_ context.Context) error {
+		return want
+	})
+
+	assert.ErrorIs(t, err, want)
+	assert.False(t, ft.CommittedLastCall(), "committed must be false when fn returns an error")
+}
+
+// TestFakeTransactor_PassesContextThrough verifies that the derived context
+// received by fn is the same context passed to RunAtomic (no substitution).
+func TestFakeTransactor_PassesContextThrough(t *testing.T) {
+	ft := NewFakeTransactor()
+
+	type ctxKey struct{}
+	outer := context.WithValue(context.Background(), ctxKey{}, "marker")
+
+	var gotVal any
+	require.NoError(t, ft.RunAtomic(outer, func(ctx context.Context) error {
+		gotVal = ctx.Value(ctxKey{})
+		return nil
+	}))
+
+	assert.Equal(t, "marker", gotVal, "fn must receive the original context unchanged")
+}
+
+// TestTxFromContext_WhenNotSet_ReturnsFalse verifies that a plain context
+// carries no transaction.
+func TestTxFromContext_WhenNotSet_ReturnsFalse(t *testing.T) {
+	tx, ok := TxFromContext(context.Background())
+
+	assert.False(t, ok)
+	assert.Nil(t, tx)
+}


### PR DESCRIPTION
## Summary
- Adds `Transactor` interface and `PostgresTransactor` backed by `*pgxpool.Pool` for atomic multi-table operations
- `DBTX` interface satisfied by both pool and `pgx.Tx` — repositories transparently participate in transactions via `DBTXFromContext`
- Active transaction stored in `context.Context`; domain logic never sees `pgx.Tx`
- Nested `RunAtomic` calls reuse the outer transaction (no savepoints)
- Panic recovery: rolls back then re-raises to preserve original stack trace
- `FakeTransactor` with `CommittedLastCall()` for unit-testable atomic logic
- `NewPool` adds pgx-native pool alongside existing `*sql.DB` for goose migrations

## Test plan
- [x] `make ci` passes (lint + test -race + build)
- [x] `/project:verify-issue` verdict: PASS
- [x] `/project:review` verdict: PASS (all 9 applicable categories)
- [x] Integration tests pass with testcontainers (8 tests: commit, rollback, panic x2, nested commit, nested rollback, DBTXFromContext x2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)