### PR TITLE
test(auth): add authorization context testing helpers

### DIFF
--- a/internal/testutil/authctx.go
+++ b/internal/testutil/authctx.go
@@ -1,0 +1,28 @@
+// Package testutil provides reusable test helpers for the pfm-go project.
+// Import this package only from _test.go files — it is not for production use.
+package testutil
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/platform/ctxutil"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+// AuthenticatedContext returns a context with the given user ID injected,
+// simulating a request that has passed the authentication middleware.
+func AuthenticatedContext(userID uuid.UUID) context.Context {
+	return ctxutil.WithUserID(context.Background(), userID)
+}
+
+// AuthorizedContext returns a context with user ID, household ID, and role
+// injected, simulating a request that has passed both the authentication
+// and household guard middleware.
+func AuthorizedContext(userID, householdID uuid.UUID, role types.Role) context.Context {
+	ctx := ctxutil.WithUserID(context.Background(), userID)
+	ctx = ctxutil.WithHouseholdID(ctx, householdID)
+	ctx = ctxutil.WithRole(ctx, role)
+	return ctx
+}

--- a/internal/testutil/authctx_test.go
+++ b/internal/testutil/authctx_test.go
@@ -1,0 +1,64 @@
+package testutil_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zambone/pfm-go/internal/platform/ctxutil"
+	"github.com/zambone/pfm-go/internal/testutil"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+func TestAuthenticatedContext_HasUserID(t *testing.T) {
+	userID := uuid.New()
+
+	ctx := testutil.AuthenticatedContext(userID)
+
+	got, ok := ctxutil.UserID(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, userID, got)
+}
+
+func TestAuthenticatedContext_NoHouseholdID(t *testing.T) {
+	ctx := testutil.AuthenticatedContext(uuid.New())
+
+	_, ok := ctxutil.HouseholdID(ctx)
+	assert.False(t, ok, "authenticated-only context should not have household ID")
+}
+
+func TestAuthenticatedContext_NoRole(t *testing.T) {
+	ctx := testutil.AuthenticatedContext(uuid.New())
+
+	_, ok := ctxutil.Role(ctx)
+	assert.False(t, ok, "authenticated-only context should not have role")
+}
+
+func TestAuthorizedContext_HasAllValues(t *testing.T) {
+	userID := uuid.New()
+	householdID := uuid.New()
+	role := types.RoleAdmin
+
+	ctx := testutil.AuthorizedContext(userID, householdID, role)
+
+	gotUser, ok := ctxutil.UserID(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, userID, gotUser)
+
+	gotHousehold, ok := ctxutil.HouseholdID(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, householdID, gotHousehold)
+
+	gotRole, ok := ctxutil.Role(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, role, gotRole)
+}
+
+func TestAuthorizedContext_MemberRole(t *testing.T) {
+	ctx := testutil.AuthorizedContext(uuid.New(), uuid.New(), types.RoleMember)
+
+	gotRole, ok := ctxutil.Role(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, types.RoleMember, gotRole)
+}


### PR DESCRIPTION
## Summary
- Create `internal/testutil/` package for reusable test helpers importable from any `_test.go` file
- Add `AuthenticatedContext(userID)` — returns context with user ID only (authn-passed, no household scope)
- Add `AuthorizedContext(userID, householdID, role)` — returns fully authorized context (authn + authz passed)
- No HTTP or middleware dependencies — pure `context.Context` manipulation via `ctxutil`
- 5 tests verifying all context values are set correctly and unset fields return false

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 5 acceptance criteria COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)