### PR TITLE
feat(user): implement SQL queries and extend UserRepo postgres adapter

### DIFF
--- a/db/queries/users.sql
+++ b/db/queries/users.sql
@@ -8,3 +8,45 @@ FROM users
 WHERE lower(email) = lower(sqlc.arg('email'))
   AND deleted_at IS NULL
 LIMIT 1;
+
+-- name: CreateUser :one
+INSERT INTO users (email, password_hash, display_name, created_by, updated_by)
+VALUES (sqlc.arg('email'), sqlc.arg('password_hash'), sqlc.arg('display_name'),
+        sqlc.arg('created_by'), sqlc.arg('updated_by'))
+RETURNING id, email, display_name, password_hash, version, created_at, updated_at, created_by, updated_by;
+
+-- name: FindUserByID :one
+SELECT id, email, display_name, password_hash, version, created_at, updated_at, created_by, updated_by
+FROM users
+WHERE id = sqlc.arg('id')
+  AND deleted_at IS NULL;
+
+-- name: UpdateUserProfile :one
+UPDATE users
+SET display_name = sqlc.arg('display_name'),
+    updated_at   = NOW(),
+    updated_by   = sqlc.arg('updated_by'),
+    version      = version + 1
+WHERE id         = sqlc.arg('id')
+  AND version    = sqlc.arg('expected_version')
+  AND deleted_at IS NULL
+RETURNING id, email, display_name, password_hash, version, created_at, updated_at, created_by, updated_by;
+
+-- name: ChangeUserPassword :one
+UPDATE users
+SET password_hash = sqlc.arg('password_hash'),
+    updated_at    = NOW(),
+    updated_by    = sqlc.arg('updated_by'),
+    version       = version + 1
+WHERE id          = sqlc.arg('id')
+  AND version     = sqlc.arg('expected_version')
+  AND deleted_at  IS NULL
+RETURNING id, email, display_name, password_hash, version, created_at, updated_at, created_by, updated_by;
+
+-- name: DeactivateUser :exec
+UPDATE users
+SET deleted_at = NOW(),
+    updated_at = NOW(),
+    updated_by = sqlc.arg('updated_by')
+WHERE id       = sqlc.arg('id')
+  AND deleted_at IS NULL;

--- a/internal/adapter/postgres/user_repo.go
+++ b/internal/adapter/postgres/user_repo.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -27,6 +31,119 @@ func NewUserRepo(pool *pgxpool.Pool) *UserRepo {
 		panic("postgres: NewUserRepo requires non-nil pool")
 	}
 	return &UserRepo{pool: pool}
