### PR TITLE
feat(account): implement AccountLogic domain service with TDD

### DIFF
--- a/internal/domain/account/account_logic.go
+++ b/internal/domain/account/account_logic.go
@@ -1,0 +1,136 @@
+package account
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+// clocker abstracts the current time.
+// Structurally satisfied by platform/clock.Clock.
+type clocker interface {
+	Now() time.Time
+}
+
+// validAccountTypes lists the allowed values for the account_type validation rule.
+var validAccountTypes = []string{
+	string(types.AccountTypeChecking),
+	string(types.AccountTypeSavings),
+	string(types.AccountTypeCreditCard),
+	string(types.AccountTypeInvestment),
+}
+
+// validCurrencies lists the allowed values for the currency_code validation rule.
+var validCurrencies = []string{
+	string(types.CurrencyUSD),
+	string(types.CurrencyBRL),
+	string(types.CurrencyEUR),
+}
+
+// AccountLogic orchestrates the account lifecycle: creation, queries,
+// name and balance updates, and deactivation with zero-balance enforcement.
+type AccountLogic struct {
+	repo Repository
+	clk  clocker
+}
+
+// NewAccountLogic constructs an AccountLogic. Panics if any dependency is nil.
+func NewAccountLogic(repo Repository, clk clocker) *AccountLogic {
+	if repo == nil {
+		panic("account: NewAccountLogic requires non-nil repo")
+	}
+	if clk == nil {
+		panic("account: NewAccountLogic requires non-nil clk")
+	}
+	return &AccountLogic{repo: repo, clk: clk}
+}
+
+// Create validates input and persists a new account with zero balance.
+func (l *AccountLogic) Create(ctx context.Context, householdID uuid.UUID, input CreateInput, callerID uuid.UUID) (Account, error) {
+	r := validate.NewResult()
+	r.Field("name", input.Name, validate.Required, validate.MinLen(2), validate.MaxLen(100))
+	r.Field("account_type", string(input.AccountType), validate.Required, validate.OneOf(validAccountTypes...))
+	r.Field("currency_code", string(input.CurrencyCode), validate.Required, validate.OneOf(validCurrencies...))
+	if err := r.Error(); err != nil {
+		return Account{}, err
+	}
+
+	a, err := l.repo.Create(ctx, householdID, input, callerID)
+	if err != nil {
+		if errors.Is(err, message.ErrAccountNameTaken) {
+			return Account{}, fmt.Errorf(message.ErrAccountLogicCreate, message.ErrAccountNameTaken)
+		}
+		return Account{}, fmt.Errorf(message.ErrAccountLogicCreate, err)
+	}
+	return a, nil
+}
+
+// FindByID returns the active account with the given ID.
+func (l *AccountLogic) FindByID(ctx context.Context, id uuid.UUID) (Account, error) {
+	a, err := l.repo.FindByID(ctx, id)
+	if err != nil {
+		return Account{}, fmt.Errorf(message.ErrAccountLogicFindByID, err)
+	}
+	return a, nil
+}
+
+// ListForHousehold returns all active accounts belonging to the given household.
+func (l *AccountLogic) ListForHousehold(ctx context.Context, householdID uuid.UUID) ([]Account, error) {
+	list, err := l.repo.ListForHousehold(ctx, householdID)
+	if err != nil {
+		return nil, fmt.Errorf(message.ErrAccountLogicListForHouse, err)
+	}
+	return list, nil
+}
+
+// UpdateName validates input and updates the account name with optimistic concurrency.
+func (l *AccountLogic) UpdateName(ctx context.Context, id uuid.UUID, input UpdateNameInput, expectedVersion int, callerID uuid.UUID) (Account, error) {
+	r := validate.NewResult()
+	r.Field("name", input.Name, validate.Required, validate.MinLen(2), validate.MaxLen(100))
+	if err := r.Error(); err != nil {
+		return Account{}, err
+	}
+
+	a, err := l.repo.UpdateName(ctx, id, input, expectedVersion, callerID)
+	if err != nil {
+		return Account{}, fmt.Errorf(message.ErrAccountLogicUpdateName, err)
+	}
+	return a, nil
+}
+
+// UpdateBalance sets the account balance to the new value with optimistic concurrency.
+func (l *AccountLogic) UpdateBalance(ctx context.Context, id uuid.UUID, input UpdateBalanceInput, expectedVersion int, callerID uuid.UUID) (Account, error) {
+	a, err := l.repo.UpdateBalance(ctx, id, input, expectedVersion, callerID)
+	if err != nil {
+		return Account{}, fmt.Errorf(message.ErrAccountLogicUpdateBalance, err)
+	}
+	return a, nil
+}
+
+// Deactivate checks the account has zero balance, then soft-deletes it.
+// Returns ErrAccountBalanceNotZero if the balance is non-zero.
+func (l *AccountLogic) Deactivate(ctx context.Context, id uuid.UUID, callerID uuid.UUID) error {
+	a, err := l.repo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, message.ErrAccountNotFound) {
+			return nil // already gone — idempotent
+		}
+		return fmt.Errorf(message.ErrAccountLogicDeactivate, err)
+	}
+
+	if a.Balance != 0 {
+		return fmt.Errorf(message.ErrAccountLogicDeactivate, message.ErrAccountBalanceNotZero)
+	}
+
+	if err := l.repo.Deactivate(ctx, id, callerID); err != nil {
+		return fmt.Errorf(message.ErrAccountLogicDeactivate, err)
+	}
+	return nil
+}

