### PR TITLE
feat(ctxutil): add Role context helpers and extract shared types package

### DIFF
--- a/internal/adapter/postgres/fake_household_repo.go
+++ b/internal/adapter/postgres/fake_household_repo.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/zambone/pfm-go/internal/domain/household"
 	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/types"
 )
 
 // memberKey uniquely identifies a membership by household and user.
@@ -65,7 +66,7 @@ func (f *FakeHouseholdRepository) Create(_ context.Context, input household.Crea
 	h := household.Household{
 		ID:        uuid.New(),
 		Name:      input.Name,
-		Status:    household.StatusActive,
+		Status:    types.StatusActive,
 		Version:   1,
 		CreatedBy: callerID,
 		UpdatedBy: callerID,
@@ -76,7 +77,7 @@ func (f *FakeHouseholdRepository) Create(_ context.Context, input household.Crea
 	f.members[key] = household.Membership{
 		HouseholdID: h.ID,
 		UserID:      callerID,
-		Role:        household.RoleAdmin,
+		Role:        types.RoleAdmin,
 		InvitedBy:   uuid.Nil,
 	}
 

--- a/internal/adapter/postgres/fake_household_repo_test.go
+++ b/internal/adapter/postgres/fake_household_repo_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zambone/pfm-go/internal/adapter/postgres"
 	"github.com/zambone/pfm-go/internal/domain/household"
 	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/types"
 )
 
 // ---------------------------------------------------------------------------
@@ -27,7 +28,7 @@ func TestFakeHouseholdRepository_Create_StoresHouseholdAndMembership(t *testing.
 	require.NoError(t, err)
 	assert.NotEqual(t, uuid.Nil, h.ID)
 	assert.Equal(t, "Home", h.Name)
-	assert.Equal(t, household.StatusActive, h.Status)
+	assert.Equal(t, types.StatusActive, h.Status)
 	assert.Equal(t, 1, h.Version)
 
 	// The caller should be findable as a member via ListForUser.
@@ -98,13 +99,13 @@ func TestFakeHouseholdRepository_AddMember_StoresAndReflectsInList(t *testing.T)
 
 	m, err := repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
 		UserID: newMember,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 
 	require.NoError(t, err)
 	assert.Equal(t, h.ID, m.HouseholdID)
 	assert.Equal(t, newMember, m.UserID)
-	assert.Equal(t, household.RoleMember, m.Role)
+	assert.Equal(t, types.RoleMember, m.Role)
 
 	list, err := repo.ListForUser(context.Background(), newMember)
 	require.NoError(t, err)
@@ -121,13 +122,13 @@ func TestFakeHouseholdRepository_AddMember_DuplicateReturnsMemberExists(t *testi
 
 	_, err = repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
 		UserID: newMember,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 	require.NoError(t, err)
 
 	_, err = repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
 		UserID: newMember,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 
 	require.Error(t, err)
@@ -147,7 +148,7 @@ func TestFakeHouseholdRepository_RemoveMember_SoftDeletes(t *testing.T) {
 	require.NoError(t, err)
 	_, err = repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
 		UserID: member,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 	require.NoError(t, err)
 

--- a/internal/adapter/postgres/household_repo.go
+++ b/internal/adapter/postgres/household_repo.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zambone/pfm-go/internal/domain/household"
 	"github.com/zambone/pfm-go/internal/message"
 	"github.com/zambone/pfm-go/internal/platform/database"
+	"github.com/zambone/pfm-go/internal/types"
 )
 
 // HouseholdRepo implements domain/household.Repository using PostgreSQL via sqlc-generated queries.
@@ -36,7 +37,7 @@ func householdFromRow(id uuid.UUID, name, status string, version int32, createdA
 	return household.Household{
 		ID:        id,
 		Name:      name,
-		Status:    household.Status(status),
+		Status:    types.Status(status),
 		Version:   int(version),
 		CreatedAt: pgTimestamptzToTime(createdAt),
 		UpdatedAt: pgTimestamptzToTime(updatedAt),
@@ -50,7 +51,7 @@ func membershipFromRow(householdID, userID uuid.UUID, role string, invitedBy pgt
 	return household.Membership{
 		HouseholdID: householdID,
 		UserID:      userID,
-		Role:        household.Role(role),
+		Role:        types.Role(role),
 		InvitedBy:   pgUUIDToUUID(invitedBy),
 		JoinedAt:    pgTimestamptzToTime(joinedAt),
 	}
@@ -81,7 +82,7 @@ func (r *HouseholdRepo) Create(ctx context.Context, input household.CreateInput,
 	_, err = q.CreateHouseholdMember(ctx, CreateHouseholdMemberParams{
 		HouseholdID: row.ID,
 		UserID:      callerID,
-		Role:        string(household.RoleAdmin),
+		Role:        string(types.RoleAdmin),
 		InvitedBy:   uuidToPgUUID(uuid.Nil),
 	})
 	if err != nil {

--- a/internal/adapter/postgres/household_repo_integration_test.go
+++ b/internal/adapter/postgres/household_repo_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zambone/pfm-go/internal/domain/household"
 	"github.com/zambone/pfm-go/internal/message"
 	"github.com/zambone/pfm-go/internal/platform/database"
+	"github.com/zambone/pfm-go/internal/types"
 )
 
 // insertTestUser inserts a minimal user row via raw SQL and returns the server-assigned UUID.
@@ -46,14 +47,14 @@ func TestHouseholdRepo_Create_StoresHouseholdAndMembership(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, uuid.Nil, h.ID)
 	assert.Equal(t, "Home", h.Name)
-	assert.Equal(t, household.StatusActive, h.Status)
+	assert.Equal(t, types.StatusActive, h.Status)
 	assert.Equal(t, 1, h.Version)
 	assert.False(t, h.CreatedAt.IsZero())
 
 	members, err := repo.ListMembers(ctx, h.ID)
 	require.NoError(t, err)
 	assert.Len(t, members, 1)
-	assert.Equal(t, household.RoleAdmin, members[0].Role)
+	assert.Equal(t, types.RoleAdmin, members[0].Role)
 }
 
 // ---------------------------------------------------------------------------
@@ -158,7 +159,7 @@ func TestHouseholdRepo_FindMembership_ReturnsAdminMembership(t *testing.T) {
 	m, err := repo.FindMembership(ctx, h.ID, callerID)
 
 	require.NoError(t, err)
-	assert.Equal(t, household.RoleAdmin, m.Role)
+	assert.Equal(t, types.RoleAdmin, m.Role)
 	assert.Equal(t, h.ID, m.HouseholdID)
 }
 
@@ -194,7 +195,7 @@ func TestHouseholdRepo_ListMembers_ReturnsAllActive(t *testing.T) {
 	secondUser := insertTestUser(t, pool)
 	_, err = repo.AddMember(ctx, h.ID, household.AddMemberInput{
 		UserID: secondUser,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 	require.NoError(t, err)
 
@@ -220,13 +221,13 @@ func TestHouseholdRepo_AddMember_StoresAndReturns(t *testing.T) {
 	newUser := insertTestUser(t, pool)
 	m, err := repo.AddMember(ctx, h.ID, household.AddMemberInput{
 		UserID: newUser,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 
 	require.NoError(t, err)
 	assert.Equal(t, h.ID, m.HouseholdID)
 	assert.Equal(t, newUser, m.UserID)
-	assert.Equal(t, household.RoleMember, m.Role)
+	assert.Equal(t, types.RoleMember, m.Role)
 }
 
 func TestHouseholdRepo_AddMember_DuplicateReturnsMemberExists(t *testing.T) {
@@ -241,13 +242,13 @@ func TestHouseholdRepo_AddMember_DuplicateReturnsMemberExists(t *testing.T) {
 	newUser := insertTestUser(t, pool)
 	_, err = repo.AddMember(ctx, h.ID, household.AddMemberInput{
 		UserID: newUser,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 	require.NoError(t, err)
 
 	_, err = repo.AddMember(ctx, h.ID, household.AddMemberInput{
 		UserID: newUser,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 
 	require.Error(t, err)
@@ -270,7 +271,7 @@ func TestHouseholdRepo_RemoveMember_SoftDeletes(t *testing.T) {
 	newUser := insertTestUser(t, pool)
 	_, err = repo.AddMember(ctx, h.ID, household.AddMemberInput{
 		UserID: newUser,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 	require.NoError(t, err)
 
@@ -398,7 +399,7 @@ func TestHouseholdRepo_Txn_CreateCommits(t *testing.T) {
 	members, err := repo.ListMembers(ctx, householdID)
 	require.NoError(t, err)
 	assert.Len(t, members, 1)
-	assert.Equal(t, household.RoleAdmin, members[0].Role)
+	assert.Equal(t, types.RoleAdmin, members[0].Role)
 }
 
 // TestHouseholdRepo_Txn_CreateRollsBack verifies that when a transaction
@@ -448,7 +449,7 @@ func TestHouseholdRepo_Workflow_DeactivateHidesFromAllMembers(t *testing.T) {
 
 	_, err = repo.AddMember(ctx, h.ID, household.AddMemberInput{
 		UserID: member,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, admin)
 	require.NoError(t, err)
 
@@ -490,7 +491,7 @@ func TestHouseholdRepo_Workflow_AddRemoveMember(t *testing.T) {
 
 	_, err = repo.AddMember(ctx, h.ID, household.AddMemberInput{
 		UserID: member,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, admin)
 	require.NoError(t, err)
 

--- a/internal/domain/household/household.go
+++ b/internal/domain/household/household.go
@@ -6,28 +6,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-)
 
-// Role represents the permission level of a household member.
-// Restricted to RoleAdmin and RoleMember — matches the CHECK constraint in the DB.
-type Role string
-
-const (
-	// RoleAdmin grants full management capabilities within the household.
-	RoleAdmin Role = "ADMIN"
-	// RoleMember grants read and limited write access within the household.
-	RoleMember Role = "MEMBER"
-)
-
-// Status represents the lifecycle state of a household.
-// Restricted to StatusActive and StatusInactive — matches the CHECK constraint in the DB.
-type Status string
-
-const (
-	// StatusActive indicates the household is operational.
-	StatusActive Status = "ACTIVE"
-	// StatusInactive indicates the household has been deactivated.
-	StatusInactive Status = "INACTIVE"
+	"github.com/zambone/pfm-go/internal/types"
 )
 
 // Household represents the central organizing unit for all financial data.
@@ -35,7 +15,7 @@ const (
 type Household struct {
 	ID        uuid.UUID
 	Name      string
-	Status    Status
+	Status    types.Status
 	Version   int // optimistic concurrency version, mirrors the DB column
 	CreatedAt time.Time
 	UpdatedAt time.Time
@@ -48,7 +28,7 @@ type Household struct {
 type Membership struct {
 	HouseholdID uuid.UUID
 	UserID      uuid.UUID
-	Role        Role
+	Role        types.Role
 	InvitedBy   uuid.UUID
 	JoinedAt    time.Time
 }
@@ -68,7 +48,7 @@ type UpdateNameInput struct {
 // The inviter's ID comes from context — it is not part of the input.
 type AddMemberInput struct {
 	UserID uuid.UUID
-	Role   Role
+	Role   types.Role
 }
 
 // HouseholdReader defines the read-only storage contract for the household domain.

--- a/internal/domain/household/household_factory_test.go
+++ b/internal/domain/household/household_factory_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/zambone/pfm-go/internal/domain/household"
+	"github.com/zambone/pfm-go/internal/types"
 )
 
 var (
@@ -25,7 +26,7 @@ func householdFactory(overrides ...func(*household.Household)) household.Househo
 	h := household.Household{
 		ID:        testHouseholdID,
 		Name:      "Test Household",
-		Status:    household.StatusActive,
+		Status:    types.StatusActive,
 		Version:   1,
 		CreatedAt: fixedTime,
 		UpdatedAt: fixedTime,
@@ -43,7 +44,7 @@ func membershipFactory(overrides ...func(*household.Membership)) household.Membe
 	m := household.Membership{
 		HouseholdID: testHouseholdID,
 		UserID:      testOwnerID,
-		Role:        household.RoleAdmin,
+		Role:        types.RoleAdmin,
 		InvitedBy:   uuid.Nil,
 		JoinedAt:    fixedTime,
 	}
@@ -79,7 +80,7 @@ func updateNameInputFactory(overrides ...func(*household.UpdateNameInput)) house
 func addMemberInputFactory(overrides ...func(*household.AddMemberInput)) household.AddMemberInput {
 	in := household.AddMemberInput{
 		UserID: testMemberID,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}
 	for _, o := range overrides {
 		o(&in)
@@ -95,7 +96,7 @@ func TestFactories_ProduceValidDefaults(t *testing.T) {
 
 		assert.NotEqual(t, uuid.Nil, h.ID)
 		assert.NotEmpty(t, h.Name)
-		assert.Equal(t, household.StatusActive, h.Status)
+		assert.Equal(t, types.StatusActive, h.Status)
 		assert.Equal(t, 1, h.Version)
 		assert.False(t, h.CreatedAt.IsZero())
 		assert.False(t, h.UpdatedAt.IsZero())
@@ -108,7 +109,7 @@ func TestFactories_ProduceValidDefaults(t *testing.T) {
 
 		assert.NotEqual(t, uuid.Nil, m.HouseholdID)
 		assert.NotEqual(t, uuid.Nil, m.UserID)
-		assert.Equal(t, household.RoleAdmin, m.Role)
+		assert.Equal(t, types.RoleAdmin, m.Role)
 		assert.False(t, m.JoinedAt.IsZero())
 	})
 
@@ -125,9 +126,9 @@ func TestFactories_ProduceValidDefaults(t *testing.T) {
 	})
 
 	t.Run("membershipFactory override applies", func(t *testing.T) {
-		m := membershipFactory(func(m *household.Membership) { m.Role = household.RoleMember })
+		m := membershipFactory(func(m *household.Membership) { m.Role = types.RoleMember })
 
-		assert.Equal(t, household.RoleMember, m.Role)
+		assert.Equal(t, types.RoleMember, m.Role)
 	})
 
 	t.Run("updateNameInputFactory has non-empty name", func(t *testing.T) {
@@ -140,7 +141,7 @@ func TestFactories_ProduceValidDefaults(t *testing.T) {
 		in := addMemberInputFactory()
 
 		assert.NotEqual(t, uuid.Nil, in.UserID)
-		assert.Equal(t, household.RoleMember, in.Role)
+		assert.Equal(t, types.RoleMember, in.Role)
 	})
 
 	t.Run("householdFactory fixedTime is 2026-01-01", func(t *testing.T) {

--- a/internal/domain/household/household_logic.go
+++ b/internal/domain/household/household_logic.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/zambone/pfm-go/internal/message"
 	"github.com/zambone/pfm-go/internal/platform/validate"
+	"github.com/zambone/pfm-go/internal/types"
 )
 
 // transactor abstracts atomic multi-table operations.
@@ -96,7 +97,7 @@ func (l *HouseholdLogic) AddMember(ctx context.Context, householdID uuid.UUID, i
 		}
 		return Membership{}, fmt.Errorf(message.ErrHouseholdLogicAddMember, err)
 	}
-	if callerMembership.Role != RoleAdmin {
+	if callerMembership.Role != types.RoleAdmin {
 		return Membership{}, fmt.Errorf(message.ErrHouseholdLogicAddMember, message.ErrHouseholdNotAdmin)
 	}
 
@@ -117,7 +118,7 @@ func (l *HouseholdLogic) RemoveMember(ctx context.Context, householdID uuid.UUID
 		}
 		return fmt.Errorf(message.ErrHouseholdLogicRemoveMember, err)
 	}
-	if callerMembership.Role != RoleAdmin {
+	if callerMembership.Role != types.RoleAdmin {
 		return fmt.Errorf(message.ErrHouseholdLogicRemoveMember, message.ErrHouseholdNotAdmin)
 	}
 
@@ -128,7 +129,7 @@ func (l *HouseholdLogic) RemoveMember(ctx context.Context, householdID uuid.UUID
 	}
 	adminCount := 0
 	for _, m := range members {
-		if m.Role == RoleAdmin {
+		if m.Role == types.RoleAdmin {
 			adminCount++
 		}
 	}
@@ -141,7 +142,7 @@ func (l *HouseholdLogic) RemoveMember(ctx context.Context, householdID uuid.UUID
 		}
 		return fmt.Errorf(message.ErrHouseholdLogicRemoveMember, err)
 	}
-	if targetMembership.Role == RoleAdmin && adminCount <= 1 {
+	if targetMembership.Role == types.RoleAdmin && adminCount <= 1 {
 		return fmt.Errorf(message.ErrHouseholdLogicRemoveMember, message.ErrHouseholdLastAdmin)
 	}
 

--- a/internal/domain/household/household_logic_test.go
+++ b/internal/domain/household/household_logic_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zambone/pfm-go/internal/platform/clock"
 	"github.com/zambone/pfm-go/internal/platform/database"
 	"github.com/zambone/pfm-go/internal/platform/validate"
+	"github.com/zambone/pfm-go/internal/types"
 )
 
 // newHouseholdLogic returns a HouseholdLogic with a fresh fake repo, fake transactor,
@@ -40,7 +41,7 @@ func TestHouseholdLogic_Create_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, uuid.Nil, h.ID)
 	assert.Equal(t, "Home", h.Name)
-	assert.Equal(t, household.StatusActive, h.Status)
+	assert.Equal(t, types.StatusActive, h.Status)
 	assert.Equal(t, 1, h.Version)
 }
 
@@ -62,7 +63,7 @@ func TestHouseholdLogic_Create_CallerBecomesAdmin(t *testing.T) {
 
 	m, err := repo.FindMembership(context.Background(), h.ID, callerID)
 	require.NoError(t, err)
-	assert.Equal(t, household.RoleAdmin, m.Role)
+	assert.Equal(t, types.RoleAdmin, m.Role)
 }
 
 // ---------------------------------------------------------------------------
@@ -133,12 +134,12 @@ func TestHouseholdLogic_AddMember_AdminCanAdd(t *testing.T) {
 
 	m, err := logic.AddMember(context.Background(), h.ID, household.AddMemberInput{
 		UserID: newMember,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 
 	require.NoError(t, err)
 	assert.Equal(t, newMember, m.UserID)
-	assert.Equal(t, household.RoleMember, m.Role)
+	assert.Equal(t, types.RoleMember, m.Role)
 }
 
 func TestHouseholdLogic_AddMember_NonAdminDenied(t *testing.T) {
@@ -152,14 +153,14 @@ func TestHouseholdLogic_AddMember_NonAdminDenied(t *testing.T) {
 	// Add memberUser as MEMBER (not admin).
 	_, err = repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
 		UserID: memberUser,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 	require.NoError(t, err)
 
 	// memberUser tries to add anotherUser — should be denied.
 	_, err = logic.AddMember(context.Background(), h.ID, household.AddMemberInput{
 		UserID: anotherUser,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, memberUser)
 
 	require.Error(t, err)
@@ -175,13 +176,13 @@ func TestHouseholdLogic_AddMember_DuplicateReturnsError(t *testing.T) {
 
 	_, err = logic.AddMember(context.Background(), h.ID, household.AddMemberInput{
 		UserID: newMember,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 	require.NoError(t, err)
 
 	_, err = logic.AddMember(context.Background(), h.ID, household.AddMemberInput{
 		UserID: newMember,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 
 	require.Error(t, err)
@@ -200,7 +201,7 @@ func TestHouseholdLogic_RemoveMember_AdminCanRemove(t *testing.T) {
 	require.NoError(t, err)
 	_, err = logic.AddMember(context.Background(), h.ID, household.AddMemberInput{
 		UserID: member,
-		Role:   household.RoleMember,
+		Role:   types.RoleMember,
 	}, callerID)
 	require.NoError(t, err)
 
@@ -220,11 +221,11 @@ func TestHouseholdLogic_RemoveMember_NonAdminDenied(t *testing.T) {
 	h, err := logic.Create(context.Background(), household.CreateInput{Name: "Home"}, callerID)
 	require.NoError(t, err)
 	_, err = repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
-		UserID: memberUser, Role: household.RoleMember,
+		UserID: memberUser, Role: types.RoleMember,
 	}, callerID)
 	require.NoError(t, err)
 	_, err = repo.AddMember(context.Background(), h.ID, household.AddMemberInput{
-		UserID: anotherMember, Role: household.RoleMember,
+		UserID: anotherMember, Role: types.RoleMember,
 	}, callerID)
 	require.NoError(t, err)
 

--- a/internal/platform/ctxutil/ctxutil.go
+++ b/internal/platform/ctxutil/ctxutil.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/types"
 )
 
 type contextKey int
@@ -12,6 +14,7 @@ const (
 	userIdKey contextKey = iota
 	householdIdKey
 	traceIdKey
+	roleKey
 )
 
 // WithUserID returns a new context with a given user id.
@@ -45,4 +48,15 @@ func WithTraceID(ctx context.Context, id string) context.Context {
 func TraceID(ctx context.Context) (string, bool) {
 	id, ok := ctx.Value(traceIdKey).(string)
 	return id, ok
+}
+
+// WithRole returns a new context with the given household membership role.
+func WithRole(ctx context.Context, role types.Role) context.Context {
+	return context.WithValue(ctx, roleKey, role)
+}
+
+// Role extracts the household membership role from the context.
+func Role(ctx context.Context) (types.Role, bool) {
+	role, ok := ctx.Value(roleKey).(types.Role)
+	return role, ok
 }

--- a/internal/platform/ctxutil/ctxutil_test.go
+++ b/internal/platform/ctxutil/ctxutil_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/zambone/pfm-go/internal/platform/ctxutil"
+	"github.com/zambone/pfm-go/internal/types"
 )
 
 func TestUserID_RoundTrip(t *testing.T) {
@@ -29,6 +30,7 @@ func TestMissingFromContext_ReturnsFalse(t *testing.T) {
 		{"user ID", func(ctx context.Context) bool { _, ok := ctxutil.UserID(ctx); return ok }},
 		{"household ID", func(ctx context.Context) bool { _, ok := ctxutil.HouseholdID(ctx); return ok }},
 		{"trace ID", func(ctx context.Context) bool { _, ok := ctxutil.TraceID(ctx); return ok }},
+		{"role", func(ctx context.Context) bool { _, ok := ctxutil.Role(ctx); return ok }},
 	}
 
 	for _, tt := range tests {
@@ -57,15 +59,26 @@ func TestTraceID_RoundTrip(t *testing.T) {
 	assert.Equal(t, "abc123", got)
 }
 
+func TestRole_RoundTrip(t *testing.T) {
+	ctx := ctxutil.WithRole(context.Background(), types.RoleAdmin)
+
+	got, ok := ctxutil.Role(ctx)
+
+	assert.True(t, ok)
+	assert.Equal(t, types.RoleAdmin, got)
+}
+
 func TestMultipleValues_Coexist(t *testing.T) {
 	userID := uuid.New()
 	householdID := uuid.New()
 	traceID := "trace-123"
+	role := types.RoleMember
 
 	ctx := context.Background()
 	ctx = ctxutil.WithUserID(ctx, userID)
 	ctx = ctxutil.WithHouseholdID(ctx, householdID)
 	ctx = ctxutil.WithTraceID(ctx, traceID)
+	ctx = ctxutil.WithRole(ctx, role)
 
 	gotUser, ok := ctxutil.UserID(ctx)
 	assert.True(t, ok)
@@ -78,17 +91,23 @@ func TestMultipleValues_Coexist(t *testing.T) {
 	gotTrace, ok := ctxutil.TraceID(ctx)
 	assert.True(t, ok)
 	assert.Equal(t, traceID, gotTrace)
+
+	gotRole, ok := ctxutil.Role(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, role, gotRole)
 }
 
 func TestContextValues_AccessibleAcrossGoroutines(t *testing.T) {
 	userID := uuid.New()
 	householdID := uuid.New()
 	traceID := "trace-goroutine"
+	role := types.RoleAdmin
 
 	ctx := context.Background()
 	ctx = ctxutil.WithUserID(ctx, userID)
 	ctx = ctxutil.WithHouseholdID(ctx, householdID)
 	ctx = ctxutil.WithTraceID(ctx, traceID)
+	ctx = ctxutil.WithRole(ctx, role)
 
 	done := make(chan struct{})
 	go func() {
@@ -105,6 +124,10 @@ func TestContextValues_AccessibleAcrossGoroutines(t *testing.T) {
 		gotTrace, ok := ctxutil.TraceID(ctx)
 		assert.True(t, ok)
 		assert.Equal(t, traceID, gotTrace)
+
+		gotRole, ok := ctxutil.Role(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, role, gotRole)
 	}()
 
 	<-done

--- a/internal/types/role.go
+++ b/internal/types/role.go
@@ -1,0 +1,26 @@
+// Package types contains shared value types that cross layer boundaries.
+// Only leaf types with no business logic belong here — the domain, platform,
+// and adapter layers all import this package safely.
+package types
+
+// Role represents the permission level of a household member.
+// Restricted to RoleAdmin and RoleMember — matches the CHECK constraint in the DB.
+type Role string
+
+const (
+	// RoleAdmin grants full management capabilities within the household.
+	RoleAdmin Role = "ADMIN"
+	// RoleMember grants read and limited write access within the household.
+	RoleMember Role = "MEMBER"
+)
+
+// Status represents the lifecycle state of a household.
+// Restricted to StatusActive and StatusInactive — matches the CHECK constraint in the DB.
+type Status string
+
+const (
+	// StatusActive indicates the household is operational.
+	StatusActive Status = "ACTIVE"
+	// StatusInactive indicates the household has been deactivated.
+	StatusInactive Status = "INACTIVE"
+)


### PR DESCRIPTION
## Summary
- Create `internal/types/` package for shared value types (`Role`, `Status`) that need to cross layer boundaries without violating import rules
- Move `Role` and `Status` typed constants from `domain/household` to `internal/types` — `domain/*` and `platform/*` can both import `types/` safely
- Add `WithRole`/`Role` context getter/setter pair to `ctxutil` using `types.Role` for compile-time type safety
- Update all household domain, adapter, fake, and test files to reference `types.RoleAdmin`, `types.StatusActive`, etc.
- Add Role round-trip test, missing-context test, multi-value coexistence test, and goroutine safety test

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 5 acceptance criteria COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)
- [x] All existing household tests pass after the refactor (safety net verified)

closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)