+}
+
+// uuidToPgUUID converts a uuid.UUID to pgtype.UUID for use as a nullable DB column.
+// Returns a NULL pgtype.UUID when id is uuid.Nil, since nullable self-referential FKs
+// (e.g. created_by REFERENCES users(id)) must be NULL when no real user exists yet.
+func uuidToPgUUID(id uuid.UUID) pgtype.UUID {
+	if id == uuid.Nil {
+		return pgtype.UUID{}
+	}
+	return pgtype.UUID{Bytes: id, Valid: true}
+}
+
+// pgUUIDToUUID converts a nullable pgtype.UUID to uuid.UUID.
+// Returns uuid.Nil when the DB value is NULL.
+func pgUUIDToUUID(p pgtype.UUID) uuid.UUID {
+	if !p.Valid {
+		return uuid.Nil
+	}
+	return p.Bytes
+}
+
+// pgTimestamptzToTime converts a pgtype.Timestamptz to time.Time.
+// Returns zero time when the DB value is NULL.
+func pgTimestamptzToTime(p pgtype.Timestamptz) time.Time {
+	if !p.Valid {
+		return time.Time{}
+	}
+	return p.Time
+}
+
+// isUniqueViolation reports whether err is a PostgreSQL unique-constraint violation
+// for the given constraint name.
+func isUniqueViolation(err error, constraintName string) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) &&
+		pgErr.Code == "23505" &&
+		pgErr.ConstraintName == constraintName
+}
+
+// Create inserts a new user and returns the saved entity with server-assigned fields.
+// Returns an error wrapping ErrUserEmailTaken when the email is already in use.
+func (r *UserRepo) Create(ctx context.Context, input domainuser.RegisterInput, passwordHash string, callerID uuid.UUID) (domainuser.User, error) {
+	ctx, span := otel.Tracer("postgres").Start(ctx, "UserRepo.Create")
+	defer span.End()
+
+	db := database.DBTXFromContext(ctx, r.pool)
+	row, err := New(db).CreateUser(ctx, CreateUserParams{
+		Email:        input.Email,
+		PasswordHash: passwordHash,
+		DisplayName:  input.DisplayName,
+		CreatedBy:    uuidToPgUUID(callerID),
+		UpdatedBy:    uuidToPgUUID(callerID),
+	})
+	if err != nil {
+		if isUniqueViolation(err, "users_email_unique_active") {
+			err = fmt.Errorf(message.ErrUserCreate, message.ErrUserEmailTaken)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return domainuser.User{}, err
+		}
+		err = fmt.Errorf(message.ErrUserCreate, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return domainuser.User{}, err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return domainuser.User{
+		ID:           row.ID,
+		Email:        row.Email,
+		DisplayName:  row.DisplayName,
+		PasswordHash: row.PasswordHash,
+		Version:      int(row.Version),
+		CreatedAt:    pgTimestamptzToTime(row.CreatedAt),
+		UpdatedAt:    pgTimestamptzToTime(row.UpdatedAt),
+		CreatedBy:    pgUUIDToUUID(row.CreatedBy),
+		UpdatedBy:    pgUUIDToUUID(row.UpdatedBy),
+	}, nil
+}
+
+// FindByID returns the active (non-deleted) user with the given ID.
+// Returns an error wrapping ErrUserNotFound when no matching active user exists.
+func (r *UserRepo) FindByID(ctx context.Context, id uuid.UUID) (domainuser.User, error) {
+	ctx, span := otel.Tracer("postgres").Start(ctx, "UserRepo.FindByID")
+	defer span.End()
+
+	db := database.DBTXFromContext(ctx, r.pool)
+	row, err := New(db).FindUserByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			err = fmt.Errorf(message.ErrUserFindByID, message.ErrUserNotFound)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return domainuser.User{}, err
+		}
+		err = fmt.Errorf(message.ErrUserFindByID, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return domainuser.User{}, err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return domainuser.User{
+		ID:           row.ID,
+		Email:        row.Email,
+		DisplayName:  row.DisplayName,
+		PasswordHash: row.PasswordHash,
+		Version:      int(row.Version),
+		CreatedAt:    pgTimestamptzToTime(row.CreatedAt),
+		UpdatedAt:    pgTimestamptzToTime(row.UpdatedAt),
+		CreatedBy:    pgUUIDToUUID(row.CreatedBy),
+		UpdatedBy:    pgUUIDToUUID(row.UpdatedBy),
+	}, nil
 }
 
 // FindByEmail returns the active (non-deleted) user whose email matches (case-insensitive).
@@ -56,4 +173,105 @@ func (r *UserRepo) FindByEmail(ctx context.Context, email string) (domainuser.Us
 		Email:        row.Email,
 		PasswordHash: row.PasswordHash,
 	}, nil
+}
+
+// UpdateProfile changes the display name of the user identified by id.
+// Returns an error wrapping ErrUserVersionConflict when expectedVersion does not match.
+func (r *UserRepo) UpdateProfile(ctx context.Context, id uuid.UUID, input domainuser.UpdateProfileInput, expectedVersion int, callerID uuid.UUID) (domainuser.User, error) {
+	ctx, span := otel.Tracer("postgres").Start(ctx, "UserRepo.UpdateProfile")
+	defer span.End()
+
+	db := database.DBTXFromContext(ctx, r.pool)
+	row, err := New(db).UpdateUserProfile(ctx, UpdateUserProfileParams{
+		ID:              id,
+		DisplayName:     input.DisplayName,
+		UpdatedBy:       uuidToPgUUID(callerID),
+		ExpectedVersion: int32(expectedVersion),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			err = fmt.Errorf(message.ErrUserUpdateProfile, message.ErrUserVersionConflict)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return domainuser.User{}, err
+		}
+		err = fmt.Errorf(message.ErrUserUpdateProfile, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return domainuser.User{}, err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return domainuser.User{
+		ID:           row.ID,
+		Email:        row.Email,
+		DisplayName:  row.DisplayName,
+		PasswordHash: row.PasswordHash,
+		Version:      int(row.Version),
+		CreatedAt:    pgTimestamptzToTime(row.CreatedAt),
+		UpdatedAt:    pgTimestamptzToTime(row.UpdatedAt),
+		CreatedBy:    pgUUIDToUUID(row.CreatedBy),
+		UpdatedBy:    pgUUIDToUUID(row.UpdatedBy),
+	}, nil
+}
+
+// ChangePassword replaces the password hash of the user identified by id.
+// Returns an error wrapping ErrUserVersionConflict when expectedVersion does not match.
+func (r *UserRepo) ChangePassword(ctx context.Context, id uuid.UUID, newHash string, expectedVersion int, callerID uuid.UUID) (domainuser.User, error) {
+	ctx, span := otel.Tracer("postgres").Start(ctx, "UserRepo.ChangePassword")
+	defer span.End()
+
+	db := database.DBTXFromContext(ctx, r.pool)
+	row, err := New(db).ChangeUserPassword(ctx, ChangeUserPasswordParams{
+		ID:              id,
+		PasswordHash:    newHash,
+		UpdatedBy:       uuidToPgUUID(callerID),
+		ExpectedVersion: int32(expectedVersion),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			err = fmt.Errorf(message.ErrUserChangePassword, message.ErrUserVersionConflict)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return domainuser.User{}, err
+		}
+		err = fmt.Errorf(message.ErrUserChangePassword, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return domainuser.User{}, err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return domainuser.User{
+		ID:           row.ID,
+		Email:        row.Email,
+		DisplayName:  row.DisplayName,
+		PasswordHash: row.PasswordHash,
+		Version:      int(row.Version),
+		CreatedAt:    pgTimestamptzToTime(row.CreatedAt),
+		UpdatedAt:    pgTimestamptzToTime(row.UpdatedAt),
+		CreatedBy:    pgUUIDToUUID(row.CreatedBy),
+		UpdatedBy:    pgUUIDToUUID(row.UpdatedBy),
+	}, nil
+}
+
+// Deactivate soft-deletes the user. Idempotent — deactivating an already-deactivated
+// or non-existent user is not an error.
+func (r *UserRepo) Deactivate(ctx context.Context, id uuid.UUID, callerID uuid.UUID) error {
+	ctx, span := otel.Tracer("postgres").Start(ctx, "UserRepo.Deactivate")
+	defer span.End()
+
+	db := database.DBTXFromContext(ctx, r.pool)
+	if err := New(db).DeactivateUser(ctx, DeactivateUserParams{
+		ID:        id,
+		UpdatedBy: uuidToPgUUID(callerID),
+	}); err != nil {
+		err = fmt.Errorf(message.ErrUserDeactivate, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return nil
 }

--- a/internal/adapter/postgres/user_repo_integration_test.go
+++ b/internal/adapter/postgres/user_repo_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,7 @@ import (
 
 	pfmdb "github.com/zambone/pfm-go/db"
 	"github.com/zambone/pfm-go/internal/adapter/postgres"
+	domainuser "github.com/zambone/pfm-go/internal/domain/user"
 	"github.com/zambone/pfm-go/internal/message"
 	"github.com/zambone/pfm-go/internal/platform/config"
 	"github.com/zambone/pfm-go/internal/platform/database"
@@ -156,4 +158,231 @@ func TestUserRepo_FindByEmail_SoftDeleted_ReturnsInvalidCredentials(t *testing.T
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, message.ErrLoginInvalidCredentials),
 		"soft-deleted user must return ErrLoginInvalidCredentials, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+// integCallerID is uuid.Nil, which maps to SQL NULL via uuidToPgUUID.
+// This models the bootstrap scenario: the first user self-registers with no creator.
+var integCallerID = uuid.Nil
+
+// integRegisterInput returns a RegisterInput with sensible defaults.
+func integRegisterInput(email string) domainuser.RegisterInput {
+	return domainuser.RegisterInput{
+		Email:       email,
+		DisplayName: "Test User",
+		Password:    "correct-horse-battery-staple",
+	}
+}
+
+// TestUserRepo_Create_StoresAndReturnsUser verifies the happy path:
+// the created user has a server-assigned ID, correct fields, and Version = 1.
+func TestUserRepo_Create_StoresAndReturnsUser(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	u, err := repo.Create(ctx, integRegisterInput("create@example.com"), integTestPasswordHash, integCallerID)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, u.ID)
+	assert.Equal(t, "create@example.com", u.Email)
+	assert.Equal(t, "Test User", u.DisplayName)
+	assert.Equal(t, integTestPasswordHash, u.PasswordHash)
+	assert.Equal(t, 1, u.Version)
+	assert.False(t, u.CreatedAt.IsZero())
+	assert.Equal(t, integCallerID, u.CreatedBy)
+}
+
+// TestUserRepo_Create_EmailAlreadyTaken verifies that inserting a duplicate email
+// returns an error wrapping ErrUserEmailTaken.
+func TestUserRepo_Create_EmailAlreadyTaken(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	insertUser(t, pool, "taken@example.com", integTestPasswordHash)
+
+	_, err := repo.Create(ctx, integRegisterInput("taken@example.com"), integTestPasswordHash, integCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrUserEmailTaken),
+		"expected ErrUserEmailTaken, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// FindByID
+// ---------------------------------------------------------------------------
+
+// TestUserRepo_FindByID_ReturnsUser verifies that an inserted user is returned by ID.
+func TestUserRepo_FindByID_ReturnsUser(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	created, err := repo.Create(ctx, integRegisterInput("findbyid@example.com"), integTestPasswordHash, integCallerID)
+	require.NoError(t, err)
+
+	u, err := repo.FindByID(ctx, created.ID)
+
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, u.ID)
+	assert.Equal(t, "findbyid@example.com", u.Email)
+	assert.Equal(t, 1, u.Version)
+}
+
+// TestUserRepo_FindByID_NotFound verifies that a missing ID returns ErrUserNotFound.
+func TestUserRepo_FindByID_NotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	_, err := repo.FindByID(ctx, uuid.MustParse("00000000-0000-0000-0000-000000000099"))
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrUserNotFound),
+		"expected ErrUserNotFound, got: %v", err)
+}
+
+// TestUserRepo_FindByID_SoftDeleted_NotFound verifies that a deactivated user
+// is invisible to FindByID.
+func TestUserRepo_FindByID_SoftDeleted_NotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	created, err := repo.Create(ctx, integRegisterInput("deleted2@example.com"), integTestPasswordHash, integCallerID)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, "UPDATE users SET deleted_at = NOW() WHERE id = $1", created.ID)
+	require.NoError(t, err)
+
+	_, err = repo.FindByID(ctx, created.ID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrUserNotFound),
+		"soft-deleted user must not be findable by ID, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// UpdateProfile
+// ---------------------------------------------------------------------------
+
+// TestUserRepo_UpdateProfile_UpdatesDisplayName verifies the happy path:
+// display name is updated and version increments.
+func TestUserRepo_UpdateProfile_UpdatesDisplayName(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	created, err := repo.Create(ctx, integRegisterInput("profile@example.com"), integTestPasswordHash, integCallerID)
+	require.NoError(t, err)
+
+	updated, err := repo.UpdateProfile(ctx, created.ID,
+		domainuser.UpdateProfileInput{DisplayName: "New Name"},
+		created.Version, integCallerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, "New Name", updated.DisplayName)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+// TestUserRepo_UpdateProfile_VersionConflict verifies that a stale version
+// returns ErrUserVersionConflict.
+func TestUserRepo_UpdateProfile_VersionConflict(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	created, err := repo.Create(ctx, integRegisterInput("conflict@example.com"), integTestPasswordHash, integCallerID)
+	require.NoError(t, err)
+
+	_, err = repo.UpdateProfile(ctx, created.ID,
+		domainuser.UpdateProfileInput{DisplayName: "X"},
+		created.Version+99, integCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrUserVersionConflict),
+		"expected ErrUserVersionConflict, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// ChangePassword
+// ---------------------------------------------------------------------------
+
+// TestUserRepo_ChangePassword_UpdatesHash verifies the happy path:
+// the password hash is replaced and version increments.
+func TestUserRepo_ChangePassword_UpdatesHash(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	created, err := repo.Create(ctx, integRegisterInput("pwd@example.com"), integTestPasswordHash, integCallerID)
+	require.NoError(t, err)
+
+	newHash := strings.Repeat("y", 128)
+	updated, err := repo.ChangePassword(ctx, created.ID, newHash, created.Version, integCallerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, newHash, updated.PasswordHash)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+// TestUserRepo_ChangePassword_VersionConflict verifies that a stale version
+// returns ErrUserVersionConflict.
+func TestUserRepo_ChangePassword_VersionConflict(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	created, err := repo.Create(ctx, integRegisterInput("pwdconflict@example.com"), integTestPasswordHash, integCallerID)
+	require.NoError(t, err)
+
+	_, err = repo.ChangePassword(ctx, created.ID, strings.Repeat("z", 128), created.Version+99, integCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrUserVersionConflict),
+		"expected ErrUserVersionConflict, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// Deactivate
+// ---------------------------------------------------------------------------
+
+// TestUserRepo_Deactivate_SoftDeletesUser verifies that a deactivated user
+// is no longer findable by ID or email.
+func TestUserRepo_Deactivate_SoftDeletesUser(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	created, err := repo.Create(ctx, integRegisterInput("deactivate@example.com"), integTestPasswordHash, integCallerID)
+	require.NoError(t, err)
+
+	err = repo.Deactivate(ctx, created.ID, integCallerID)
+	require.NoError(t, err)
+
+	_, err = repo.FindByID(ctx, created.ID)
+	assert.True(t, errors.Is(err, message.ErrUserNotFound),
+		"deactivated user must not be findable by ID")
+
+	_, err = repo.FindByEmail(ctx, "deactivate@example.com")
+	assert.True(t, errors.Is(err, message.ErrLoginInvalidCredentials),
+		"deactivated user must not be findable by email")
+}
+
+// TestUserRepo_Deactivate_IsIdempotent verifies that deactivating an already-
+// deactivated user does not return an error.
+func TestUserRepo_Deactivate_IsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	created, err := repo.Create(ctx, integRegisterInput("idemp@example.com"), integTestPasswordHash, integCallerID)
+	require.NoError(t, err)
+
+	require.NoError(t, repo.Deactivate(ctx, created.ID, integCallerID))
+	assert.NoError(t, repo.Deactivate(ctx, created.ID, integCallerID), "second deactivate must not error")
 }

--- a/internal/adapter/postgres/users.sql.go
+++ b/internal/adapter/postgres/users.sql.go
@@ -12,6 +12,128 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const changeUserPassword = `-- name: ChangeUserPassword :one
+UPDATE users
+SET password_hash = $1,
+    updated_at    = NOW(),
+    updated_by    = $2,
+    version       = version + 1
+WHERE id          = $3
+  AND version     = $4
+  AND deleted_at  IS NULL
+RETURNING id, email, display_name, password_hash, version, created_at, updated_at, created_by, updated_by
+`
+
+type ChangeUserPasswordParams struct {
+	PasswordHash    string      `json:"password_hash"`
+	UpdatedBy       pgtype.UUID `json:"updated_by"`
+	ID              uuid.UUID   `json:"id"`
+	ExpectedVersion int32       `json:"expected_version"`
+}
+
+type ChangeUserPasswordRow struct {
+	ID           uuid.UUID          `json:"id"`
+	Email        string             `json:"email"`
+	DisplayName  string             `json:"display_name"`
+	PasswordHash string             `json:"password_hash"`
+	Version      int32              `json:"version"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	CreatedBy    pgtype.UUID        `json:"created_by"`
+	UpdatedBy    pgtype.UUID        `json:"updated_by"`
+}
+
+func (q *Queries) ChangeUserPassword(ctx context.Context, arg ChangeUserPasswordParams) (ChangeUserPasswordRow, error) {
+	row := q.db.QueryRow(ctx, changeUserPassword,
+		arg.PasswordHash,
+		arg.UpdatedBy,
+		arg.ID,
+		arg.ExpectedVersion,
+	)
+	var i ChangeUserPasswordRow
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.DisplayName,
+		&i.PasswordHash,
+		&i.Version,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.CreatedBy,
+		&i.UpdatedBy,
+	)
+	return i, err
+}
+
+const createUser = `-- name: CreateUser :one
+INSERT INTO users (email, password_hash, display_name, created_by, updated_by)
+VALUES ($1, $2, $3,
+        $4, $5)
+RETURNING id, email, display_name, password_hash, version, created_at, updated_at, created_by, updated_by
+`
+
+type CreateUserParams struct {
+	Email        string      `json:"email"`
+	PasswordHash string      `json:"password_hash"`
+	DisplayName  string      `json:"display_name"`
+	CreatedBy    pgtype.UUID `json:"created_by"`
+	UpdatedBy    pgtype.UUID `json:"updated_by"`
+}
+
+type CreateUserRow struct {
+	ID           uuid.UUID          `json:"id"`
+	Email        string             `json:"email"`
+	DisplayName  string             `json:"display_name"`
+	PasswordHash string             `json:"password_hash"`
+	Version      int32              `json:"version"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	CreatedBy    pgtype.UUID        `json:"created_by"`
+	UpdatedBy    pgtype.UUID        `json:"updated_by"`
+}
+
+func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (CreateUserRow, error) {
+	row := q.db.QueryRow(ctx, createUser,
+		arg.Email,
+		arg.PasswordHash,
+		arg.DisplayName,
+		arg.CreatedBy,
+		arg.UpdatedBy,
+	)
+	var i CreateUserRow
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.DisplayName,
+		&i.PasswordHash,
+		&i.Version,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.CreatedBy,
+		&i.UpdatedBy,
+	)
+	return i, err
+}
+
+const deactivateUser = `-- name: DeactivateUser :exec
+UPDATE users
+SET deleted_at = NOW(),
+    updated_at = NOW(),
+    updated_by = $1
+WHERE id       = $2
+  AND deleted_at IS NULL
+`
+
+type DeactivateUserParams struct {
+	UpdatedBy pgtype.UUID `json:"updated_by"`
+	ID        uuid.UUID   `json:"id"`
+}
+
+func (q *Queries) DeactivateUser(ctx context.Context, arg DeactivateUserParams) error {
+	_, err := q.db.Exec(ctx, deactivateUser, arg.UpdatedBy, arg.ID)
+	return err
+}
+
 const findUserByEmail = `-- name: FindUserByEmail :one
 SELECT
     id,
@@ -39,6 +161,95 @@ func (q *Queries) FindUserByEmail(ctx context.Context, email string) (FindUserBy
 		&i.Email,
 		&i.PasswordHash,
 		&i.DeletedAt,
+	)
+	return i, err
+}
+
+const findUserByID = `-- name: FindUserByID :one
+SELECT id, email, display_name, password_hash, version, created_at, updated_at, created_by, updated_by
+FROM users
+WHERE id = $1
+  AND deleted_at IS NULL
+`
+
+type FindUserByIDRow struct {
+	ID           uuid.UUID          `json:"id"`
+	Email        string             `json:"email"`
+	DisplayName  string             `json:"display_name"`
+	PasswordHash string             `json:"password_hash"`
+	Version      int32              `json:"version"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	CreatedBy    pgtype.UUID        `json:"created_by"`
+	UpdatedBy    pgtype.UUID        `json:"updated_by"`
+}
+
+func (q *Queries) FindUserByID(ctx context.Context, id uuid.UUID) (FindUserByIDRow, error) {
+	row := q.db.QueryRow(ctx, findUserByID, id)
+	var i FindUserByIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.DisplayName,
+		&i.PasswordHash,
+		&i.Version,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.CreatedBy,
+		&i.UpdatedBy,
+	)
+	return i, err
+}
+
+const updateUserProfile = `-- name: UpdateUserProfile :one
+UPDATE users
+SET display_name = $1,
+    updated_at   = NOW(),
+    updated_by   = $2,
+    version      = version + 1
+WHERE id         = $3
+  AND version    = $4
+  AND deleted_at IS NULL
+RETURNING id, email, display_name, password_hash, version, created_at, updated_at, created_by, updated_by
+`
+
+type UpdateUserProfileParams struct {
+	DisplayName     string      `json:"display_name"`
+	UpdatedBy       pgtype.UUID `json:"updated_by"`
+	ID              uuid.UUID   `json:"id"`
+	ExpectedVersion int32       `json:"expected_version"`
+}
+
+type UpdateUserProfileRow struct {
+	ID           uuid.UUID          `json:"id"`
+	Email        string             `json:"email"`
+	DisplayName  string             `json:"display_name"`
+	PasswordHash string             `json:"password_hash"`
+	Version      int32              `json:"version"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	CreatedBy    pgtype.UUID        `json:"created_by"`
+	UpdatedBy    pgtype.UUID        `json:"updated_by"`
+}
+
+func (q *Queries) UpdateUserProfile(ctx context.Context, arg UpdateUserProfileParams) (UpdateUserProfileRow, error) {
+	row := q.db.QueryRow(ctx, updateUserProfile,
+		arg.DisplayName,
+		arg.UpdatedBy,
+		arg.ID,
+		arg.ExpectedVersion,
+	)
+	var i UpdateUserProfileRow
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.DisplayName,
+		&i.PasswordHash,
+		&i.Version,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.CreatedBy,
+		&i.UpdatedBy,
 	)
 	return i, err
 }


### PR DESCRIPTION
## Summary
- Add 5 sqlc queries (CreateUser, FindUserByID, UpdateUserProfile, ChangeUserPassword, DeactivateUser) with optimistic locking and soft-delete filtering
- Implement all 6 `Repository` interface methods on `UserRepo` with OTel spans and domain-sentinel error mapping
- Map `uuid.Nil` to SQL NULL in `uuidToPgUUID` for self-referential FK bootstrap scenario
- Add 15 integration tests (testcontainers) covering happy paths, error mapping, soft-delete visibility, version conflicts, and idempotent deactivation

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 7 acceptance criteria COVERED)
- [x] `/project:review` verdict: PASS (all 10 categories)
- [x] Integration tests pass with testcontainers (`-race -count=1`)

closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)