### PR TITLE
feat(account): implement FakeAccountRepository with name uniqueness

### DIFF
--- a/internal/adapter/postgres/fake_account_repo.go
+++ b/internal/adapter/postgres/fake_account_repo.go
@@ -1,0 +1,219 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/domain/account"
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+// FakeAccountRepository is a test double for domain/account.Repository.
+// It stores accounts in an in-memory map keyed by ID and enforces per-household
+// name uniqueness via a secondary index.
+//
+// NOT FOR PRODUCTION — panics if called outside a test binary.
+// Thread-safe via sync.RWMutex.
+type FakeAccountRepository struct {
+	mu    sync.RWMutex
+	byID  map[uuid.UUID]account.Account
+	names map[string]uuid.UUID // key: "householdID:lower(name)" → account ID
+	err   error                // injected error returned by all methods
+}
+
+// NewFakeAccountRepository returns an empty FakeAccountRepository ready for use in tests.
+func NewFakeAccountRepository() *FakeAccountRepository {
+	return &FakeAccountRepository{
+		byID:  make(map[uuid.UUID]account.Account),
+		names: make(map[string]uuid.UUID),
+	}
+}
+
+// nameKey builds the composite key for the per-household name uniqueness index.
+func nameKey(householdID uuid.UUID, name string) string {
+	return householdID.String() + ":" + strings.ToLower(name)
+}
+
+// SetError configures every subsequent method call to return err.
+// Pass nil to clear the injected error.
+func (f *FakeAccountRepository) SetError(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+}
+
+// Create stores a new account with zero balance and returns it.
+// Returns an error wrapping ErrAccountNameTaken if the name already exists in the household.
+// Panics if called outside a test binary.
+func (f *FakeAccountRepository) Create(_ context.Context, householdID uuid.UUID, input account.CreateInput, callerID uuid.UUID) (account.Account, error) {
+	if !testing.Testing() {
+		panic("FakeAccountRepository: not for production use — wire AccountRepo instead")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return account.Account{}, f.err
+	}
+
+	nk := nameKey(householdID, input.Name)
+	if _, exists := f.names[nk]; exists {
+		return account.Account{}, fmt.Errorf(message.ErrAccountCreate, message.ErrAccountNameTaken)
+	}
+
+	a := account.Account{
+		ID:           uuid.New(),
+		HouseholdID:  householdID,
+		Name:         input.Name,
+		AccountType:  input.AccountType,
+		CurrencyCode: input.CurrencyCode,
+		Balance:      0,
+		Status:       types.StatusActive,
+		Version:      1,
+		CreatedBy:    callerID,
+		UpdatedBy:    callerID,
+	}
+	f.byID[a.ID] = a
+	f.names[nk] = a.ID
+	return a, nil
+}
+
+// FindByID returns the active account with the given ID.
+// Returns an error wrapping ErrAccountNotFound when not found.
+// Panics if called outside a test binary.
+func (f *FakeAccountRepository) FindByID(_ context.Context, id uuid.UUID) (account.Account, error) {
+	if !testing.Testing() {
+		panic("FakeAccountRepository: not for production use — wire AccountRepo instead")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	if f.err != nil {
+		return account.Account{}, f.err
+	}
+
+	a, ok := f.byID[id]
+	if !ok {
+		return account.Account{}, fmt.Errorf(message.ErrAccountFindByID, message.ErrAccountNotFound)
+	}
+	return a, nil
+}
+
+// ListForHousehold returns all active accounts belonging to the given household.
+// Panics if called outside a test binary.
+func (f *FakeAccountRepository) ListForHousehold(_ context.Context, householdID uuid.UUID) ([]account.Account, error) {
+	if !testing.Testing() {
+		panic("FakeAccountRepository: not for production use — wire AccountRepo instead")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	var result []account.Account
+	for _, a := range f.byID {
+		if a.HouseholdID == householdID {
+			result = append(result, a)
+		}
+	}
+	return result, nil
+}
+
+// UpdateName changes the name of the account.
+// Returns an error wrapping ErrAccountVersionConflict if expectedVersion does not match.
+// Returns an error wrapping ErrAccountNameTaken if the new name conflicts.
+// Panics if called outside a test binary.
+func (f *FakeAccountRepository) UpdateName(_ context.Context, id uuid.UUID, input account.UpdateNameInput, expectedVersion int, callerID uuid.UUID) (account.Account, error) {
+	if !testing.Testing() {
+		panic("FakeAccountRepository: not for production use — wire AccountRepo instead")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return account.Account{}, f.err
+	}
+
+	a, ok := f.byID[id]
+	if !ok {
+		return account.Account{}, fmt.Errorf(message.ErrAccountUpdateName, message.ErrAccountNotFound)
+	}
+	if a.Version != expectedVersion {
+		return account.Account{}, fmt.Errorf(message.ErrAccountUpdateName, message.ErrAccountVersionConflict)
+	}
+
+	newKey := nameKey(a.HouseholdID, input.Name)
+	if existingID, exists := f.names[newKey]; exists && existingID != id {
+		return account.Account{}, fmt.Errorf(message.ErrAccountUpdateName, message.ErrAccountNameTaken)
+	}
+
+	oldKey := nameKey(a.HouseholdID, a.Name)
+	delete(f.names, oldKey)
+
+	a.Name = input.Name
+	a.Version++
+	a.UpdatedBy = callerID
+	f.byID[id] = a
+	f.names[newKey] = id
+	return a, nil
+}
+
+// UpdateBalance sets the account balance to the new value.
+// Returns an error wrapping ErrAccountVersionConflict if expectedVersion does not match.
+// Panics if called outside a test binary.
+func (f *FakeAccountRepository) UpdateBalance(_ context.Context, id uuid.UUID, input account.UpdateBalanceInput, expectedVersion int, callerID uuid.UUID) (account.Account, error) {
+	if !testing.Testing() {
+		panic("FakeAccountRepository: not for production use — wire AccountRepo instead")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return account.Account{}, f.err
+	}
+
+	a, ok := f.byID[id]
+	if !ok {
+		return account.Account{}, fmt.Errorf(message.ErrAccountUpdateBalance, message.ErrAccountNotFound)
+	}
+	if a.Version != expectedVersion {
+		return account.Account{}, fmt.Errorf(message.ErrAccountUpdateBalance, message.ErrAccountVersionConflict)
+	}
+
+	a.Balance = input.Balance
+	a.Version++
+	a.UpdatedBy = callerID
+	f.byID[id] = a
+	return a, nil
+}
+
+// Deactivate soft-deletes the account by removing it from the maps.
+// Idempotent — deactivating an already-removed account is not an error.
+// Panics if called outside a test binary.
+func (f *FakeAccountRepository) Deactivate(_ context.Context, id uuid.UUID, _ uuid.UUID) error {
+	if !testing.Testing() {
+		panic("FakeAccountRepository: not for production use — wire AccountRepo instead")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return f.err
+	}
+
+	a, ok := f.byID[id]
+	if !ok {
+		return nil // already gone — idempotent
+	}
+	delete(f.names, nameKey(a.HouseholdID, a.Name))
+	delete(f.byID, id)
+	return nil
+}

--- a/internal/adapter/postgres/fake_account_repo_test.go
+++ b/internal/adapter/postgres/fake_account_repo_test.go
@@ -1,0 +1,246 @@
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zambone/pfm-go/internal/adapter/postgres"
+	"github.com/zambone/pfm-go/internal/domain/account"
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+var (
+	fakeAccountHouseholdID = uuid.MustParse("00000000-0000-0000-0000-000000000010")
+	fakeAccountCallerID    = uuid.MustParse("00000000-0000-0000-0000-000000000001")
+)
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+func TestFakeAccountRepository_Create_StoresAndReturns(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+
+	a, err := repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name:         "Checking",
+		AccountType:  types.AccountTypeChecking,
+		CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, a.ID)
+	assert.Equal(t, "Checking", a.Name)
+	assert.Equal(t, types.AccountTypeChecking, a.AccountType)
+	assert.Equal(t, int64(0), a.Balance)
+	assert.Equal(t, 1, a.Version)
+}
+
+func TestFakeAccountRepository_Create_DuplicateName_ReturnsNameTaken(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+
+	_, err := repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name:         "Checking",
+		AccountType:  types.AccountTypeChecking,
+		CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+	require.NoError(t, err)
+
+	_, err = repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name:         "Checking",
+		AccountType:  types.AccountTypeSavings,
+		CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrAccountNameTaken))
+}
+
+// ---------------------------------------------------------------------------
+// FindByID
+// ---------------------------------------------------------------------------
+
+func TestFakeAccountRepository_FindByID_ReturnsAccount(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+
+	created, err := repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(context.Background(), created.ID)
+
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, found.ID)
+}
+
+func TestFakeAccountRepository_FindByID_NotFound(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+
+	_, err := repo.FindByID(context.Background(), uuid.New())
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrAccountNotFound))
+}
+
+// ---------------------------------------------------------------------------
+// ListForHousehold
+// ---------------------------------------------------------------------------
+
+func TestFakeAccountRepository_ListForHousehold_ReturnsOnlyHouseholdAccounts(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+	otherHousehold := uuid.New()
+
+	_, err := repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name: "A1", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+	require.NoError(t, err)
+	_, err = repo.Create(context.Background(), otherHousehold, account.CreateInput{
+		Name: "A2", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+	require.NoError(t, err)
+
+	list, err := repo.ListForHousehold(context.Background(), fakeAccountHouseholdID)
+
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+}
+
+// ---------------------------------------------------------------------------
+// UpdateName
+// ---------------------------------------------------------------------------
+
+func TestFakeAccountRepository_UpdateName_ChangesNameAndVersion(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+
+	created, err := repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name: "Old", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+	require.NoError(t, err)
+
+	updated, err := repo.UpdateName(context.Background(), created.ID,
+		account.UpdateNameInput{Name: "New"}, created.Version, fakeAccountCallerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, "New", updated.Name)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+func TestFakeAccountRepository_UpdateName_VersionConflict(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+
+	created, err := repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name: "Old", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+	require.NoError(t, err)
+
+	_, err = repo.UpdateName(context.Background(), created.ID,
+		account.UpdateNameInput{Name: "New"}, created.Version+99, fakeAccountCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrAccountVersionConflict))
+}
+
+func TestFakeAccountRepository_UpdateName_DuplicateName_ReturnsNameTaken(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+
+	_, err := repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name: "Existing", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+	require.NoError(t, err)
+	created, err := repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name: "Other", AccountType: types.AccountTypeSavings, CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+	require.NoError(t, err)
+
+	_, err = repo.UpdateName(context.Background(), created.ID,
+		account.UpdateNameInput{Name: "Existing"}, created.Version, fakeAccountCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrAccountNameTaken))
+}
+
+// ---------------------------------------------------------------------------
+// UpdateBalance
+// ---------------------------------------------------------------------------
+
+func TestFakeAccountRepository_UpdateBalance_ChangesBalanceAndVersion(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+
+	created, err := repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+	require.NoError(t, err)
+
+	updated, err := repo.UpdateBalance(context.Background(), created.ID,
+		account.UpdateBalanceInput{Balance: 10000}, created.Version, fakeAccountCallerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(10000), updated.Balance)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+func TestFakeAccountRepository_UpdateBalance_VersionConflict(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+
+	created, err := repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+	require.NoError(t, err)
+
+	_, err = repo.UpdateBalance(context.Background(), created.ID,
+		account.UpdateBalanceInput{Balance: 10000}, created.Version+99, fakeAccountCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrAccountVersionConflict))
+}
+
+// ---------------------------------------------------------------------------
+// Deactivate
+// ---------------------------------------------------------------------------
+
+func TestFakeAccountRepository_Deactivate_SoftDeletes(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+
+	created, err := repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+	require.NoError(t, err)
+
+	err = repo.Deactivate(context.Background(), created.ID, fakeAccountCallerID)
+	require.NoError(t, err)
+
+	_, err = repo.FindByID(context.Background(), created.ID)
+	assert.True(t, errors.Is(err, message.ErrAccountNotFound))
+}
+
+func TestFakeAccountRepository_Deactivate_IsIdempotent(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+
+	created, err := repo.Create(context.Background(), fakeAccountHouseholdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, fakeAccountCallerID)
+	require.NoError(t, err)
+
+	require.NoError(t, repo.Deactivate(context.Background(), created.ID, fakeAccountCallerID))
+	assert.NoError(t, repo.Deactivate(context.Background(), created.ID, fakeAccountCallerID))
+}
+
+// ---------------------------------------------------------------------------
+// SetError
+// ---------------------------------------------------------------------------
+
+func TestFakeAccountRepository_SetError_InjectsError(t *testing.T) {
+	repo := postgres.NewFakeAccountRepository()
+	injected := errors.New("injected")
+
+	repo.SetError(injected)
+
+	_, err := repo.FindByID(context.Background(), uuid.New())
+	assert.ErrorIs(t, err, injected)
+}

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -222,6 +222,29 @@ const (
 	ErrHouseholdLogicDeactivate   = "household logic: deactivate: %w"
 )
 
+// Account repository errors.
+var (
+	// ErrAccountNotFound is returned when an account lookup by ID finds no active record.
+	ErrAccountNotFound = errors.New("account: not found")
+	// ErrAccountVersionConflict is returned when an optimistic-lock update finds a stale version.
+	ErrAccountVersionConflict = errors.New("account: version conflict")
+	// ErrAccountNameTaken is returned when creating or renaming an account to a name already
+	// used by another active account in the same household.
+	ErrAccountNameTaken = errors.New("account: name already taken in household")
+	// ErrAccountBalanceNotZero is returned when deactivating an account that still has a balance.
+	ErrAccountBalanceNotZero = errors.New("account: balance must be zero to deactivate")
+)
+
+// Account repository format strings (adapter layer).
+const (
+	ErrAccountCreate         = "account: create: %w"
+	ErrAccountFindByID       = "account: find by id: %w"
+	ErrAccountListForHouse   = "account: list for household: %w"
+	ErrAccountUpdateName     = "account: update name: %w"
+	ErrAccountUpdateBalance  = "account: update balance: %w"
+	ErrAccountDeactivate     = "account: deactivate: %w"
+)
+
 // Startup errors (used by cmd/pfm/main.go composition root).
 const (
 	ErrRunLoadConfig = "load config: %w"


### PR DESCRIPTION
## Summary
- Add `FakeAccountRepository` implementing `account.Repository` with in-memory map and per-household name uniqueness index (`householdID:lower(name)`)
- Add Account error sentinels (`ErrAccountNotFound`, `ErrAccountVersionConflict`, `ErrAccountNameTaken`, `ErrAccountBalanceNotZero`) and 6 format strings to `message/errors.go`
- Thread-safe via `sync.RWMutex` with `testing.Testing()` production guard
- 12 tests covering Create, FindByID, ListForHousehold, UpdateName, UpdateBalance, Deactivate, duplicate names (create + rename), version conflicts, and error injection

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 10 acceptance criteria COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)