### PR TITLE
test(household): add transactional and cross-method integration tests

### DIFF
--- a/internal/adapter/postgres/household_repo_integration_test.go
+++ b/internal/adapter/postgres/household_repo_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zambone/pfm-go/internal/adapter/postgres"
 	"github.com/zambone/pfm-go/internal/domain/household"
 	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/database"
 )
 
 // insertTestUser inserts a minimal user row via raw SQL and returns the server-assigned UUID.
@@ -362,4 +363,185 @@ func TestHouseholdRepo_Deactivate_IsIdempotent(t *testing.T) {
 
 	require.NoError(t, repo.Deactivate(ctx, created.ID, callerID))
 	assert.NoError(t, repo.Deactivate(ctx, created.ID, callerID))
+}
+
+// ===========================================================================
+// Cross-method and transactional integration tests (#68)
+// ===========================================================================
+
+// TestHouseholdRepo_Txn_CreateCommits verifies that when Create runs inside
+// a committed transaction, both the household and its admin membership are
+// visible in subsequent queries.
+func TestHouseholdRepo_Txn_CreateCommits(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewHouseholdRepo(pool)
+	tx := database.NewPostgresTransactor(pool)
+	callerID := insertTestUser(t, pool)
+
+	var householdID uuid.UUID
+	err := tx.RunAtomic(ctx, func(txCtx context.Context) error {
+		h, err := repo.Create(txCtx, household.CreateInput{Name: "Atomic Home"}, callerID)
+		if err != nil {
+			return err
+		}
+		householdID = h.ID
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Both the household and membership should be visible after commit.
+	found, err := repo.FindByID(ctx, householdID)
+	require.NoError(t, err)
+	assert.Equal(t, "Atomic Home", found.Name)
+
+	members, err := repo.ListMembers(ctx, householdID)
+	require.NoError(t, err)
+	assert.Len(t, members, 1)
+	assert.Equal(t, household.RoleAdmin, members[0].Role)
+}
+
+// TestHouseholdRepo_Txn_CreateRollsBack verifies that when a transaction
+// fails after Create, neither the household nor the membership is committed.
+func TestHouseholdRepo_Txn_CreateRollsBack(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewHouseholdRepo(pool)
+	tx := database.NewPostgresTransactor(pool)
+	callerID := insertTestUser(t, pool)
+
+	var householdID uuid.UUID
+	simulatedErr := errors.New("simulated failure after create")
+
+	err := tx.RunAtomic(ctx, func(txCtx context.Context) error {
+		h, err := repo.Create(txCtx, household.CreateInput{Name: "Doomed"}, callerID)
+		if err != nil {
+			return err
+		}
+		householdID = h.ID
+		return simulatedErr // force rollback
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, simulatedErr)
+
+	// Neither household nor membership should exist after rollback.
+	_, err = repo.FindByID(ctx, householdID)
+	assert.True(t, errors.Is(err, message.ErrHouseholdNotFound),
+		"household must not exist after rollback, got: %v", err)
+
+	list, err := repo.ListForUser(ctx, callerID)
+	require.NoError(t, err)
+	assert.Empty(t, list, "caller should have no households after rollback")
+}
+
+// TestHouseholdRepo_Workflow_DeactivateHidesFromAllMembers verifies that
+// deactivating a household removes it from ListForUser for every member.
+func TestHouseholdRepo_Workflow_DeactivateHidesFromAllMembers(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewHouseholdRepo(pool)
+	admin := insertTestUser(t, pool)
+	member := insertTestUser(t, pool)
+
+	h, err := repo.Create(ctx, household.CreateInput{Name: "Shared"}, admin)
+	require.NoError(t, err)
+
+	_, err = repo.AddMember(ctx, h.ID, household.AddMemberInput{
+		UserID: member,
+		Role:   household.RoleMember,
+	}, admin)
+	require.NoError(t, err)
+
+	// Both users see the household before deactivation.
+	adminList, err := repo.ListForUser(ctx, admin)
+	require.NoError(t, err)
+	assert.Len(t, adminList, 1)
+
+	memberList, err := repo.ListForUser(ctx, member)
+	require.NoError(t, err)
+	assert.Len(t, memberList, 1)
+
+	// Deactivate.
+	err = repo.Deactivate(ctx, h.ID, admin)
+	require.NoError(t, err)
+
+	// Neither user sees the household after deactivation.
+	adminList, err = repo.ListForUser(ctx, admin)
+	require.NoError(t, err)
+	assert.Empty(t, adminList, "admin should not see deactivated household")
+
+	memberList, err = repo.ListForUser(ctx, member)
+	require.NoError(t, err)
+	assert.Empty(t, memberList, "member should not see deactivated household")
+}
+
+// TestHouseholdRepo_Workflow_AddRemoveMember verifies that adding a member
+// makes the household visible in their list, and removing them hides it —
+// while other members remain unaffected.
+func TestHouseholdRepo_Workflow_AddRemoveMember(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewHouseholdRepo(pool)
+	admin := insertTestUser(t, pool)
+	member := insertTestUser(t, pool)
+
+	h, err := repo.Create(ctx, household.CreateInput{Name: "Home"}, admin)
+	require.NoError(t, err)
+
+	_, err = repo.AddMember(ctx, h.ID, household.AddMemberInput{
+		UserID: member,
+		Role:   household.RoleMember,
+	}, admin)
+	require.NoError(t, err)
+
+	// Member sees the household.
+	memberList, err := repo.ListForUser(ctx, member)
+	require.NoError(t, err)
+	assert.Len(t, memberList, 1)
+
+	// Remove the member.
+	err = repo.RemoveMember(ctx, h.ID, member, admin)
+	require.NoError(t, err)
+
+	// Member no longer sees it.
+	memberList, err = repo.ListForUser(ctx, member)
+	require.NoError(t, err)
+	assert.Empty(t, memberList, "removed member should not see household")
+
+	// Admin still sees it.
+	adminList, err := repo.ListForUser(ctx, admin)
+	require.NoError(t, err)
+	assert.Len(t, adminList, 1, "admin should still see household")
+}
+
+// TestHouseholdRepo_Workflow_VersionChain verifies optimistic concurrency:
+// two sequential updates with correct version chain succeed (v1→v2→v3),
+// but reusing the first version fails.
+func TestHouseholdRepo_Workflow_VersionChain(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewHouseholdRepo(pool)
+	callerID := insertTestUser(t, pool)
+
+	created, err := repo.Create(ctx, household.CreateInput{Name: "V1"}, callerID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, created.Version)
+
+	v2, err := repo.UpdateName(ctx, created.ID,
+		household.UpdateNameInput{Name: "V2"}, created.Version, callerID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, v2.Version)
+	assert.Equal(t, "V2", v2.Name)
+
+	v3, err := repo.UpdateName(ctx, created.ID,
+		household.UpdateNameInput{Name: "V3"}, v2.Version, callerID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, v3.Version)
+	assert.Equal(t, "V3", v3.Name)
+
+	// Reusing v1 should fail.
+	_, err = repo.UpdateName(ctx, created.ID,
+		household.UpdateNameInput{Name: "Stale"}, created.Version, callerID)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrHouseholdVersionConflict))
 }


### PR DESCRIPTION
## Summary
- Add 5 cross-method integration tests exercising transactional integrity and multi-step workflows
- `Txn_CreateCommits`: Verify both household and membership visible after committed RunAtomic
- `Txn_CreateRollsBack`: Verify neither persists when RunAtomic callback returns error
- `Workflow_DeactivateHidesFromAllMembers`: Verify deactivation removes from all members' ListForUser
- `Workflow_AddRemoveMember`: Verify add/remove visibility for both affected and unaffected members
- `Workflow_VersionChain`: Verify v1→v2→v3 succeeds and stale version fails

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 6 acceptance criteria COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)