### PR TITLE
feat(user): implement UserLogic domain service with TDD

### DIFF
--- a/internal/adapter/postgres/fake_user_repo.go
+++ b/internal/adapter/postgres/fake_user_repo.go
@@ -68,6 +68,10 @@ func (f *FakeUserRepository) Create(_ context.Context, input domainuser.Register
 		return domainuser.User{}, f.err
 	}
 
+	if _, exists := f.byEmail[strings.ToLower(input.Email)]; exists {
+		return domainuser.User{}, fmt.Errorf(message.ErrUserCreate, message.ErrUserEmailTaken)
+	}
+
 	u := domainuser.User{
 		ID:           uuid.New(),
 		Email:        input.Email,

--- a/internal/domain/user/user_factory_test.go
+++ b/internal/domain/user/user_factory_test.go
@@ -45,6 +45,18 @@ func registerInputFactory(overrides ...func(*domainuser.RegisterInput)) domainus
 	return in
 }
 
+// changePasswordInputFactory returns a valid ChangePasswordInput with sensible defaults.
+func changePasswordInputFactory(overrides ...func(*domainuser.ChangePasswordInput)) domainuser.ChangePasswordInput {
+	in := domainuser.ChangePasswordInput{
+		OldPassword: "correct-horse-battery-staple",
+		NewPassword: "new-correct-horse-staple",
+	}
+	for _, o := range overrides {
+		o(&in)
+	}
+	return in
+}
+
 // updateProfileInputFactory returns a valid UpdateProfileInput with sensible defaults.
 func updateProfileInputFactory(overrides ...func(*domainuser.UpdateProfileInput)) domainuser.UpdateProfileInput {
 	in := domainuser.UpdateProfileInput{

--- a/internal/domain/user/user_logic.go
+++ b/internal/domain/user/user_logic.go
@@ -1,0 +1,140 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+)
+
+// passwordHasher abstracts both hashing and verification of passwords.
+// Structurally satisfied by adapter/auth.FakeHasher and adapter/auth.Argon2idHasher.
+// Distinct from passwordVerifier (Verify-only) used by LoginLogic.
+type passwordHasher interface {
+	Hash(ctx context.Context, password string) (string, error)
+	Verify(ctx context.Context, password, hash string) (bool, error)
+}
+
+// UserLogic orchestrates the user lifecycle: registration, profile updates,
+// password changes, and deactivation.
+type UserLogic struct {
+	repo   Repository
+	hasher passwordHasher
+	clk    clocker
+}
+
+// NewUserLogic constructs a UserLogic. Panics if any dependency is nil.
+func NewUserLogic(repo Repository, hasher passwordHasher, clk clocker) *UserLogic {
+	if repo == nil {
+		panic("user: NewUserLogic requires non-nil repo")
+	}
+	if hasher == nil {
+		panic("user: NewUserLogic requires non-nil hasher")
+	}
+	if clk == nil {
+		panic("user: NewUserLogic requires non-nil clk")
+	}
+	return &UserLogic{repo: repo, hasher: hasher, clk: clk}
+}
+
+// Register validates input, hashes the password, and creates a new user.
+// Returns a ValidationError if input is invalid.
+// Returns an error wrapping ErrUserEmailTaken if the email is already registered.
+func (l *UserLogic) Register(ctx context.Context, input RegisterInput, callerID uuid.UUID) (User, error) {
+	r := validate.NewResult()
+	r.Field("email", input.Email, validate.Required)
+	r.Field("display_name", input.DisplayName, validate.Required, validate.MinLen(2), validate.MaxLen(100))
+	r.Field("password", input.Password, validate.Required, validate.MinLen(8))
+	if err := r.Error(); err != nil {
+		return User{}, err
+	}
+
+	hash, err := l.hasher.Hash(ctx, input.Password)
+	if err != nil {
+		return User{}, fmt.Errorf(message.ErrUserLogicRegister, err)
+	}
+
+	u, err := l.repo.Create(ctx, input, hash, callerID)
+	if err != nil {
+		if errors.Is(err, message.ErrUserEmailTaken) {
+			return User{}, fmt.Errorf(message.ErrUserLogicRegister, message.ErrUserEmailTaken)
+		}
+		return User{}, fmt.Errorf(message.ErrUserLogicRegister, err)
+	}
+	return u, nil
+}
+
+// FindByID returns the active user with the given ID.
+// Returns an error wrapping ErrUserNotFound when no matching active user exists.
+func (l *UserLogic) FindByID(ctx context.Context, id uuid.UUID) (User, error) {
+	u, err := l.repo.FindByID(ctx, id)
+	if err != nil {
+		return User{}, fmt.Errorf(message.ErrUserLogicFindByID, err)
+	}
+	return u, nil
+}
+
+// UpdateProfile validates input and updates the display name of the user identified by id.
+// Returns a ValidationError if the new display name is invalid.
+// Returns an error wrapping ErrUserVersionConflict when expectedVersion does not match.
+func (l *UserLogic) UpdateProfile(ctx context.Context, id uuid.UUID, input UpdateProfileInput, expectedVersion int, callerID uuid.UUID) (User, error) {
+	r := validate.NewResult()
+	r.Field("display_name", input.DisplayName, validate.Required, validate.MinLen(2), validate.MaxLen(100))
+	if err := r.Error(); err != nil {
+		return User{}, err
+	}
+
+	u, err := l.repo.UpdateProfile(ctx, id, input, expectedVersion, callerID)
+	if err != nil {
+		return User{}, fmt.Errorf(message.ErrUserLogicUpdateProfile, err)
+	}
+	return u, nil
+}
+
+// ChangePassword verifies the old password then replaces the hash with a new one.
+// Returns an error wrapping ErrLoginInvalidCredentials if the old password is wrong.
+// Returns an error wrapping ErrUserVersionConflict when expectedVersion does not match.
+func (l *UserLogic) ChangePassword(ctx context.Context, id uuid.UUID, input ChangePasswordInput, expectedVersion int, callerID uuid.UUID) (User, error) {
+	r := validate.NewResult()
+	r.Field("old_password", input.OldPassword, validate.Required)
+	r.Field("new_password", input.NewPassword, validate.Required, validate.MinLen(8))
+	if err := r.Error(); err != nil {
+		return User{}, err
+	}
+
+	current, err := l.repo.FindByID(ctx, id)
+	if err != nil {
+		return User{}, fmt.Errorf(message.ErrUserLogicChangePassword, err)
+	}
+
+	ok, err := l.hasher.Verify(ctx, input.OldPassword, current.PasswordHash)
+	if err != nil {
+		return User{}, fmt.Errorf(message.ErrUserLogicChangePassword, err)
+	}
+	if !ok {
+		return User{}, fmt.Errorf(message.ErrUserLogicChangePassword, message.ErrLoginInvalidCredentials)
+	}
+
+	newHash, err := l.hasher.Hash(ctx, input.NewPassword)
+	if err != nil {
+		return User{}, fmt.Errorf(message.ErrUserLogicChangePassword, err)
+	}
+
+	u, err := l.repo.ChangePassword(ctx, id, newHash, expectedVersion, callerID)
+	if err != nil {
+		return User{}, fmt.Errorf(message.ErrUserLogicChangePassword, err)
+	}
+	return u, nil
+}
+
+// Deactivate soft-deletes the user identified by id.
+func (l *UserLogic) Deactivate(ctx context.Context, id uuid.UUID, callerID uuid.UUID) error {
+	if err := l.repo.Deactivate(ctx, id, callerID); err != nil {
+		return fmt.Errorf(message.ErrUserLogicDeactivate, err)
+	}
+	return nil
+}

--- a/internal/domain/user/user_logic_test.go
+++ b/internal/domain/user/user_logic_test.go
@@ -1,0 +1,294 @@
+package user_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zambone/pfm-go/internal/adapter/auth"
+	"github.com/zambone/pfm-go/internal/adapter/postgres"
+	"github.com/zambone/pfm-go/internal/platform/clock"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+
+	domainuser "github.com/zambone/pfm-go/internal/domain/user"
+	"github.com/zambone/pfm-go/internal/message"
+)
+
+// nonExistentID is a UUID guaranteed never to be seeded in any test repo.
+var nonExistentID = uuid.MustParse("00000000-0000-0000-0000-000000000099")
+
+// newUserLogic returns a UserLogic pre-seeded with one active user (testUserID, testEmail,
+// password = "correct-horse-battery-staple" hashed with FakeHasher).
+func newUserLogic(t *testing.T) (*domainuser.UserLogic, *postgres.FakeUserRepository) {
+	t.Helper()
+	clk := clock.NewFakeClock(fixedTime)
+	repo := postgres.NewFakeUserRepository()
+	hasher := auth.NewFakeHasher()
+
+	hash, err := hasher.Hash(context.Background(), testPassword)
+	require.NoError(t, err)
+
+	repo.Add(domainuser.User{
+		ID:           testUserID,
+		Email:        testEmail,
+		PasswordHash: hash,
+		Version:      1,
+	})
+
+	logic := domainuser.NewUserLogic(repo, hasher, clk)
+	return logic, repo
+}
+
+// ---------------------------------------------------------------------------
+// NewUserLogic nil guards
+// ---------------------------------------------------------------------------
+
+// TestNewUserLogic_PanicsOnNilDependencies verifies that all three nil guards
+// fire at wiring time, not at request time.
+func TestNewUserLogic_PanicsOnNilDependencies(t *testing.T) {
+	clk := clock.NewFakeClock(fixedTime)
+	repo := postgres.NewFakeUserRepository()
+	hasher := auth.NewFakeHasher()
+
+	cases := []struct {
+		name string
+		fn   func()
+	}{
+		{"nil repo", func() { domainuser.NewUserLogic(nil, hasher, clk) }},
+		{"nil hasher", func() { domainuser.NewUserLogic(repo, nil, clk) }},
+		{"nil clk", func() { domainuser.NewUserLogic(repo, hasher, nil) }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Panics(t, tc.fn)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Register
+// ---------------------------------------------------------------------------
+
+// TestUserLogic_Register_HappyPath verifies that Register returns a User with
+// a server-assigned ID, hashed password, and all input fields populated.
+func TestUserLogic_Register_HappyPath(t *testing.T) {
+	logic, _ := newUserLogic(t)
+	in := registerInputFactory(func(i *domainuser.RegisterInput) {
+		i.Email = "new@example.com" // avoid collision with seed user
+	})
+
+	u, err := logic.Register(context.Background(), in, testUserID)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, u.ID)
+	assert.Equal(t, "new@example.com", u.Email)
+	assert.Equal(t, in.DisplayName, u.DisplayName)
+	assert.NotEqual(t, in.Password, u.PasswordHash, "password must be hashed, not stored in plain text")
+	assert.Equal(t, 1, u.Version)
+}
+
+// TestUserLogic_Register_EmailAlreadyTaken verifies that registering with a
+// duplicate email propagates ErrUserEmailTaken.
+func TestUserLogic_Register_EmailAlreadyTaken(t *testing.T) {
+	logic, _ := newUserLogic(t)
+	in := registerInputFactory() // default email = testEmail, already seeded
+
+	_, err := logic.Register(context.Background(), in, testUserID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrUserEmailTaken),
+		"expected ErrUserEmailTaken, got: %v", err)
+}
+
+// TestUserLogic_Register_ValidationErrors verifies that invalid inputs are
+// rejected with a ValidationError before any repo call.
+func TestUserLogic_Register_ValidationErrors(t *testing.T) {
+	cases := []struct {
+		name  string
+		input domainuser.RegisterInput
+		field string
+	}{
+		{
+			name:  "empty email",
+			input: registerInputFactory(func(i *domainuser.RegisterInput) { i.Email = "" }),
+			field: "email",
+		},
+		{
+			name:  "empty display name",
+			input: registerInputFactory(func(i *domainuser.RegisterInput) { i.DisplayName = "" }),
+			field: "display_name",
+		},
+		{
+			name: "short password",
+			input: registerInputFactory(func(i *domainuser.RegisterInput) {
+				i.Email = "short@example.com"
+				i.Password = "short"
+			}),
+			field: "password",
+		},
+	}
+
+	logic, _ := newUserLogic(t)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := logic.Register(context.Background(), tc.input, testUserID)
+
+			require.Error(t, err)
+			var ve *validate.ValidationError
+			require.True(t, errors.As(err, &ve),
+				"expected ValidationError, got: %T %v", err, err)
+			hasField := false
+			for _, v := range ve.Violations {
+				if v.Field == tc.field {
+					hasField = true
+					break
+				}
+			}
+			assert.True(t, hasField, "expected violation on field %q, violations: %v", tc.field, ve.Violations)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FindByID
+// ---------------------------------------------------------------------------
+
+// TestUserLogic_FindByID_HappyPath verifies that a seeded user is returned by ID.
+func TestUserLogic_FindByID_HappyPath(t *testing.T) {
+	logic, _ := newUserLogic(t)
+
+	u, err := logic.FindByID(context.Background(), testUserID)
+
+	require.NoError(t, err)
+	assert.Equal(t, testUserID, u.ID)
+}
+
+// TestUserLogic_FindByID_NotFound verifies that ErrUserNotFound propagates from
+// the repo when the ID does not exist.
+func TestUserLogic_FindByID_NotFound(t *testing.T) {
+	logic, _ := newUserLogic(t)
+
+	_, err := logic.FindByID(context.Background(), nonExistentID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrUserNotFound),
+		"expected ErrUserNotFound, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// UpdateProfile
+// ---------------------------------------------------------------------------
+
+// TestUserLogic_UpdateProfile_HappyPath verifies that display name is updated
+// and version increments.
+func TestUserLogic_UpdateProfile_HappyPath(t *testing.T) {
+	logic, _ := newUserLogic(t)
+	in := updateProfileInputFactory()
+
+	u, err := logic.UpdateProfile(context.Background(), testUserID, in, 1, testUserID)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Name", u.DisplayName)
+	assert.Equal(t, 2, u.Version)
+}
+
+// TestUserLogic_UpdateProfile_ValidationError verifies that an invalid display
+// name is rejected before the repo is called.
+func TestUserLogic_UpdateProfile_ValidationError(t *testing.T) {
+	logic, _ := newUserLogic(t)
+	in := updateProfileInputFactory(func(i *domainuser.UpdateProfileInput) { i.DisplayName = "" })
+
+	_, err := logic.UpdateProfile(context.Background(), testUserID, in, 1, testUserID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T %v", err, err)
+}
+
+// TestUserLogic_UpdateProfile_VersionConflict verifies that a stale version
+// propagates ErrUserVersionConflict.
+func TestUserLogic_UpdateProfile_VersionConflict(t *testing.T) {
+	logic, _ := newUserLogic(t)
+	in := updateProfileInputFactory()
+
+	_, err := logic.UpdateProfile(context.Background(), testUserID, in, 99, testUserID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrUserVersionConflict),
+		"expected ErrUserVersionConflict, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// ChangePassword
+// ---------------------------------------------------------------------------
+
+// TestUserLogic_ChangePassword_HappyPath verifies that the password hash is
+// replaced and version increments.
+func TestUserLogic_ChangePassword_HappyPath(t *testing.T) {
+	logic, repo := newUserLogic(t)
+	in := changePasswordInputFactory()
+
+	u, err := logic.ChangePassword(context.Background(), testUserID, in, 1, testUserID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, u.Version)
+
+	// Verify new password is accepted after change.
+	updated, err := repo.FindByID(context.Background(), testUserID)
+	require.NoError(t, err)
+	hasher := auth.NewFakeHasher()
+	ok, err := hasher.Verify(context.Background(), in.NewPassword, updated.PasswordHash)
+	require.NoError(t, err)
+	assert.True(t, ok, "new password must be verifiable after change")
+}
+
+// TestUserLogic_ChangePassword_WrongOldPassword verifies that a wrong current
+// password returns ErrLoginInvalidCredentials.
+func TestUserLogic_ChangePassword_WrongOldPassword(t *testing.T) {
+	logic, _ := newUserLogic(t)
+	in := changePasswordInputFactory(func(i *domainuser.ChangePasswordInput) {
+		i.OldPassword = "wrong-password"
+	})
+
+	_, err := logic.ChangePassword(context.Background(), testUserID, in, 1, testUserID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrLoginInvalidCredentials),
+		"expected ErrLoginInvalidCredentials, got: %v", err)
+}
+
+// TestUserLogic_ChangePassword_VersionConflict verifies that a stale version
+// propagates ErrUserVersionConflict.
+func TestUserLogic_ChangePassword_VersionConflict(t *testing.T) {
+	logic, _ := newUserLogic(t)
+	in := changePasswordInputFactory()
+
+	_, err := logic.ChangePassword(context.Background(), testUserID, in, 99, testUserID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrUserVersionConflict),
+		"expected ErrUserVersionConflict, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// Deactivate
+// ---------------------------------------------------------------------------
+
+// TestUserLogic_Deactivate_HappyPath verifies that a deactivated user is no
+// longer findable by ID.
+func TestUserLogic_Deactivate_HappyPath(t *testing.T) {
+	logic, _ := newUserLogic(t)
+
+	err := logic.Deactivate(context.Background(), testUserID, testUserID)
+
+	require.NoError(t, err)
+
+	_, findErr := logic.FindByID(context.Background(), testUserID)
+	assert.True(t, errors.Is(findErr, message.ErrUserNotFound),
+		"deactivated user must not be findable")
+}

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -150,8 +150,11 @@ var (
 	ErrUserNotFound = errors.New("user: not found")
 	// ErrUserVersionConflict is returned when an optimistic-lock update finds a stale version.
 	ErrUserVersionConflict = errors.New("user: version conflict")
+	// ErrUserEmailTaken is returned when Register finds an existing user with the same email.
+	ErrUserEmailTaken = errors.New("user: email already taken")
 )
 
+// User repository format strings (adapter layer).
 const (
 	ErrUserFindByEmail    = "user: find by email: %w"
 	ErrUserFindByID       = "user: find by id: %w"
@@ -159,6 +162,15 @@ const (
 	ErrUserUpdateProfile  = "user: update profile: %w"
 	ErrUserChangePassword = "user: change password: %w"
 	ErrUserDeactivate     = "user: deactivate: %w"
+)
+
+// User logic format strings (domain layer).
+const (
+	ErrUserLogicRegister       = "user logic: register: %w"
+	ErrUserLogicFindByID       = "user logic: find by id: %w"
+	ErrUserLogicUpdateProfile  = "user logic: update profile: %w"
+	ErrUserLogicChangePassword = "user logic: change password: %w"
+	ErrUserLogicDeactivate     = "user logic: deactivate: %w"
 )
 
 // Startup errors (used by cmd/pfm/main.go composition root).


### PR DESCRIPTION
## Summary
- Add `UserLogic` with five lifecycle operations: `Register`, `FindByID`, `UpdateProfile`, `ChangePassword`, `Deactivate`
- Add `passwordHasher` interface (Hash + Verify) at consumer — distinct from `passwordVerifier` (Verify-only) used by `LoginLogic`
- Validate all inputs via `platform/validate` before any repo call (email required, display name 2–100 chars, password ≥8 chars)
- Add `ErrUserEmailTaken` sentinel and five `ErrUserLogic*` operation-context format strings to `message/errors.go`
- Enforce email uniqueness in `FakeUserRepository.Create` (returns `ErrUserEmailTaken` for duplicate emails)
- Add `changePasswordInputFactory` to `user_factory_test.go` (flagged as needed by PR #58 review)
- 13 unit tests covering all operations, validation errors, version conflicts, wrong password, and nil guards

## Test plan
- [x] `make ci` passes (lint + test -race + build)
- [x] `/project:verify-issue` verdict: PASS
- [x] `/project:review` verdict: PASS (all categories)
- [ ] Integration tests pass with testcontainers (N/A — no SQL changes; covered by #55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)