### PR TITLE
feat(household): implement HouseholdLogic domain service with TDD

### DIFF
--- a/internal/adapter/postgres/fake_household_repo.go
+++ b/internal/adapter/postgres/fake_household_repo.go
@@ -128,6 +128,50 @@ func (f *FakeHouseholdRepository) ListForUser(_ context.Context, userID uuid.UUI
 	return result, nil
 }
 
+// FindMembership returns the active membership for a user in a household.
+// Returns an error wrapping ErrHouseholdMemberNotFound when no active membership exists.
+// Panics if called outside a test binary.
+func (f *FakeHouseholdRepository) FindMembership(_ context.Context, householdID uuid.UUID, userID uuid.UUID) (household.Membership, error) {
+	if !testing.Testing() {
+		panic("FakeHouseholdRepository: not for production use — wire HouseholdRepo instead")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	if f.err != nil {
+		return household.Membership{}, f.err
+	}
+
+	key := memberKey{HouseholdID: householdID, UserID: userID}
+	m, ok := f.members[key]
+	if !ok || f.removed[key] {
+		return household.Membership{}, fmt.Errorf(message.ErrHouseholdFindMembership, message.ErrHouseholdMemberNotFound)
+	}
+	return m, nil
+}
+
+// ListMembers returns all active memberships for the given household.
+// Panics if called outside a test binary.
+func (f *FakeHouseholdRepository) ListMembers(_ context.Context, householdID uuid.UUID) ([]household.Membership, error) {
+	if !testing.Testing() {
+		panic("FakeHouseholdRepository: not for production use — wire HouseholdRepo instead")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	var result []household.Membership
+	for key, m := range f.members {
+		if key.HouseholdID == householdID && !f.removed[key] {
+			result = append(result, m)
+		}
+	}
+	return result, nil
+}
+
 // AddMember adds a new membership to the household.
 // Returns an error wrapping ErrHouseholdMemberExists if the user already has an active membership.
 // Panics if called outside a test binary.

--- a/internal/domain/household/household.go
+++ b/internal/domain/household/household.go
@@ -78,6 +78,11 @@ type HouseholdReader interface {
 	FindByID(ctx context.Context, id uuid.UUID) (Household, error)
 	// ListForUser returns all active households where the given user has an active membership.
 	ListForUser(ctx context.Context, userID uuid.UUID) ([]Household, error)
+	// FindMembership returns the active membership for a user in a household.
+	// Returns an error wrapping ErrHouseholdMemberNotFound when no active membership exists.
+	FindMembership(ctx context.Context, householdID uuid.UUID, userID uuid.UUID) (Membership, error)
+	// ListMembers returns all active memberships for the given household.
+	ListMembers(ctx context.Context, householdID uuid.UUID) ([]Membership, error)
 }
 
 // HouseholdWriter defines the write-only storage contract for the household domain.

--- a/internal/domain/household/household_logic.go
+++ b/internal/domain/household/household_logic.go
@@ -1,0 +1,175 @@
+package household
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+)
+
+// transactor abstracts atomic multi-table operations.
+// Structurally satisfied by platform/database.Transactor.
+type transactor interface {
+	RunAtomic(ctx context.Context, fn func(ctx context.Context) error) error
+}
+
+// clocker abstracts the current time.
+// Structurally satisfied by platform/clock.Clock.
+type clocker interface {
+	Now() time.Time
+}
+
+// HouseholdLogic orchestrates the household lifecycle: creation, membership management,
+// name updates, and deactivation.
+type HouseholdLogic struct {
+	repo Repository
+	tx   transactor
+	clk  clocker
+}
+
+// NewHouseholdLogic constructs a HouseholdLogic. Panics if any dependency is nil.
+func NewHouseholdLogic(repo Repository, tx transactor, clk clocker) *HouseholdLogic {
+	if repo == nil {
+		panic("household: NewHouseholdLogic requires non-nil repo")
+	}
+	if tx == nil {
+		panic("household: NewHouseholdLogic requires non-nil tx")
+	}
+	if clk == nil {
+		panic("household: NewHouseholdLogic requires non-nil clk")
+	}
+	return &HouseholdLogic{repo: repo, tx: tx, clk: clk}
+}
+
+// Create validates input and persists a new household with the caller as its founding ADMIN
+// member. Both the household and the membership are created atomically via the Transactor.
+func (l *HouseholdLogic) Create(ctx context.Context, input CreateInput, callerID uuid.UUID) (Household, error) {
+	r := validate.NewResult()
+	r.Field("name", input.Name, validate.Required, validate.MinLen(2), validate.MaxLen(100))
+	if err := r.Error(); err != nil {
+		return Household{}, err
+	}
+
+	var created Household
+	if err := l.tx.RunAtomic(ctx, func(txCtx context.Context) error {
+		h, err := l.repo.Create(txCtx, input, callerID)
+		if err != nil {
+			return err
+		}
+		created = h
+		return nil
+	}); err != nil {
+		return Household{}, fmt.Errorf(message.ErrHouseholdLogicCreate, err)
+	}
+	return created, nil
+}
+
+// FindByID returns the active household with the given ID.
+func (l *HouseholdLogic) FindByID(ctx context.Context, id uuid.UUID) (Household, error) {
+	h, err := l.repo.FindByID(ctx, id)
+	if err != nil {
+		return Household{}, fmt.Errorf(message.ErrHouseholdLogicFindByID, err)
+	}
+	return h, nil
+}
+
+// ListForUser returns all active households where the user has an active membership.
+func (l *HouseholdLogic) ListForUser(ctx context.Context, userID uuid.UUID) ([]Household, error) {
+	list, err := l.repo.ListForUser(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf(message.ErrHouseholdLogicListForUser, err)
+	}
+	return list, nil
+}
+
+// AddMember validates the caller is an ADMIN of the household, then adds the new member.
+func (l *HouseholdLogic) AddMember(ctx context.Context, householdID uuid.UUID, input AddMemberInput, callerID uuid.UUID) (Membership, error) {
+	callerMembership, err := l.repo.FindMembership(ctx, householdID, callerID)
+	if err != nil {
+		if errors.Is(err, message.ErrHouseholdMemberNotFound) {
+			return Membership{}, fmt.Errorf(message.ErrHouseholdLogicAddMember, message.ErrHouseholdNotAdmin)
+		}
+		return Membership{}, fmt.Errorf(message.ErrHouseholdLogicAddMember, err)
+	}
+	if callerMembership.Role != RoleAdmin {
+		return Membership{}, fmt.Errorf(message.ErrHouseholdLogicAddMember, message.ErrHouseholdNotAdmin)
+	}
+
+	m, err := l.repo.AddMember(ctx, householdID, input, callerID)
+	if err != nil {
+		return Membership{}, fmt.Errorf(message.ErrHouseholdLogicAddMember, err)
+	}
+	return m, nil
+}
+
+// RemoveMember validates the caller is an ADMIN and that removing the target would not
+// leave the household without any admins, then soft-deletes the membership.
+func (l *HouseholdLogic) RemoveMember(ctx context.Context, householdID uuid.UUID, userID uuid.UUID, callerID uuid.UUID) error {
+	callerMembership, err := l.repo.FindMembership(ctx, householdID, callerID)
+	if err != nil {
+		if errors.Is(err, message.ErrHouseholdMemberNotFound) {
+			return fmt.Errorf(message.ErrHouseholdLogicRemoveMember, message.ErrHouseholdNotAdmin)
+		}
+		return fmt.Errorf(message.ErrHouseholdLogicRemoveMember, err)
+	}
+	if callerMembership.Role != RoleAdmin {
+		return fmt.Errorf(message.ErrHouseholdLogicRemoveMember, message.ErrHouseholdNotAdmin)
+	}
+
+	// Check if removing the target would leave the household without any admins.
+	members, err := l.repo.ListMembers(ctx, householdID)
+	if err != nil {
+		return fmt.Errorf(message.ErrHouseholdLogicRemoveMember, err)
+	}
+	adminCount := 0
+	for _, m := range members {
+		if m.Role == RoleAdmin {
+			adminCount++
+		}
+	}
+
+	// Look up the target's role to see if they're an admin.
+	targetMembership, err := l.repo.FindMembership(ctx, householdID, userID)
+	if err != nil {
+		if errors.Is(err, message.ErrHouseholdMemberNotFound) {
+			return nil // already removed — idempotent
+		}
+		return fmt.Errorf(message.ErrHouseholdLogicRemoveMember, err)
+	}
+	if targetMembership.Role == RoleAdmin && adminCount <= 1 {
+		return fmt.Errorf(message.ErrHouseholdLogicRemoveMember, message.ErrHouseholdLastAdmin)
+	}
+
+	if err := l.repo.RemoveMember(ctx, householdID, userID, callerID); err != nil {
+		return fmt.Errorf(message.ErrHouseholdLogicRemoveMember, err)
+	}
+	return nil
+}
+
+// UpdateName validates input and updates the household name with optimistic concurrency.
+func (l *HouseholdLogic) UpdateName(ctx context.Context, id uuid.UUID, input UpdateNameInput, expectedVersion int, callerID uuid.UUID) (Household, error) {
+	r := validate.NewResult()
+	r.Field("name", input.Name, validate.Required, validate.MinLen(2), validate.MaxLen(100))
+	if err := r.Error(); err != nil {
+		return Household{}, err
+	}
+
+	h, err := l.repo.UpdateName(ctx, id, input, expectedVersion, callerID)
+	if err != nil {
+		return Household{}, fmt.Errorf(message.ErrHouseholdLogicUpdateName, err)
+	}
+	return h, nil
+}
+
+// Deactivate soft-deletes the household.
+func (l *HouseholdLogic) Deactivate(ctx context.Context, id uuid.UUID, callerID uuid.UUID) error {
+	if err := l.repo.Deactivate(ctx, id, callerID); err != nil {
+		return fmt.Errorf(message.ErrHouseholdLogicDeactivate, err)
+	}
+	return nil
+}

--- a/internal/domain/household/household_logic_test.go
+++ b/internal/domain/household/household_logic_test.go
@@ -1,0 +1,319 @@
+package household_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zambone/pfm-go/internal/adapter/postgres"
+	"github.com/zambone/pfm-go/internal/domain/household"
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/clock"
+	"github.com/zambone/pfm-go/internal/platform/database"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+)
+
+// newHouseholdLogic returns a HouseholdLogic with a fresh fake repo, fake transactor,
+// and fake clock. The callerID is returned for convenience.
+func newHouseholdLogic() (*household.HouseholdLogic, *postgres.FakeHouseholdRepository, uuid.UUID) {
+	repo := postgres.NewFakeHouseholdRepository()
+	tx := database.NewFakeTransactor()
+	clk := clock.NewFakeClock(fixedTime)
+	callerID := testOwnerID
+	logic := household.NewHouseholdLogic(repo, tx, clk)
+	return logic, repo, callerID
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+func TestHouseholdLogic_Create_HappyPath(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+
+	h, err := logic.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, h.ID)
+	assert.Equal(t, "Home", h.Name)
+	assert.Equal(t, household.StatusActive, h.Status)
+	assert.Equal(t, 1, h.Version)
+}
+
+func TestHouseholdLogic_Create_EmptyName_FailsValidation(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+
+	_, err := logic.Create(context.Background(), household.CreateInput{Name: ""}, callerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %v", err)
+}
+
+func TestHouseholdLogic_Create_CallerBecomesAdmin(t *testing.T) {
+	logic, repo, callerID := newHouseholdLogic()
+
+	h, err := logic.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	m, err := repo.FindMembership(context.Background(), h.ID, callerID)
+	require.NoError(t, err)
+	assert.Equal(t, household.RoleAdmin, m.Role)
+}
+
+// ---------------------------------------------------------------------------
+// FindByID
+// ---------------------------------------------------------------------------
+
+func TestHouseholdLogic_FindByID_HappyPath(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+
+	created, err := logic.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	found, err := logic.FindByID(context.Background(), created.ID)
+
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, found.ID)
+}
+
+func TestHouseholdLogic_FindByID_NotFound(t *testing.T) {
+	logic, _, _ := newHouseholdLogic()
+
+	_, err := logic.FindByID(context.Background(), uuid.New())
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrHouseholdNotFound))
+}
+
+// ---------------------------------------------------------------------------
+// ListForUser
+// ---------------------------------------------------------------------------
+
+func TestHouseholdLogic_ListForUser_ReturnsOnlyCallerHouseholds(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+
+	_, err := logic.Create(context.Background(), household.CreateInput{Name: "H1"}, callerID)
+	require.NoError(t, err)
+	_, err = logic.Create(context.Background(), household.CreateInput{Name: "H2"}, callerID)
+	require.NoError(t, err)
+
+	list, err := logic.ListForUser(context.Background(), callerID)
+
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+}
+
+func TestHouseholdLogic_ListForUser_EmptyForUnknownUser(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+
+	_, err := logic.Create(context.Background(), household.CreateInput{Name: "H1"}, callerID)
+	require.NoError(t, err)
+
+	list, err := logic.ListForUser(context.Background(), uuid.New())
+
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}
+
+// ---------------------------------------------------------------------------
+// AddMember
+// ---------------------------------------------------------------------------
+
+func TestHouseholdLogic_AddMember_AdminCanAdd(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+	newMember := uuid.New()
+
+	h, err := logic.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	m, err := logic.AddMember(context.Background(), h.ID, household.AddMemberInput{
+		UserID: newMember,
+		Role:   household.RoleMember,
+	}, callerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, newMember, m.UserID)
+	assert.Equal(t, household.RoleMember, m.Role)
+}
+
+func TestHouseholdLogic_AddMember_NonAdminDenied(t *testing.T) {
+	logic, repo, callerID := newHouseholdLogic()
+	memberUser := uuid.New()
+	anotherUser := uuid.New()
+
+	h, err := logic.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	// Add memberUser as MEMBER (not admin).
+	_, err = repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
+		UserID: memberUser,
+		Role:   household.RoleMember,
+	}, callerID)
+	require.NoError(t, err)
+
+	// memberUser tries to add anotherUser — should be denied.
+	_, err = logic.AddMember(context.Background(), h.ID, household.AddMemberInput{
+		UserID: anotherUser,
+		Role:   household.RoleMember,
+	}, memberUser)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrHouseholdNotAdmin))
+}
+
+func TestHouseholdLogic_AddMember_DuplicateReturnsError(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+	newMember := uuid.New()
+
+	h, err := logic.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	_, err = logic.AddMember(context.Background(), h.ID, household.AddMemberInput{
+		UserID: newMember,
+		Role:   household.RoleMember,
+	}, callerID)
+	require.NoError(t, err)
+
+	_, err = logic.AddMember(context.Background(), h.ID, household.AddMemberInput{
+		UserID: newMember,
+		Role:   household.RoleMember,
+	}, callerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrHouseholdMemberExists))
+}
+
+// ---------------------------------------------------------------------------
+// RemoveMember
+// ---------------------------------------------------------------------------
+
+func TestHouseholdLogic_RemoveMember_AdminCanRemove(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+	member := uuid.New()
+
+	h, err := logic.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+	_, err = logic.AddMember(context.Background(), h.ID, household.AddMemberInput{
+		UserID: member,
+		Role:   household.RoleMember,
+	}, callerID)
+	require.NoError(t, err)
+
+	err = logic.RemoveMember(context.Background(), h.ID, member, callerID)
+	require.NoError(t, err)
+
+	list, err := logic.ListForUser(context.Background(), member)
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}
+
+func TestHouseholdLogic_RemoveMember_NonAdminDenied(t *testing.T) {
+	logic, repo, callerID := newHouseholdLogic()
+	memberUser := uuid.New()
+	anotherMember := uuid.New()
+
+	h, err := logic.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+	_, err = repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
+		UserID: memberUser, Role: household.RoleMember,
+	}, callerID)
+	require.NoError(t, err)
+	_, err = repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
+		UserID: anotherMember, Role: household.RoleMember,
+	}, callerID)
+	require.NoError(t, err)
+
+	err = logic.RemoveMember(context.Background(), h.ID, anotherMember, memberUser)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrHouseholdNotAdmin))
+}
+
+func TestHouseholdLogic_RemoveMember_LastAdminDenied(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+
+	h, err := logic.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	err = logic.RemoveMember(context.Background(), h.ID, callerID, callerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrHouseholdLastAdmin))
+}
+
+// ---------------------------------------------------------------------------
+// UpdateName
+// ---------------------------------------------------------------------------
+
+func TestHouseholdLogic_UpdateName_HappyPath(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+
+	created, err := logic.Create(context.Background(), household.CreateInput{Name: "Old"}, callerID)
+	require.NoError(t, err)
+
+	updated, err := logic.UpdateName(context.Background(), created.ID,
+		household.UpdateNameInput{Name: "New"}, created.Version, callerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, "New", updated.Name)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+func TestHouseholdLogic_UpdateName_EmptyName_FailsValidation(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+
+	created, err := logic.Create(context.Background(), household.CreateInput{Name: "Old"}, callerID)
+	require.NoError(t, err)
+
+	_, err = logic.UpdateName(context.Background(), created.ID,
+		household.UpdateNameInput{Name: ""}, created.Version, callerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+func TestHouseholdLogic_UpdateName_VersionConflict(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+
+	created, err := logic.Create(context.Background(), household.CreateInput{Name: "Old"}, callerID)
+	require.NoError(t, err)
+
+	_, err = logic.UpdateName(context.Background(), created.ID,
+		household.UpdateNameInput{Name: "New"}, created.Version+99, callerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrHouseholdVersionConflict))
+}
+
+// ---------------------------------------------------------------------------
+// Deactivate
+// ---------------------------------------------------------------------------
+
+func TestHouseholdLogic_Deactivate_HappyPath(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+
+	created, err := logic.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	err = logic.Deactivate(context.Background(), created.ID, callerID)
+	require.NoError(t, err)
+
+	_, err = logic.FindByID(context.Background(), created.ID)
+	assert.True(t, errors.Is(err, message.ErrHouseholdNotFound))
+}
+
+func TestHouseholdLogic_Deactivate_IsIdempotent(t *testing.T) {
+	logic, _, callerID := newHouseholdLogic()
+
+	created, err := logic.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
+	require.NoError(t, err)
+
+	require.NoError(t, logic.Deactivate(context.Background(), created.ID, callerID))
+	assert.NoError(t, logic.Deactivate(context.Background(), created.ID, callerID))
+}

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -181,6 +181,12 @@ var (
 	ErrHouseholdVersionConflict = errors.New("household: version conflict")
 	// ErrHouseholdMemberExists is returned when adding a member who already has an active membership.
 	ErrHouseholdMemberExists = errors.New("household: member already exists")
+	// ErrHouseholdMemberNotFound is returned when a membership lookup finds no active record.
+	ErrHouseholdMemberNotFound = errors.New("household: member not found")
+	// ErrHouseholdNotAdmin is returned when a non-ADMIN attempts an admin-only operation.
+	ErrHouseholdNotAdmin = errors.New("household: caller is not an admin")
+	// ErrHouseholdLastAdmin is returned when removing the last ADMIN would leave the household without one.
+	ErrHouseholdLastAdmin = errors.New("household: cannot remove last admin")
 )
 
 // Household repository format strings (adapter layer).
@@ -191,7 +197,20 @@ const (
 	ErrHouseholdAddMember    = "household: add member: %w"
 	ErrHouseholdRemoveMember = "household: remove member: %w"
 	ErrHouseholdUpdateName   = "household: update name: %w"
-	ErrHouseholdDeactivate   = "household: deactivate: %w"
+	ErrHouseholdDeactivate       = "household: deactivate: %w"
+	ErrHouseholdFindMembership   = "household: find membership: %w"
+	ErrHouseholdListMembers      = "household: list members: %w"
+)
+
+// Household logic format strings (domain layer).
+const (
+	ErrHouseholdLogicCreate       = "household logic: create: %w"
+	ErrHouseholdLogicFindByID     = "household logic: find by id: %w"
+	ErrHouseholdLogicListForUser  = "household logic: list for user: %w"
+	ErrHouseholdLogicAddMember    = "household logic: add member: %w"
+	ErrHouseholdLogicRemoveMember = "household logic: remove member: %w"
+	ErrHouseholdLogicUpdateName   = "household logic: update name: %w"
+	ErrHouseholdLogicDeactivate   = "household logic: deactivate: %w"
 )
 
 // Startup errors (used by cmd/pfm/main.go composition root).


### PR DESCRIPTION
## Summary
- Add `HouseholdLogic` service with 7 methods: Create, FindByID, ListForUser, AddMember, RemoveMember, UpdateName, Deactivate
- Create uses `Transactor` for atomic household + admin membership creation
- AddMember/RemoveMember enforce ADMIN role via `FindMembership` lookup
- RemoveMember prevents removing the last admin (counts admins via `ListMembers`)
- Validation via centralized `validate` engine for household name fields
- Extend `HouseholdReader` port with `FindMembership` and `ListMembers` for role checks
- Add 3 new sentinels (`ErrHouseholdNotAdmin`, `ErrHouseholdLastAdmin`, `ErrHouseholdMemberNotFound`) and 7 logic-layer format strings
- 18 unit tests covering all methods, validation failures, role enforcement, last-admin edge case, version conflict, and idempotent deactivation

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 9 acceptance criteria + 5 edge cases COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)