### PR TITLE
feat(account): define Repository port with reader/writer segregation

### DIFF
--- a/internal/domain/account/account.go
+++ b/internal/domain/account/account.go
@@ -2,6 +2,7 @@
 package account
 
 import (
+	"context"
 	"time"
 
 	"github.com/google/uuid"
@@ -43,4 +44,39 @@ type UpdateNameInput struct {
 // Balance is in minor units (cents/centavos).
 type UpdateBalanceInput struct {
 	Balance int64
+}
+
+// AccountReader defines the read-only storage contract for the account domain.
+type AccountReader interface {
+	// FindByID returns the active (non-deleted) account with the given ID.
+	// Returns an error wrapping ErrAccountNotFound when no matching active account exists.
+	FindByID(ctx context.Context, id uuid.UUID) (Account, error)
+	// ListForHousehold returns all active accounts belonging to the given household.
+	ListForHousehold(ctx context.Context, householdID uuid.UUID) ([]Account, error)
+}
+
+// AccountWriter defines the write-only storage contract for the account domain.
+type AccountWriter interface {
+	// Create persists a new account with zero balance and returns the saved entity
+	// with server-assigned fields (ID, Version, timestamps).
+	// Returns an error wrapping ErrAccountNameTaken when the name is already used
+	// by another active account in the same household.
+	Create(ctx context.Context, householdID uuid.UUID, input CreateInput, callerID uuid.UUID) (Account, error)
+	// UpdateName changes the name of the account.
+	// Returns an error wrapping ErrAccountVersionConflict when expectedVersion does not match.
+	// Returns an error wrapping ErrAccountNameTaken when the new name conflicts.
+	UpdateName(ctx context.Context, id uuid.UUID, input UpdateNameInput, expectedVersion int, callerID uuid.UUID) (Account, error)
+	// UpdateBalance sets the account balance to the new value.
+	// Returns an error wrapping ErrAccountVersionConflict when expectedVersion does not match.
+	UpdateBalance(ctx context.Context, id uuid.UUID, input UpdateBalanceInput, expectedVersion int, callerID uuid.UUID) (Account, error)
+	// Deactivate soft-deletes the account.
+	// Idempotent — deactivating an already-deactivated account is not an error.
+	Deactivate(ctx context.Context, id uuid.UUID, callerID uuid.UUID) error
+}
+
+// Repository defines the full storage contract for the account domain.
+// Defined at the consumer (domain) rather than the provider (adapter) per interface segregation.
+type Repository interface {
+	AccountReader
+	AccountWriter
 }


### PR DESCRIPTION
## Summary
- Add `AccountReader` interface (FindByID, ListForHousehold)
- Add `AccountWriter` interface (Create, UpdateName, UpdateBalance, Deactivate)
- Compose into `Repository` following the established domain pattern
- `Create` accepts `householdID` to scope accounts; `UpdateName`/`UpdateBalance` use optimistic concurrency via `expectedVersion`
- 2 reader + 4 writer = 6 total methods

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 6 acceptance criteria COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)