### PR TITLE
test(account): add cross-method and workflow integration tests

### DIFF
--- a/internal/adapter/postgres/account_repo_integration_test.go
+++ b/internal/adapter/postgres/account_repo_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -15,8 +16,11 @@ import (
 	"github.com/zambone/pfm-go/internal/adapter/postgres"
 	"github.com/zambone/pfm-go/internal/domain/account"
 	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/clock"
 	"github.com/zambone/pfm-go/internal/types"
 )
+
+var fixedAccountTime = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // insertTestHousehold inserts a minimal household row and returns its UUID.
 // Needed because accounts have FK references to households(id).
@@ -292,4 +296,119 @@ func TestAccountRepo_Deactivate_IsIdempotent(t *testing.T) {
 
 	require.NoError(t, repo.Deactivate(ctx, created.ID, uuid.Nil))
 	assert.NoError(t, repo.Deactivate(ctx, created.ID, uuid.Nil))
+}
+
+// ===========================================================================
+// Cross-method and workflow integration tests (#88)
+// ===========================================================================
+
+// TestAccountRepo_Workflow_DeactivateHidesFromList verifies that a deactivated
+// account no longer appears in ListForHousehold results.
+func TestAccountRepo_Workflow_DeactivateHidesFromList(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewAccountRepo(pool)
+	householdID := insertTestHousehold(t, pool)
+
+	a1, err := repo.Create(ctx, householdID, account.CreateInput{
+		Name: "Keep", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, uuid.Nil)
+	require.NoError(t, err)
+
+	a2, err := repo.Create(ctx, householdID, account.CreateInput{
+		Name: "Remove", AccountType: types.AccountTypeSavings, CurrencyCode: types.CurrencyUSD,
+	}, uuid.Nil)
+	require.NoError(t, err)
+
+	err = repo.Deactivate(ctx, a2.ID, uuid.Nil)
+	require.NoError(t, err)
+
+	list, err := repo.ListForHousehold(ctx, householdID)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+	assert.Equal(t, a1.ID, list[0].ID)
+}
+
+// TestAccountRepo_Workflow_VersionChain verifies optimistic concurrency:
+// two sequential updates with correct version chain succeed (v1→v2→v3),
+// but reusing the first version fails.
+func TestAccountRepo_Workflow_VersionChain(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewAccountRepo(pool)
+	householdID := insertTestHousehold(t, pool)
+
+	created, err := repo.Create(ctx, householdID, defaultAccountInput(), uuid.Nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, created.Version)
+
+	v2, err := repo.UpdateName(ctx, created.ID,
+		account.UpdateNameInput{Name: "V2"}, created.Version, uuid.Nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, v2.Version)
+
+	v3, err := repo.UpdateName(ctx, created.ID,
+		account.UpdateNameInput{Name: "V3"}, v2.Version, uuid.Nil)
+	require.NoError(t, err)
+	assert.Equal(t, 3, v3.Version)
+
+	// Reusing v1 should fail.
+	_, err = repo.UpdateName(ctx, created.ID,
+		account.UpdateNameInput{Name: "Stale"}, created.Version, uuid.Nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrAccountVersionConflict))
+}
+
+// TestAccountRepo_Workflow_NonZeroBalanceDeactivateRejected verifies that the
+// AccountLogic layer rejects deactivation when balance is non-zero, using
+// the real postgres adapter.
+func TestAccountRepo_Workflow_NonZeroBalanceDeactivateRejected(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewAccountRepo(pool)
+	clk := clock.NewFakeClock(fixedAccountTime)
+	logic := account.NewAccountLogic(repo, clk)
+	householdID := insertTestHousehold(t, pool)
+
+	created, err := logic.Create(ctx, householdID, account.CreateInput{
+		Name: "Funded", AccountType: types.AccountTypeChecking, CurrencyCode: types.CurrencyUSD,
+	}, uuid.Nil)
+	require.NoError(t, err)
+
+	// Set a non-zero balance.
+	_, err = repo.UpdateBalance(ctx, created.ID,
+		account.UpdateBalanceInput{Balance: 50000}, created.Version, uuid.Nil)
+	require.NoError(t, err)
+
+	// Logic layer should reject deactivation.
+	err = logic.Deactivate(ctx, created.ID, uuid.Nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrAccountBalanceNotZero))
+
+	// Account should still be findable.
+	found, err := repo.FindByID(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Funded", found.Name)
+}
+
+// TestAccountRepo_Workflow_DeactivatedNameReusable verifies that after an account
+// is soft-deleted, its name can be reused by a new account in the same household
+// (the partial unique index only covers non-deleted rows).
+func TestAccountRepo_Workflow_DeactivatedNameReusable(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	repo := postgres.NewAccountRepo(pool)
+	householdID := insertTestHousehold(t, pool)
+
+	created, err := repo.Create(ctx, householdID, defaultAccountInput(), uuid.Nil)
+	require.NoError(t, err)
+
+	err = repo.Deactivate(ctx, created.ID, uuid.Nil)
+	require.NoError(t, err)
+
+	// Same name should now succeed — the deactivated row has deleted_at set.
+	reused, err := repo.Create(ctx, householdID, defaultAccountInput(), uuid.Nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, created.ID, reused.ID)
+	assert.Equal(t, created.Name, reused.Name)
 }


### PR DESCRIPTION
## Summary
- Add 4 cross-method integration tests exercising Account-specific workflows
- `Workflow_DeactivateHidesFromList`: deactivated account removed from ListForHousehold
- `Workflow_VersionChain`: v1→v2→v3 succeeds, stale version reuse fails
- `Workflow_NonZeroBalanceDeactivateRejected`: AccountLogic + real adapter rejects deactivation when balance != 0
- `Workflow_DeactivatedNameReusable`: partial unique index allows reusing a soft-deleted account's name

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 5 ACs + 2 edge cases COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)