### PR TITLE
feat(household): define Repository port with reader/writer segregation

### DIFF
--- a/internal/domain/household/household.go
+++ b/internal/domain/household/household.go
@@ -2,6 +2,7 @@
 package household
 
 import (
+	"context"
 	"time"
 
 	"github.com/google/uuid"
@@ -68,4 +69,40 @@ type UpdateNameInput struct {
 type AddMemberInput struct {
 	UserID uuid.UUID
 	Role   Role
+}
+
+// HouseholdReader defines the read-only storage contract for the household domain.
+type HouseholdReader interface {
+	// FindByID returns the active (non-deleted) household with the given ID.
+	// Returns an error wrapping ErrHouseholdNotFound when no matching active household exists.
+	FindByID(ctx context.Context, id uuid.UUID) (Household, error)
+	// ListForUser returns all active households where the given user has an active membership.
+	ListForUser(ctx context.Context, userID uuid.UUID) ([]Household, error)
+}
+
+// HouseholdWriter defines the write-only storage contract for the household domain.
+type HouseholdWriter interface {
+	// Create persists a new household and its founding admin membership atomically.
+	// The callerID becomes both the household's created_by and the admin member.
+	// Returns the saved household with server-assigned fields (ID, Version, timestamps).
+	Create(ctx context.Context, input CreateInput, callerID uuid.UUID) (Household, error)
+	// AddMember adds a new membership to the household.
+	// The callerID is recorded as invited_by on the membership.
+	AddMember(ctx context.Context, householdID uuid.UUID, input AddMemberInput, callerID uuid.UUID) (Membership, error)
+	// RemoveMember soft-deletes the membership for the given user in the household.
+	// Idempotent — removing an already-removed or non-existent membership is not an error.
+	RemoveMember(ctx context.Context, householdID uuid.UUID, userID uuid.UUID, callerID uuid.UUID) error
+	// UpdateName changes the name of the household.
+	// Returns an error wrapping ErrHouseholdVersionConflict when expectedVersion does not match.
+	UpdateName(ctx context.Context, id uuid.UUID, input UpdateNameInput, expectedVersion int, callerID uuid.UUID) (Household, error)
+	// Deactivate soft-deletes the household.
+	// Idempotent — deactivating an already-deactivated household is not an error.
+	Deactivate(ctx context.Context, id uuid.UUID, callerID uuid.UUID) error
+}
+
+// Repository defines the full storage contract for the household domain.
+// Defined at the consumer (domain) rather than the provider (adapter) per interface segregation.
+type Repository interface {
+	HouseholdReader
+	HouseholdWriter
 }


### PR DESCRIPTION
## Summary
- Add `HouseholdReader` interface (FindByID, ListForUser)
- Add `HouseholdWriter` interface (Create, AddMember, RemoveMember, UpdateName, Deactivate)
- Compose into `Repository` following the User domain pattern with interface segregation
- `Create` signature accepts `callerID` to support atomic household + admin membership insertion

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 6 acceptance criteria COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)