### PR TITLE
feat(middleware): add authentication middleware for bearer token validation

### DIFF
--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -123,6 +123,13 @@ const (
 	ErrTokenServiceKeyLength = "token service: key must be 32 bytes, got %d"
 )
 
+// Authentication middleware messages.
+const (
+	MsgAuthnMissingToken = "missing or malformed authorization header"
+	MsgAuthnExpiredToken = "token expired"
+	MsgAuthnInvalidToken = "invalid token"
+)
+
 // Startup errors (used by cmd/pfm/main.go composition root).
 const (
 	ErrRunLoadConfig = "load config: %w"

--- a/internal/middleware/authn.go
+++ b/internal/middleware/authn.go
@@ -1,0 +1,88 @@
+// Package middleware provides HTTP middleware for the pfm-go application.
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/ctxutil"
+)
+
+const (
+	headerAuthorization = "Authorization"
+	bearerPrefix        = "Bearer "
+	headerContentType   = "Content-Type"
+	mimeJSON            = "application/json"
+)
+
+// tokenValidator is the subset of port/auth.TokenService required by Authn.
+// Accepting an interface defined here (rather than importing port/auth) follows
+// interface segregation: the middleware only needs Validate, not Issue.
+type tokenValidator interface {
+	Validate(ctx context.Context, token string) (uuid.UUID, error)
+}
+
+// Authn returns middleware that enforces Bearer token authentication.
+// It extracts the token from the Authorization header, validates it with tv,
+// and injects the authenticated user ID into the request context via ctxutil.
+// Any failure returns 401 Unauthorized with a JSON error body before the next
+// handler is called. Panics if tv is nil.
+func Authn(tv tokenValidator) func(http.Handler) http.Handler {
+	if tv == nil {
+		panic("middleware: Authn requires non-nil tokenValidator")
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token, ok := extractBearer(r)
+			if !ok {
+				writeJSON(w, http.StatusUnauthorized, message.MsgAuthnMissingToken)
+				return
+			}
+
+			userID, err := tv.Validate(r.Context(), token)
+			if err != nil {
+				if errors.Is(err, message.ErrTokenExpired) {
+					writeJSON(w, http.StatusUnauthorized, message.MsgAuthnExpiredToken)
+					return
+				}
+				writeJSON(w, http.StatusUnauthorized, message.MsgAuthnInvalidToken)
+				return
+			}
+
+			next.ServeHTTP(w, r.WithContext(ctxutil.WithUserID(r.Context(), userID)))
+		})
+	}
+}
+
+// extractBearer parses the Authorization header and returns the raw token.
+// Returns ("", false) if the header is absent, missing the "Bearer " prefix,
+// contains whitespace in the token, or is otherwise malformed.
+func extractBearer(r *http.Request) (string, bool) {
+	h := r.Header.Get(headerAuthorization)
+	if h == "" {
+		return "", false
+	}
+	// Require exact "Bearer " prefix — scheme is case-sensitive per convention.
+	if !strings.HasPrefix(h, bearerPrefix) {
+		return "", false
+	}
+	token := h[len(bearerPrefix):]
+	// Reject empty tokens and tokens containing whitespace (e.g. "tok1 tok2").
+	if token == "" || strings.ContainsAny(token, " \t") {
+		return "", false
+	}
+	return token, true
+}
+
+// writeJSON writes a JSON body of the form {"error": "<msg>"} with the given status code.
+func writeJSON(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set(headerContentType, mimeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg}) // best-effort
+}

