### PR TITLE
test(user): add case-insensitive email duplicate integration test

### DIFF
--- a/internal/adapter/postgres/user_repo_integration_test.go
+++ b/internal/adapter/postgres/user_repo_integration_test.go
@@ -212,6 +212,24 @@ func TestUserRepo_Create_EmailAlreadyTaken(t *testing.T) {
 		"expected ErrUserEmailTaken, got: %v", err)
 }
 
+// TestUserRepo_Create_EmailCaseInsensitiveDuplicate verifies that email uniqueness
+// is case-insensitive: inserting "ALICE@example.com" when "alice@example.com" already
+// exists returns ErrUserEmailTaken.
+func TestUserRepo_Create_EmailCaseInsensitiveDuplicate(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	_, err := repo.Create(ctx, integRegisterInput("alice@example.com"), integTestPasswordHash, integCallerID)
+	require.NoError(t, err)
+
+	_, err = repo.Create(ctx, integRegisterInput("ALICE@example.com"), integTestPasswordHash, integCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrUserEmailTaken),
+		"case-insensitive duplicate must return ErrUserEmailTaken, got: %v", err)
+}
+
 // ---------------------------------------------------------------------------
 // FindByID
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `TestUserRepo_Create_EmailCaseInsensitiveDuplicate` integration test verifying that the partial unique index on `lower(email)` correctly rejects case-variant duplicates with `ErrUserEmailTaken`
- Completes the 12-test suite specified in #55 (11 were already shipped with #54)

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 5 acceptance criteria COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)
- [x] Integration tests pass with testcontainers (`-race -count=1`)

closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)