### PR TITLE
test(auth): add nil clock panic test for NewFakeTokenService

### DIFF
--- a/internal/adapter/auth/fake_token_service_test.go
+++ b/internal/adapter/auth/fake_token_service_test.go
@@ -111,6 +111,14 @@ func TestFakeTokenService_Issue_SameUserProducesUniqueTokens(t *testing.T) {
 	assert.NotEqual(t, t1, t2, "each Issue call must produce a unique token")
 }
 
+// TestNewFakeTokenService_PanicsOnNilClock verifies that constructing a
+// FakeTokenService with a nil clock panics at startup.
+func TestNewFakeTokenService_PanicsOnNilClock(t *testing.T) {
+	assert.Panics(t, func() {
+		authadapter.NewFakeTokenService(nil)
+	})
+}
+
 // TestFakeTokenService_Validate_TokenNotRenewable verifies the edge case:
 // validating after expiry always returns ErrTokenExpired even if re-issued.
 func TestFakeTokenService_Validate_TokenNotRenewable(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `TestNewFakeTokenService_PanicsOnNilClock` — the missing constructor guard test caught by `/review-tests` after #45 merged
- Brings `NewFakeTokenService` coverage from 66.7% → 100%
- Mirrors the existing `TestNewPasetoTokenService_RejectsNilClock` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)