### PR TITLE
feat(household): implement FakeHouseholdRepository with full CRUD

### DIFF
--- a/internal/adapter/postgres/fake_household_repo.go
+++ b/internal/adapter/postgres/fake_household_repo.go
@@ -1,0 +1,225 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/domain/household"
+	"github.com/zambone/pfm-go/internal/message"
+)
+
+// memberKey uniquely identifies a membership by household and user.
+type memberKey struct {
+	HouseholdID uuid.UUID
+	UserID      uuid.UUID
+}
+
+// FakeHouseholdRepository is a test double for domain/household.Repository.
+// It stores households in an in-memory map and memberships in a separate map
+// keyed by (household_id, user_id).
+//
+// NOT FOR PRODUCTION — panics if called outside a test binary.
+// Thread-safe via sync.RWMutex.
+type FakeHouseholdRepository struct {
+	mu      sync.RWMutex
+	byID    map[uuid.UUID]household.Household   // key: Household.ID
+	members map[memberKey]household.Membership   // key: (household_id, user_id)
+	removed map[memberKey]bool                   // tracks soft-deleted memberships
+	err     error                                // injected error returned by all methods
+}
+
+// NewFakeHouseholdRepository returns an empty FakeHouseholdRepository ready for use in tests.
+func NewFakeHouseholdRepository() *FakeHouseholdRepository {
+	return &FakeHouseholdRepository{
+		byID:    make(map[uuid.UUID]household.Household),
+		members: make(map[memberKey]household.Membership),
+		removed: make(map[memberKey]bool),
+	}
+}
+
+// SetError configures every subsequent method call to return err.
+// Pass nil to clear the injected error.
+func (f *FakeHouseholdRepository) SetError(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+}
+
+// Create stores a new household and its founding admin membership atomically.
+// Panics if called outside a test binary.
+func (f *FakeHouseholdRepository) Create(_ context.Context, input household.CreateInput, callerID uuid.UUID) (household.Household, error) {
+	if !testing.Testing() {
+		panic("FakeHouseholdRepository: not for production use — wire HouseholdRepo instead")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return household.Household{}, f.err
+	}
+
+	h := household.Household{
+		ID:        uuid.New(),
+		Name:      input.Name,
+		Status:    household.StatusActive,
+		Version:   1,
+		CreatedBy: callerID,
+		UpdatedBy: callerID,
+	}
+	f.byID[h.ID] = h
+
+	key := memberKey{HouseholdID: h.ID, UserID: callerID}
+	f.members[key] = household.Membership{
+		HouseholdID: h.ID,
+		UserID:      callerID,
+		Role:        household.RoleAdmin,
+		InvitedBy:   uuid.Nil,
+	}
+
+	return h, nil
+}
+
+// FindByID returns the active household with the given ID.
+// Returns an error wrapping ErrHouseholdNotFound when not found.
+// Panics if called outside a test binary.
+func (f *FakeHouseholdRepository) FindByID(_ context.Context, id uuid.UUID) (household.Household, error) {
+	if !testing.Testing() {
+		panic("FakeHouseholdRepository: not for production use — wire HouseholdRepo instead")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	if f.err != nil {
+		return household.Household{}, f.err
+	}
+
+	h, ok := f.byID[id]
+	if !ok {
+		return household.Household{}, fmt.Errorf(message.ErrHouseholdFindByID, message.ErrHouseholdNotFound)
+	}
+	return h, nil
+}
+
+// ListForUser returns all active households where the given user has an active membership.
+// Panics if called outside a test binary.
+func (f *FakeHouseholdRepository) ListForUser(_ context.Context, userID uuid.UUID) ([]household.Household, error) {
+	if !testing.Testing() {
+		panic("FakeHouseholdRepository: not for production use — wire HouseholdRepo instead")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	var result []household.Household
+	for key, m := range f.members {
+		if m.UserID == userID && !f.removed[key] {
+			if h, ok := f.byID[key.HouseholdID]; ok {
+				result = append(result, h)
+			}
+		}
+	}
+	return result, nil
+}
+
+// AddMember adds a new membership to the household.
+// Returns an error wrapping ErrHouseholdMemberExists if the user already has an active membership.
+// Panics if called outside a test binary.
+func (f *FakeHouseholdRepository) AddMember(_ context.Context, householdID uuid.UUID, input household.AddMemberInput, callerID uuid.UUID) (household.Membership, error) {
+	if !testing.Testing() {
+		panic("FakeHouseholdRepository: not for production use — wire HouseholdRepo instead")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return household.Membership{}, f.err
+	}
+
+	key := memberKey{HouseholdID: householdID, UserID: input.UserID}
+	if _, exists := f.members[key]; exists && !f.removed[key] {
+		return household.Membership{}, fmt.Errorf(message.ErrHouseholdAddMember, message.ErrHouseholdMemberExists)
+	}
+
+	m := household.Membership{
+		HouseholdID: householdID,
+		UserID:      input.UserID,
+		Role:        input.Role,
+		InvitedBy:   callerID,
+	}
+	f.members[key] = m
+	delete(f.removed, key) // re-adding a previously removed member clears the soft-delete
+	return m, nil
+}
+
+// RemoveMember soft-deletes the membership for the given user in the household.
+// Idempotent — removing a non-existent membership is not an error.
+// Panics if called outside a test binary.
+func (f *FakeHouseholdRepository) RemoveMember(_ context.Context, householdID uuid.UUID, userID uuid.UUID, _ uuid.UUID) error {
+	if !testing.Testing() {
+		panic("FakeHouseholdRepository: not for production use — wire HouseholdRepo instead")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return f.err
+	}
+
+	key := memberKey{HouseholdID: householdID, UserID: userID}
+	f.removed[key] = true
+	return nil
+}
+
+// UpdateName changes the name of the household.
+// Returns an error wrapping ErrHouseholdVersionConflict if expectedVersion does not match.
+// Panics if called outside a test binary.
+func (f *FakeHouseholdRepository) UpdateName(_ context.Context, id uuid.UUID, input household.UpdateNameInput, expectedVersion int, callerID uuid.UUID) (household.Household, error) {
+	if !testing.Testing() {
+		panic("FakeHouseholdRepository: not for production use — wire HouseholdRepo instead")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return household.Household{}, f.err
+	}
+
+	h, ok := f.byID[id]
+	if !ok {
+		return household.Household{}, fmt.Errorf(message.ErrHouseholdUpdateName, message.ErrHouseholdNotFound)
+	}
+	if h.Version != expectedVersion {
+		return household.Household{}, fmt.Errorf(message.ErrHouseholdUpdateName, message.ErrHouseholdVersionConflict)
+	}
+
+	h.Name = input.Name
+	h.Version++
+	h.UpdatedBy = callerID
+	f.byID[id] = h
+	return h, nil
+}
+
+// Deactivate soft-deletes the household by removing it from the map.
+// Idempotent — deactivating an already-removed household is not an error.
+// Panics if called outside a test binary.
+func (f *FakeHouseholdRepository) Deactivate(_ context.Context, id uuid.UUID, _ uuid.UUID) error {
+	if !testing.Testing() {
+		panic("FakeHouseholdRepository: not for production use — wire HouseholdRepo instead")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return f.err
+	}
+
+	delete(f.byID, id)
+	return nil
+}

--- a/internal/adapter/postgres/fake_household_repo_test.go
+++ b/internal/adapter/postgres/fake_household_repo_test.go
@@ -1,0 +1,249 @@
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zambone/pfm-go/internal/adapter/postgres"
+	"github.com/zambone/pfm-go/internal/domain/household"
+	"github.com/zambone/pfm-go/internal/message"
+)
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+func TestFakeHouseholdRepository_Create_StoresHouseholdAndMembership(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+	callerID := uuid.New()
+
+	h, err := repo.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, h.ID)
+	assert.Equal(t, "Home", h.Name)
+	assert.Equal(t, household.StatusActive, h.Status)
+	assert.Equal(t, 1, h.Version)
+
+	// The caller should be findable as a member via ListForUser.
+	list, err := repo.ListForUser(context.Background(), callerID)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+	assert.Equal(t, h.ID, list[0].ID)
+}
+
+// ---------------------------------------------------------------------------
+// FindByID
+// ---------------------------------------------------------------------------
+
+func TestFakeHouseholdRepository_FindByID_ReturnsHousehold(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+	callerID := uuid.New()
+
+	created, err := repo.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(context.Background(), created.ID)
+
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, found.ID)
+	assert.Equal(t, "Home", found.Name)
+}
+
+func TestFakeHouseholdRepository_FindByID_NotFound(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+
+	_, err := repo.FindByID(context.Background(), uuid.New())
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrHouseholdNotFound))
+}
+
+// ---------------------------------------------------------------------------
+// ListForUser
+// ---------------------------------------------------------------------------
+
+func TestFakeHouseholdRepository_ListForUser_OnlyActiveMembers(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+	callerID := uuid.New()
+
+	_, err := repo.Create(context.Background(), household.CreateInput{Name: "H1"}, callerID)
+	require.NoError(t, err)
+	_, err = repo.Create(context.Background(), household.CreateInput{Name: "H2"}, callerID)
+	require.NoError(t, err)
+
+	otherUser := uuid.New()
+	list, err := repo.ListForUser(context.Background(), otherUser)
+
+	require.NoError(t, err)
+	assert.Empty(t, list, "user with no memberships should see no households")
+}
+
+// ---------------------------------------------------------------------------
+// AddMember
+// ---------------------------------------------------------------------------
+
+func TestFakeHouseholdRepository_AddMember_StoresAndReflectsInList(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+	callerID := uuid.New()
+	newMember := uuid.New()
+
+	h, err := repo.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	m, err := repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
+		UserID: newMember,
+		Role:   household.RoleMember,
+	}, callerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, h.ID, m.HouseholdID)
+	assert.Equal(t, newMember, m.UserID)
+	assert.Equal(t, household.RoleMember, m.Role)
+
+	list, err := repo.ListForUser(context.Background(), newMember)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+}
+
+func TestFakeHouseholdRepository_AddMember_DuplicateReturnsMemberExists(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+	callerID := uuid.New()
+	newMember := uuid.New()
+
+	h, err := repo.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	_, err = repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
+		UserID: newMember,
+		Role:   household.RoleMember,
+	}, callerID)
+	require.NoError(t, err)
+
+	_, err = repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
+		UserID: newMember,
+		Role:   household.RoleMember,
+	}, callerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrHouseholdMemberExists))
+}
+
+// ---------------------------------------------------------------------------
+// RemoveMember
+// ---------------------------------------------------------------------------
+
+func TestFakeHouseholdRepository_RemoveMember_SoftDeletes(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+	callerID := uuid.New()
+	member := uuid.New()
+
+	h, err := repo.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+	_, err = repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
+		UserID: member,
+		Role:   household.RoleMember,
+	}, callerID)
+	require.NoError(t, err)
+
+	err = repo.RemoveMember(context.Background(), h.ID, member, callerID)
+	require.NoError(t, err)
+
+	list, err := repo.ListForUser(context.Background(), member)
+	require.NoError(t, err)
+	assert.Empty(t, list, "removed member should see no households")
+}
+
+func TestFakeHouseholdRepository_RemoveMember_IsIdempotent(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+	callerID := uuid.New()
+
+	h, err := repo.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	err = repo.RemoveMember(context.Background(), h.ID, uuid.New(), callerID)
+	assert.NoError(t, err, "removing a non-existent member should not error")
+}
+
+// ---------------------------------------------------------------------------
+// UpdateName
+// ---------------------------------------------------------------------------
+
+func TestFakeHouseholdRepository_UpdateName_ChangesNameAndVersion(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+	callerID := uuid.New()
+
+	created, err := repo.Create(context.Background(), household.CreateInput{Name: "Old"}, callerID)
+	require.NoError(t, err)
+
+	updated, err := repo.UpdateName(context.Background(), created.ID,
+		household.UpdateNameInput{Name: "New"}, created.Version, callerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, "New", updated.Name)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+func TestFakeHouseholdRepository_UpdateName_VersionConflict(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+	callerID := uuid.New()
+
+	created, err := repo.Create(context.Background(), household.CreateInput{Name: "Old"}, callerID)
+	require.NoError(t, err)
+
+	_, err = repo.UpdateName(context.Background(), created.ID,
+		household.UpdateNameInput{Name: "New"}, created.Version+99, callerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrHouseholdVersionConflict))
+}
+
+// ---------------------------------------------------------------------------
+// Deactivate
+// ---------------------------------------------------------------------------
+
+func TestFakeHouseholdRepository_Deactivate_SoftDeletes(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+	callerID := uuid.New()
+
+	created, err := repo.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	err = repo.Deactivate(context.Background(), created.ID, callerID)
+	require.NoError(t, err)
+
+	_, err = repo.FindByID(context.Background(), created.ID)
+	assert.True(t, errors.Is(err, message.ErrHouseholdNotFound),
+		"deactivated household should not be findable")
+}
+
+func TestFakeHouseholdRepository_Deactivate_IsIdempotent(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+	callerID := uuid.New()
+
+	created, err := repo.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	require.NoError(t, repo.Deactivate(context.Background(), created.ID, callerID))
+	assert.NoError(t, repo.Deactivate(context.Background(), created.ID, callerID),
+		"second deactivate must not error")
+}
+
+// ---------------------------------------------------------------------------
+// SetError
+// ---------------------------------------------------------------------------
+
+func TestFakeHouseholdRepository_SetError_InjectsError(t *testing.T) {
+	repo := postgres.NewFakeHouseholdRepository()
+	injected := errors.New("injected")
+
+	repo.SetError(injected)
+
+	_, err := repo.FindByID(context.Background(), uuid.New())
+	assert.ErrorIs(t, err, injected)
+}

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -173,6 +173,27 @@ const (
 	ErrUserLogicDeactivate     = "user logic: deactivate: %w"
 )
 