--- a/internal/middleware/authn_test.go
+++ b/internal/middleware/authn_test.go
@@ -1,0 +1,215 @@
+package middleware_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zambone/pfm-go/internal/adapter/auth"
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/middleware"
+	"github.com/zambone/pfm-go/internal/platform/clock"
+	"github.com/zambone/pfm-go/internal/platform/ctxutil"
+)
+
+var (
+	fixedTime  = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	testUserID = uuid.MustParse("00000000-0000-0000-0000-000000000001")
+)
+
+// okHandler is a test handler that records whether it was called and
+// returns the user ID from context as a JSON body.
+func okHandler(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := ctxutil.UserID(r.Context())
+		if !ok {
+			http.Error(w, "no user id in context", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"user_id": userID.String()}) // best-effort
+	})
+}
+
+// errorBody decodes a JSON error response body into a map.
+func errorBody(t *testing.T, w *httptest.ResponseRecorder) map[string]string {
+	t.Helper()
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	return body
+}
+
+// newSvc builds a FakeTokenService pre-loaded with a valid token for testUserID.
+func newSvc(t *testing.T) (*auth.FakeTokenService, string) {
+	t.Helper()
+	clk := clock.NewFakeClock(fixedTime)
+	svc := auth.NewFakeTokenService(clk)
+	token, err := svc.Issue(context.Background(), testUserID, time.Hour)
+	require.NoError(t, err)
+	return svc, token
+}
+
+// TestAuthnMiddleware_ValidToken_InjectsUserID verifies AC1:
+// a valid Bearer token causes the user ID to be injected into context.
+func TestAuthnMiddleware_ValidToken_InjectsUserID(t *testing.T) {
+	svc, token := newSvc(t)
+	handler := middleware.Authn(svc)(okHandler(t))
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := errorBody(t, w)
+	assert.Equal(t, testUserID.String(), body["user_id"])
+}
+
+// TestAuthnMiddleware_NoAuthHeader_Returns401 verifies AC3:
+// a request with no Authorization header is rejected with 401.
+func TestAuthnMiddleware_NoAuthHeader_Returns401(t *testing.T) {
+	svc, _ := newSvc(t)
+	handler := middleware.Authn(svc)(okHandler(t))
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, message.MsgAuthnMissingToken, errorBody(t, w)["error"])
+}
+
+// TestAuthnMiddleware_InvalidToken_Returns401 verifies AC2:
+// an invalid token is rejected with 401 and a generic error message.
+func TestAuthnMiddleware_InvalidToken_Returns401(t *testing.T) {
+	svc, _ := newSvc(t)
+	handler := middleware.Authn(svc)(okHandler(t))
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer not-a-real-token")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, message.MsgAuthnInvalidToken, errorBody(t, w)["error"])
+}
+
+// TestAuthnMiddleware_ExpiredToken_Returns401 verifies AC4:
+// an expired token is rejected with 401 and a specific expiry message.
+func TestAuthnMiddleware_ExpiredToken_Returns401(t *testing.T) {
+	clk := clock.NewFakeClock(fixedTime)
+	svc := auth.NewFakeTokenService(clk)
+	token, err := svc.Issue(context.Background(), testUserID, time.Hour)
+	require.NoError(t, err)
+
+	// Advance clock past expiry.
+	clk.Advance(2 * time.Hour)
+
+	handler := middleware.Authn(svc)(okHandler(t))
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, message.MsgAuthnExpiredToken, errorBody(t, w)["error"])
+}
+
+// TestAuthnMiddleware_MalformedHeader_Returns401 verifies edge cases:
+// headers missing the Bearer prefix or with extra whitespace are rejected.
+func TestAuthnMiddleware_MalformedHeader_Returns401(t *testing.T) {
+	svc, token := newSvc(t)
+	handler := middleware.Authn(svc)(okHandler(t))
+
+	cases := []struct {
+		name   string
+		header string
+	}{
+		{"no bearer prefix", "Token " + token},
+		{"bare token", token},
+		{"empty bearer", "Bearer "},
+		{"two tokens", "Bearer " + token + " extra"},
+		{"bearer lowercase", "bearer " + token},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.Header.Set("Authorization", tc.header)
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, r)
+
+			assert.Equal(t, http.StatusUnauthorized, w.Code, "expected 401 for header: %q", tc.header)
+			assert.Equal(t, message.MsgAuthnMissingToken, errorBody(t, w)["error"])
+		})
+	}
+}
+
+// TestAuthn_PanicsOnNilTokenValidator verifies that passing nil panics at
+// wiring time rather than at request time.
+func TestAuthn_PanicsOnNilTokenValidator(t *testing.T) {
+	assert.Panics(t, func() {
+		middleware.Authn(nil)
+	})
+}
+
+// TestAuthnMiddleware_AppliedToRoute_NextReceivesContext verifies AC5:
+// a mux-registered route wrapped with the middleware delivers authenticated context.
+func TestAuthnMiddleware_AppliedToRoute_NextReceivesContext(t *testing.T) {
+	svc, token := newSvc(t)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /protected", middleware.Authn(svc)(okHandler(t)))
+
+	r := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := errorBody(t, w)
+	assert.Equal(t, testUserID.String(), body["user_id"])
+}
+
+// BenchmarkAuthnMiddleware_ValidRequest measures the per-request cost of the
+// middleware on the happy path — runs on every authenticated API request.
+func BenchmarkAuthnMiddleware_ValidRequest(b *testing.B) {
+	svc, token := func() (*auth.FakeTokenService, string) {
+		clk := clock.NewFakeClock(fixedTime)
+		svc := auth.NewFakeTokenService(clk)
+		tok, err := svc.Issue(context.Background(), testUserID, time.Hour)
+		if err != nil {
+			b.Fatal(err)
+		}
+		return svc, tok
+	}()
+
+	handler := middleware.Authn(svc)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Authn` middleware that extracts and validates Bearer tokens via an injected `tokenValidator` interface
- On success, injects authenticated user ID into request context via `ctxutil.WithUserID`
- Returns JSON 401 with distinct messages for missing/malformed header, invalid token, and expired token
- Defines a local `tokenValidator` interface (single `Validate` method) to follow ISP — middleware never imports `port/auth`
- Panics at wiring time on nil validator (not at request time) for fast-fail configuration errors
- Adds 3 message constants to `internal/message/`: `MsgAuthnMissingToken`, `MsgAuthnExpiredToken`, `MsgAuthnInvalidToken`

## Test plan
- [x] `make ci` passes (lint + test -race + build)
- [x] `/project:verify-issue` verdict: PASS
- [x] `/project:review` verdict: PASS (all 8 categories)
- [x] 100% coverage on `internal/middleware/` (8 unit tests + benchmark)
- [x] `/review-tests` verdict: PASS (naming, structure, isolation, race safety, error paths, factories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)