--- a/internal/domain/account/account_logic_test.go
+++ b/internal/domain/account/account_logic_test.go
@@ -1,0 +1,288 @@
+package account_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zambone/pfm-go/internal/adapter/postgres"
+	"github.com/zambone/pfm-go/internal/domain/account"
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/clock"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+func newAccountLogic() (*account.AccountLogic, *postgres.FakeAccountRepository, uuid.UUID, uuid.UUID) {
+	repo := postgres.NewFakeAccountRepository()
+	clk := clock.NewFakeClock(fixedTime)
+	logic := account.NewAccountLogic(repo, clk)
+	return logic, repo, testHouseholdID, testCallerID
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+func TestAccountLogic_Create_HappyPath(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	a, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name:         "Checking",
+		AccountType:  types.AccountTypeChecking,
+		CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, a.ID)
+	assert.Equal(t, "Checking", a.Name)
+	assert.Equal(t, int64(0), a.Balance)
+	assert.Equal(t, types.StatusActive, a.Status)
+	assert.Equal(t, 1, a.Version)
+}
+
+func TestAccountLogic_Create_EmptyName_FailsValidation(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	_, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name:         "",
+		AccountType:  types.AccountTypeChecking,
+		CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+func TestAccountLogic_Create_InvalidAccountType_FailsValidation(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	_, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name:         "Bad Type",
+		AccountType:  types.AccountType("UNKNOWN"),
+		CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+func TestAccountLogic_Create_InvalidCurrency_FailsValidation(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	_, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name:         "Bad Currency",
+		AccountType:  types.AccountTypeChecking,
+		CurrencyCode: types.CurrencyCode("GBP"),
+	}, callerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+func TestAccountLogic_Create_DuplicateName_ReturnsError(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	_, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+	require.NoError(t, err)
+
+	_, err = logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeSavings, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrAccountNameTaken))
+}
+
+// ---------------------------------------------------------------------------
+// FindByID
+// ---------------------------------------------------------------------------
+
+func TestAccountLogic_FindByID_HappyPath(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	created, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+	require.NoError(t, err)
+
+	found, err := logic.FindByID(context.Background(), created.ID)
+
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, found.ID)
+}
+
+func TestAccountLogic_FindByID_NotFound(t *testing.T) {
+	logic, _, _, _ := newAccountLogic()
+
+	_, err := logic.FindByID(context.Background(), uuid.New())
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrAccountNotFound))
+}
+
+// ---------------------------------------------------------------------------
+// ListForHousehold
+// ---------------------------------------------------------------------------
+
+func TestAccountLogic_ListForHousehold_ReturnsOnlyHouseholdAccounts(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	_, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "A1", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+	require.NoError(t, err)
+	_, err = logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "A2", AccountType: types.AccountTypeSavings, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+	require.NoError(t, err)
+
+	list, err := logic.ListForHousehold(context.Background(), householdID)
+
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+}
+
+// ---------------------------------------------------------------------------
+// UpdateName
+// ---------------------------------------------------------------------------
+
+func TestAccountLogic_UpdateName_HappyPath(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	created, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "Old", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+	require.NoError(t, err)
+
+	updated, err := logic.UpdateName(context.Background(), created.ID,
+		account.UpdateNameInput{Name: "New"}, created.Version, callerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, "New", updated.Name)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+func TestAccountLogic_UpdateName_EmptyName_FailsValidation(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	created, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "Old", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+	require.NoError(t, err)
+
+	_, err = logic.UpdateName(context.Background(), created.ID,
+		account.UpdateNameInput{Name: ""}, created.Version, callerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+func TestAccountLogic_UpdateName_VersionConflict(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	created, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "Old", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+	require.NoError(t, err)
+
+	_, err = logic.UpdateName(context.Background(), created.ID,
+		account.UpdateNameInput{Name: "New"}, created.Version+99, callerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrAccountVersionConflict))
+}
+
+// ---------------------------------------------------------------------------
+// UpdateBalance
+// ---------------------------------------------------------------------------
+
+func TestAccountLogic_UpdateBalance_HappyPath(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	created, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+	require.NoError(t, err)
+
+	updated, err := logic.UpdateBalance(context.Background(), created.ID,
+		account.UpdateBalanceInput{Balance: 50000}, created.Version, callerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(50000), updated.Balance)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+func TestAccountLogic_UpdateBalance_VersionConflict(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	created, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+	require.NoError(t, err)
+
+	_, err = logic.UpdateBalance(context.Background(), created.ID,
+		account.UpdateBalanceInput{Balance: 50000}, created.Version+99, callerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrAccountVersionConflict))
+}
+
+// ---------------------------------------------------------------------------
+// Deactivate
+// ---------------------------------------------------------------------------
+
+func TestAccountLogic_Deactivate_ZeroBalance_Succeeds(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	created, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+	require.NoError(t, err)
+
+	err = logic.Deactivate(context.Background(), created.ID, callerID)
+	require.NoError(t, err)
+
+	_, err = logic.FindByID(context.Background(), created.ID)
+	assert.True(t, errors.Is(err, message.ErrAccountNotFound))
+}
+
+func TestAccountLogic_Deactivate_NonZeroBalance_Fails(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	created, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+	require.NoError(t, err)
+
+	_, err = logic.UpdateBalance(context.Background(), created.ID,
+		account.UpdateBalanceInput{Balance: 10000}, created.Version, callerID)
+	require.NoError(t, err)
+
+	err = logic.Deactivate(context.Background(), created.ID, callerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrAccountBalanceNotZero))
+}
+
+func TestAccountLogic_Deactivate_IsIdempotent(t *testing.T) {
+	logic, _, householdID, callerID := newAccountLogic()
+
+	created, err := logic.Create(context.Background(), householdID, account.CreateInput{
+		Name: "Checking", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, callerID)
+	require.NoError(t, err)
+
+	require.NoError(t, logic.Deactivate(context.Background(), created.ID, callerID))
+	assert.NoError(t, logic.Deactivate(context.Background(), created.ID, callerID))
+}

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -245,6 +245,16 @@ const (
 	ErrAccountDeactivate     = "account: deactivate: %w"
 )
 
+// Account logic format strings (domain layer).
+const (
+	ErrAccountLogicCreate        = "account logic: create: %w"
+	ErrAccountLogicFindByID      = "account logic: find by id: %w"
+	ErrAccountLogicListForHouse  = "account logic: list for household: %w"
+	ErrAccountLogicUpdateName    = "account logic: update name: %w"
+	ErrAccountLogicUpdateBalance = "account logic: update balance: %w"
+	ErrAccountLogicDeactivate    = "account logic: deactivate: %w"
+)
+
 // Startup errors (used by cmd/pfm/main.go composition root).
 const (
 	ErrRunLoadConfig = "load config: %w"


### PR DESCRIPTION
## Summary
- Add `AccountLogic` service with 6 methods: Create, FindByID, ListForHousehold, UpdateName, UpdateBalance, Deactivate
- Create validates name (required, 2-100 chars), account type (OneOf: CHECKING/SAVINGS/CREDIT_CARD/INVESTMENT), and currency code (OneOf: USD/BRL/EUR)
- Deactivate enforces zero-balance check — rejects with `ErrAccountBalanceNotZero` if balance != 0, idempotent for already-deleted accounts
- UpdateName/UpdateBalance delegate optimistic concurrency to the repository
- Add 6 logic-layer format strings to `message/errors.go`
- 16 unit tests covering all methods, 3 validation failure types, duplicate name, version conflicts, zero-balance deactivation, non-zero rejection, and idempotent deactivation

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 10 ACs + 5 edge cases COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)