### PR TITLE
feat(creditcard): define Repository port with reader/writer segregation

### DIFF
--- a/internal/domain/creditcard/settings.go
+++ b/internal/domain/creditcard/settings.go
@@ -2,6 +2,7 @@
 package creditcard
 
 import (
+	"context"
 	"time"
 
 	"github.com/google/uuid"
@@ -44,4 +45,37 @@ type UpdateDueDayInput struct {
 // UpdateLimitInput carries the new credit limit in minor units.
 type UpdateLimitInput struct {
 	LimitAmount int64
+}
+
+// SettingsReader defines the read-only storage contract for credit card settings.
+type SettingsReader interface {
+	// FindByAccountID returns the active settings for the given account.
+	// Returns an error wrapping ErrCreditCardSettingsNotFound when no settings exist.
+	FindByAccountID(ctx context.Context, accountID uuid.UUID) (Settings, error)
+}
+
+// SettingsWriter defines the write-only storage contract for credit card settings.
+type SettingsWriter interface {
+	// Create persists new credit card settings for the given account.
+	// Returns an error wrapping ErrCreditCardSettingsExists when settings already exist.
+	Create(ctx context.Context, accountID uuid.UUID, input CreateInput, callerID uuid.UUID) (Settings, error)
+	// UpdateClosingDay changes the billing cycle closing day.
+	// Returns an error wrapping ErrCreditCardSettingsVersionConflict when expectedVersion does not match.
+	UpdateClosingDay(ctx context.Context, accountID uuid.UUID, input UpdateClosingDayInput, expectedVersion int, callerID uuid.UUID) (Settings, error)
+	// UpdateDueDay changes the payment due day.
+	// Returns an error wrapping ErrCreditCardSettingsVersionConflict when expectedVersion does not match.
+	UpdateDueDay(ctx context.Context, accountID uuid.UUID, input UpdateDueDayInput, expectedVersion int, callerID uuid.UUID) (Settings, error)
+	// UpdateLimit changes the credit limit.
+	// Returns an error wrapping ErrCreditCardSettingsVersionConflict when expectedVersion does not match.
+	UpdateLimit(ctx context.Context, accountID uuid.UUID, input UpdateLimitInput, expectedVersion int, callerID uuid.UUID) (Settings, error)
+	// Delete soft-deletes the settings for the given account.
+	// Idempotent — deleting already-deleted settings is not an error.
+	Delete(ctx context.Context, accountID uuid.UUID, callerID uuid.UUID) error
+}
+
+// Repository defines the full storage contract for credit card settings.
+// Defined at the consumer (domain) rather than the provider (adapter) per interface segregation.
+type Repository interface {
+	SettingsReader
+	SettingsWriter
 }


### PR DESCRIPTION
## Summary
- Add `SettingsReader` interface (FindByAccountID)
- Add `SettingsWriter` interface (Create, UpdateClosingDay, UpdateDueDay, UpdateLimit, Delete)
- Compose into `Repository` following the established domain pattern
- All methods use `accountID` as the lookup key (one-to-one relationship, not settings' own ID)
- 1 reader + 5 writer = 6 total methods

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 6 acceptance criteria COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)