+// Household repository errors.
+var (
+	// ErrHouseholdNotFound is returned when a household lookup by ID finds no active record.
+	ErrHouseholdNotFound = errors.New("household: not found")
+	// ErrHouseholdVersionConflict is returned when an optimistic-lock update finds a stale version.
+	ErrHouseholdVersionConflict = errors.New("household: version conflict")
+	// ErrHouseholdMemberExists is returned when adding a member who already has an active membership.
+	ErrHouseholdMemberExists = errors.New("household: member already exists")
+)
+
+// Household repository format strings (adapter layer).
+const (
+	ErrHouseholdCreate       = "household: create: %w"
+	ErrHouseholdFindByID     = "household: find by id: %w"
+	ErrHouseholdListForUser  = "household: list for user: %w"
+	ErrHouseholdAddMember    = "household: add member: %w"
+	ErrHouseholdRemoveMember = "household: remove member: %w"
+	ErrHouseholdUpdateName   = "household: update name: %w"
+	ErrHouseholdDeactivate   = "household: deactivate: %w"
+)
+
 // Startup errors (used by cmd/pfm/main.go composition root).
 const (
 	ErrRunLoadConfig = "load config: %w"


### PR DESCRIPTION
## Summary
- Add `FakeHouseholdRepository` implementing `household.Repository` with two in-memory maps (households by ID, memberships by composite key) and soft-delete tracking
- Add Household error sentinels (`ErrHouseholdNotFound`, `ErrHouseholdVersionConflict`, `ErrHouseholdMemberExists`) and format strings to `message/errors.go`
- Thread-safe via `sync.RWMutex` with `testing.Testing()` production guard
- 12 tests covering Create, FindByID, ListForUser, AddMember, RemoveMember, UpdateName, Deactivate, SetError, and edge cases (duplicate member, idempotent operations, version conflict)

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 11 acceptance criteria COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)