### PR TITLE
feat(user): extend User entity with audit fields and input types

### DIFF
--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -1,4 +1,4 @@
-// Package user contains the business logic for user authentication.
+// Package user contains the business logic for user authentication and lifecycle management.
 package user
 
 import (
@@ -12,7 +12,31 @@ import (
 type User struct {
 	ID           uuid.UUID
 	Email        string
+	DisplayName  string
 	PasswordHash string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	CreatedBy    uuid.UUID
+	UpdatedBy    uuid.UUID
+}
+
+// RegisterInput carries the caller-supplied data for creating a new user.
+// Validation is performed by the domain logic layer before this reaches the repository.
+type RegisterInput struct {
+	Email       string
+	DisplayName string
+	Password    string
+}
+
+// UpdateProfileInput carries the caller-supplied data for updating a user's profile.
+type UpdateProfileInput struct {
+	DisplayName string
+}
+
+// ChangePasswordInput carries the old and new passwords for a password change operation.
+type ChangePasswordInput struct {
+	OldPassword string
+	NewPassword string
 }
 
 // LoginResult is returned on successful authentication.

--- a/internal/domain/user/user_types_test.go
+++ b/internal/domain/user/user_types_test.go
@@ -1,0 +1,91 @@
+package user_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	domainuser "github.com/zambone/pfm-go/internal/domain/user"
+)
+
+// TestUser_FullStruct verifies that User carries all required fields including
+// display name and audit fields. This is a compile-time correctness test —
+// if the fields do not exist, this file will not compile.
+func TestUser_FullStruct(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	callerID := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+
+	u := domainuser.User{
+		ID:           uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		Email:        "user@example.com",
+		DisplayName:  "Test User",
+		PasswordHash: "hash",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		CreatedBy:    callerID,
+		UpdatedBy:    callerID,
+	}
+
+	if u.DisplayName != "Test User" {
+		t.Errorf("DisplayName = %q, want %q", u.DisplayName, "Test User")
+	}
+	if u.CreatedAt != now {
+		t.Errorf("CreatedAt = %v, want %v", u.CreatedAt, now)
+	}
+	if u.UpdatedAt != now {
+		t.Errorf("UpdatedAt = %v, want %v", u.UpdatedAt, now)
+	}
+	if u.CreatedBy != callerID {
+		t.Errorf("CreatedBy = %v, want %v", u.CreatedBy, callerID)
+	}
+	if u.UpdatedBy != callerID {
+		t.Errorf("UpdatedBy = %v, want %v", u.UpdatedBy, callerID)
+	}
+}
+
+// TestRegisterInput_IsConstructible verifies the RegisterInput type exists
+// with the expected fields.
+func TestRegisterInput_IsConstructible(t *testing.T) {
+	in := domainuser.RegisterInput{
+		Email:       "new@example.com",
+		DisplayName: "New User",
+		Password:    "correct-horse-battery-staple",
+	}
+
+	if in.Email == "" {
+		t.Error("Email must be set")
+	}
+	if in.DisplayName == "" {
+		t.Error("DisplayName must be set")
+	}
+	if in.Password == "" {
+		t.Error("Password must be set")
+	}
+}
+
+// TestUpdateProfileInput_IsConstructible verifies the UpdateProfileInput type.
+func TestUpdateProfileInput_IsConstructible(t *testing.T) {
+	in := domainuser.UpdateProfileInput{
+		DisplayName: "Updated Name",
+	}
+
+	if in.DisplayName == "" {
+		t.Error("DisplayName must be set")
+	}
+}
+
+// TestChangePasswordInput_IsConstructible verifies the ChangePasswordInput type.
+func TestChangePasswordInput_IsConstructible(t *testing.T) {
+	in := domainuser.ChangePasswordInput{
+		OldPassword: "old-password",
+		NewPassword: "new-password",
+	}
+
+	if in.OldPassword == "" {
+		t.Error("OldPassword must be set")
+	}
+	if in.NewPassword == "" {
+		t.Error("NewPassword must be set")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `DisplayName`, `CreatedAt`, `UpdatedAt`, `CreatedBy`, `UpdatedBy` to `User` struct
- Add `RegisterInput`, `UpdateProfileInput`, `ChangePasswordInput` domain input types
- All fields use value types (no pointers); zero values are meaningful defaults
- Existing `LoginLogic` and all tests compile and pass unchanged

## Test plan
- [x] `make ci` passes (lint + test -race + build)
- [x] `/project:verify-issue` verdict: PASS
- [x] `/project:review` verdict: PASS (all categories)
- [x] No integration tests needed — pure type definitions, no I/O

🤖 Generated with [Claude Code](https://claude.com/claude-code)