### PR TITLE
feat(middleware): implement household guard middleware for authorization

### DIFF
--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -130,6 +130,15 @@ const (
 	MsgAuthnInvalidToken = "invalid token"
 )
 
+// Authorization middleware messages.
+const (
+	MsgAuthzUnauthenticated = "authentication required"
+	MsgAuthzForbidden       = "you are not a member of this household"
+	MsgAuthzNotFound        = "household not found"
+	MsgAuthzBadRequest      = "invalid household ID in URL"
+	MsgAuthzAdminRequired   = "admin role required"
+)
+
 // Login errors and messages.
 var (
 	ErrLoginInvalidCredentials = errors.New("login: invalid credentials")

--- a/internal/middleware/authz.go
+++ b/internal/middleware/authz.go
@@ -1,0 +1,94 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/ctxutil"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+// membershipFinder is the subset of household.Repository required by the guard.
+// Accepts a narrow interface (1 method) rather than the full Repository per interface
+// segregation. Returns only the role — the middleware doesn't need the full Membership.
+type membershipFinder interface {
+	FindRole(ctx context.Context, householdID, userID uuid.UUID) (types.Role, error)
+}
+
+// HouseholdGuard returns middleware that verifies the caller is an active member of the
+// household identified by the URL path parameter named pathParam. On success it injects
+// the household ID and role into the request context. Panics if mf is nil.
+//
+// Errors:
+//   - 400 Bad Request: malformed household UUID in URL
+//   - 401 Unauthorized: no user ID in context (authn middleware missing or failed)
+//   - 403 Forbidden: caller is not a member of the household
+//   - 404 Not Found: household does not exist
+func HouseholdGuard(mf membershipFinder, pathParam string) func(http.Handler) http.Handler {
+	if mf == nil {
+		panic("middleware: HouseholdGuard requires non-nil membershipFinder")
+	}
+	return householdGuard(mf, pathParam, false)
+}
+
+// HouseholdAdminGuard returns middleware identical to HouseholdGuard but additionally
+// requires the caller to have the ADMIN role. Returns 403 if the caller is a MEMBER
+// but not an ADMIN. Panics if mf is nil.
+func HouseholdAdminGuard(mf membershipFinder, pathParam string) func(http.Handler) http.Handler {
+	if mf == nil {
+		panic("middleware: HouseholdAdminGuard requires non-nil membershipFinder")
+	}
+	return householdGuard(mf, pathParam, true)
+}
+
+// householdGuard is the shared implementation for both guard variants.
+func householdGuard(mf membershipFinder, pathParam string, requireAdmin bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// 1. Ensure the caller is authenticated (user ID must be in context).
+			userID, ok := ctxutil.UserID(r.Context())
+			if !ok {
+				writeJSON(w, http.StatusUnauthorized, message.MsgAuthzUnauthenticated)
+				return
+			}
+
+			// 2. Extract and parse the household ID from the URL path.
+			rawID := r.PathValue(pathParam)
+			householdID, err := uuid.Parse(rawID)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, message.MsgAuthzBadRequest)
+				return
+			}
+
+			// 3. Verify membership and retrieve role.
+			role, err := mf.FindRole(r.Context(), householdID, userID)
+			if err != nil {
+				if errors.Is(err, message.ErrHouseholdMemberNotFound) {
+					writeJSON(w, http.StatusForbidden, message.MsgAuthzForbidden)
+					return
+				}
+				if errors.Is(err, message.ErrHouseholdNotFound) {
+					writeJSON(w, http.StatusNotFound, message.MsgAuthzNotFound)
+					return
+				}
+				writeJSON(w, http.StatusForbidden, message.MsgAuthzForbidden)
+				return
+			}
+
+			// 4. If admin is required, check the role.
+			if requireAdmin && role != types.RoleAdmin {
+				writeJSON(w, http.StatusForbidden, message.MsgAuthzAdminRequired)
+				return
+			}
+
+			// 5. Inject household ID and role into context, call next handler.
+			ctx := ctxutil.WithHouseholdID(r.Context(), householdID)
+			ctx = ctxutil.WithRole(ctx, role)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/internal/middleware/authz_test.go
+++ b/internal/middleware/authz_test.go
@@ -1,0 +1,178 @@
+package middleware_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/middleware"
+	"github.com/zambone/pfm-go/internal/platform/ctxutil"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+// fakeMembershipFinder is a test double for the membershipFinder interface.
+type fakeMembershipFinder struct {
+	role types.Role
+	err  error
+}
+
+func (f *fakeMembershipFinder) FindRole(_ context.Context, _, _ uuid.UUID) (types.Role, error) {
+	return f.role, f.err
+}
+
+// passHandler is a simple handler that writes 200 OK — used to verify the guard
+// called next. Separate from authn_test.go's okHandler which has a different signature.
+var passHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+// newAuthzRequest creates a GET request with the given path, routed through a ServeMux
+// so that r.PathValue works. The caller's user ID is injected into context.
+func newAuthzRequest(t *testing.T, path, pattern string, userID uuid.UUID, handler http.Handler) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.Handle(pattern, handler)
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if userID != uuid.Nil {
+		req = req.WithContext(ctxutil.WithUserID(req.Context(), userID))
+	}
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	return rr
+}
+
+// parseErrorBody extracts the "error" field from a JSON response body.
+func parseErrorBody(t *testing.T, rr *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
+	return body["error"]
+}
+
+// ---------------------------------------------------------------------------
+// HouseholdGuard
+// ---------------------------------------------------------------------------
+
+func TestHouseholdGuard_MemberAllowed(t *testing.T) {
+	userID := uuid.New()
+	finder := &fakeMembershipFinder{role: types.RoleMember}
+
+	var capturedHouseholdID uuid.UUID
+	var capturedRole types.Role
+	captureHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHouseholdID, _ = ctxutil.HouseholdID(r.Context())
+		capturedRole, _ = ctxutil.Role(r.Context())
+	})
+
+	guarded := middleware.HouseholdGuard(finder, "household_id")(captureHandler)
+	householdID := uuid.New()
+	rr := newAuthzRequest(t, "/households/"+householdID.String(), "/households/{household_id}", userID, guarded)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, householdID, capturedHouseholdID)
+	assert.Equal(t, types.RoleMember, capturedRole)
+}
+
+func TestHouseholdGuard_AdminAllowed(t *testing.T) {
+	userID := uuid.New()
+	finder := &fakeMembershipFinder{role: types.RoleAdmin}
+
+	guarded := middleware.HouseholdGuard(finder, "household_id")(passHandler)
+	rr := newAuthzRequest(t, "/households/"+uuid.New().String(), "/households/{household_id}", userID, guarded)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestHouseholdGuard_NotMember_Returns403(t *testing.T) {
+	userID := uuid.New()
+	finder := &fakeMembershipFinder{err: message.ErrHouseholdMemberNotFound}
+
+	guarded := middleware.HouseholdGuard(finder, "household_id")(passHandler)
+	rr := newAuthzRequest(t, "/households/"+uuid.New().String(), "/households/{household_id}", userID, guarded)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Equal(t, message.MsgAuthzForbidden, parseErrorBody(t, rr))
+}
+
+func TestHouseholdGuard_HouseholdNotFound_Returns404(t *testing.T) {
+	userID := uuid.New()
+	finder := &fakeMembershipFinder{err: message.ErrHouseholdNotFound}
+
+	guarded := middleware.HouseholdGuard(finder, "household_id")(passHandler)
+	rr := newAuthzRequest(t, "/households/"+uuid.New().String(), "/households/{household_id}", userID, guarded)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Equal(t, message.MsgAuthzNotFound, parseErrorBody(t, rr))
+}
+
+func TestHouseholdGuard_NoUserID_Returns401(t *testing.T) {
+	finder := &fakeMembershipFinder{role: types.RoleMember}
+
+	guarded := middleware.HouseholdGuard(finder, "household_id")(passHandler)
+	// Pass uuid.Nil to signal no user ID in context.
+	rr := newAuthzRequest(t, "/households/"+uuid.New().String(), "/households/{household_id}", uuid.Nil, guarded)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Equal(t, message.MsgAuthzUnauthenticated, parseErrorBody(t, rr))
+}
+
+func TestHouseholdGuard_MalformedUUID_Returns400(t *testing.T) {
+	userID := uuid.New()
+	finder := &fakeMembershipFinder{role: types.RoleMember}
+
+	guarded := middleware.HouseholdGuard(finder, "household_id")(passHandler)
+	rr := newAuthzRequest(t, "/households/not-a-uuid", "/households/{household_id}", userID, guarded)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Equal(t, message.MsgAuthzBadRequest, parseErrorBody(t, rr))
+}
+
+// ---------------------------------------------------------------------------
+// HouseholdAdminGuard
+// ---------------------------------------------------------------------------
+
+func TestHouseholdAdminGuard_AdminAllowed(t *testing.T) {
+	userID := uuid.New()
+	finder := &fakeMembershipFinder{role: types.RoleAdmin}
+
+	guarded := middleware.HouseholdAdminGuard(finder, "household_id")(passHandler)
+	rr := newAuthzRequest(t, "/households/"+uuid.New().String(), "/households/{household_id}", userID, guarded)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestHouseholdAdminGuard_MemberDenied_Returns403(t *testing.T) {
+	userID := uuid.New()
+	finder := &fakeMembershipFinder{role: types.RoleMember}
+
+	guarded := middleware.HouseholdAdminGuard(finder, "household_id")(passHandler)
+	rr := newAuthzRequest(t, "/households/"+uuid.New().String(), "/households/{household_id}", userID, guarded)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Equal(t, message.MsgAuthzAdminRequired, parseErrorBody(t, rr))
+}
+
+// ---------------------------------------------------------------------------
+// Panic on nil
+// ---------------------------------------------------------------------------
+
+func TestHouseholdGuard_NilFinder_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		middleware.HouseholdGuard(nil, "household_id")
+	})
+}
+
+func TestHouseholdAdminGuard_NilFinder_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		middleware.HouseholdAdminGuard(nil, "household_id")
+	})
+}


### PR DESCRIPTION
## Summary
- Add `HouseholdGuard` middleware: extracts household ID from URL path (`r.PathValue`), verifies membership via `membershipFinder.FindRole`, injects `household_id` and `role` into request context
- Add `HouseholdAdminGuard` variant that additionally requires ADMIN role (403 for MEMBER)
- Define narrow `membershipFinder` interface (1 method: `FindRole`) — middleware never imports domain logic, only `types.Role` and `message/` sentinels
- Add 5 authorization message constants (`MsgAuthzUnauthenticated`, `MsgAuthzForbidden`, `MsgAuthzNotFound`, `MsgAuthzBadRequest`, `MsgAuthzAdminRequired`)
- 10 tests covering: member allowed, admin allowed, not-member (403), household not found (404), unauthenticated (401), malformed UUID (400), admin-only denial (403), and nil-finder panics (x2)

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 7 acceptance criteria + 3 edge cases COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)