### PR TITLE
feat(creditcard): implement FakeCreditCardSettingsRepository

### DIFF
--- a/internal/adapter/postgres/fake_creditcard_settings_repo.go
+++ b/internal/adapter/postgres/fake_creditcard_settings_repo.go
@@ -1,0 +1,197 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/domain/creditcard"
+	"github.com/zambone/pfm-go/internal/message"
+)
+
+// FakeCreditCardSettingsRepository is a test double for domain/creditcard.Repository.
+// It stores settings in an in-memory map keyed by account ID (one-to-one relationship).
+//
+// NOT FOR PRODUCTION — panics if called outside a test binary.
+// Thread-safe via sync.RWMutex.
+type FakeCreditCardSettingsRepository struct {
+	mu        sync.RWMutex
+	byAccount map[uuid.UUID]creditcard.Settings // key: AccountID
+	err       error                             // injected error returned by all methods
+}
+
+// NewFakeCreditCardSettingsRepository returns an empty repository ready for use in tests.
+func NewFakeCreditCardSettingsRepository() *FakeCreditCardSettingsRepository {
+	return &FakeCreditCardSettingsRepository{
+		byAccount: make(map[uuid.UUID]creditcard.Settings),
+	}
+}
+
+// SetError configures every subsequent method call to return err.
+// Pass nil to clear the injected error.
+func (f *FakeCreditCardSettingsRepository) SetError(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+}
+
+// Create stores new credit card settings for the given account.
+// Returns an error wrapping ErrCreditCardSettingsExists if settings already exist.
+// Panics if called outside a test binary.
+func (f *FakeCreditCardSettingsRepository) Create(_ context.Context, accountID uuid.UUID, input creditcard.CreateInput, callerID uuid.UUID) (creditcard.Settings, error) {
+	if !testing.Testing() {
+		panic("FakeCreditCardSettingsRepository: not for production use")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return creditcard.Settings{}, f.err
+	}
+
+	if _, exists := f.byAccount[accountID]; exists {
+		return creditcard.Settings{}, fmt.Errorf(message.ErrCCSettingsCreate, message.ErrCreditCardSettingsExists)
+	}
+
+	s := creditcard.Settings{
+		ID:          uuid.New(),
+		AccountID:   accountID,
+		ClosingDay:  input.ClosingDay,
+		DueDay:      input.DueDay,
+		LimitAmount: input.LimitAmount,
+		Version:     1,
+		CreatedBy:   callerID,
+		UpdatedBy:   callerID,
+	}
+	f.byAccount[accountID] = s
+	return s, nil
+}
+
+// FindByAccountID returns the active settings for the given account.
+// Returns an error wrapping ErrCreditCardSettingsNotFound when not found.
+// Panics if called outside a test binary.
+func (f *FakeCreditCardSettingsRepository) FindByAccountID(_ context.Context, accountID uuid.UUID) (creditcard.Settings, error) {
+	if !testing.Testing() {
+		panic("FakeCreditCardSettingsRepository: not for production use")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	if f.err != nil {
+		return creditcard.Settings{}, f.err
+	}
+
+	s, ok := f.byAccount[accountID]
+	if !ok {
+		return creditcard.Settings{}, fmt.Errorf(message.ErrCCSettingsFindByAccount, message.ErrCreditCardSettingsNotFound)
+	}
+	return s, nil
+}
+
+// UpdateClosingDay changes the billing cycle closing day.
+// Returns an error wrapping ErrCreditCardSettingsVersionConflict if version mismatches.
+// Panics if called outside a test binary.
+func (f *FakeCreditCardSettingsRepository) UpdateClosingDay(_ context.Context, accountID uuid.UUID, input creditcard.UpdateClosingDayInput, expectedVersion int, callerID uuid.UUID) (creditcard.Settings, error) {
+	if !testing.Testing() {
+		panic("FakeCreditCardSettingsRepository: not for production use")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return creditcard.Settings{}, f.err
+	}
+
+	s, ok := f.byAccount[accountID]
+	if !ok {
+		return creditcard.Settings{}, fmt.Errorf(message.ErrCCSettingsUpdateClosing, message.ErrCreditCardSettingsNotFound)
+	}
+	if s.Version != expectedVersion {
+		return creditcard.Settings{}, fmt.Errorf(message.ErrCCSettingsUpdateClosing, message.ErrCreditCardSettingsVersionConflict)
+	}
+
+	s.ClosingDay = input.ClosingDay
+	s.Version++
+	s.UpdatedBy = callerID
+	f.byAccount[accountID] = s
+	return s, nil
+}
+
+// UpdateDueDay changes the payment due day.
+// Returns an error wrapping ErrCreditCardSettingsVersionConflict if version mismatches.
+// Panics if called outside a test binary.
+func (f *FakeCreditCardSettingsRepository) UpdateDueDay(_ context.Context, accountID uuid.UUID, input creditcard.UpdateDueDayInput, expectedVersion int, callerID uuid.UUID) (creditcard.Settings, error) {
+	if !testing.Testing() {
+		panic("FakeCreditCardSettingsRepository: not for production use")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return creditcard.Settings{}, f.err
+	}
+
+	s, ok := f.byAccount[accountID]
+	if !ok {
+		return creditcard.Settings{}, fmt.Errorf(message.ErrCCSettingsUpdateDueDay, message.ErrCreditCardSettingsNotFound)
+	}
+	if s.Version != expectedVersion {
+		return creditcard.Settings{}, fmt.Errorf(message.ErrCCSettingsUpdateDueDay, message.ErrCreditCardSettingsVersionConflict)
+	}
+
+	s.DueDay = input.DueDay
+	s.Version++
+	s.UpdatedBy = callerID
+	f.byAccount[accountID] = s
+	return s, nil
+}
+
+// UpdateLimit changes the credit limit.
+// Returns an error wrapping ErrCreditCardSettingsVersionConflict if version mismatches.
+// Panics if called outside a test binary.
+func (f *FakeCreditCardSettingsRepository) UpdateLimit(_ context.Context, accountID uuid.UUID, input creditcard.UpdateLimitInput, expectedVersion int, callerID uuid.UUID) (creditcard.Settings, error) {
+	if !testing.Testing() {
+		panic("FakeCreditCardSettingsRepository: not for production use")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return creditcard.Settings{}, f.err
+	}
+
+	s, ok := f.byAccount[accountID]
+	if !ok {
+		return creditcard.Settings{}, fmt.Errorf(message.ErrCCSettingsUpdateLimit, message.ErrCreditCardSettingsNotFound)
+	}
+	if s.Version != expectedVersion {
+		return creditcard.Settings{}, fmt.Errorf(message.ErrCCSettingsUpdateLimit, message.ErrCreditCardSettingsVersionConflict)
+	}
+
+	s.LimitAmount = input.LimitAmount
+	s.Version++
+	s.UpdatedBy = callerID
+	f.byAccount[accountID] = s
+	return s, nil
+}
+
+// Delete soft-deletes the settings for the given account.
+// Idempotent — deleting non-existent settings is not an error.
+// Panics if called outside a test binary.
+func (f *FakeCreditCardSettingsRepository) Delete(_ context.Context, accountID uuid.UUID, _ uuid.UUID) error {
+	if !testing.Testing() {
+		panic("FakeCreditCardSettingsRepository: not for production use")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return f.err
+	}
+
+	delete(f.byAccount, accountID)
+	return nil
+}

--- a/internal/adapter/postgres/fake_creditcard_settings_repo_test.go
+++ b/internal/adapter/postgres/fake_creditcard_settings_repo_test.go
@@ -1,0 +1,182 @@
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zambone/pfm-go/internal/adapter/postgres"
+	"github.com/zambone/pfm-go/internal/domain/creditcard"
+	"github.com/zambone/pfm-go/internal/message"
+)
+
+var fakeCCAccountID = uuid.MustParse("00000000-0000-0000-0000-000000000020")
+var fakeCCCallerID = uuid.MustParse("00000000-0000-0000-0000-000000000001")
+
+func defaultCCCreateInput() creditcard.CreateInput {
+	return creditcard.CreateInput{ClosingDay: 25, DueDay: 10, LimitAmount: 500000}
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+func TestFakeCCSettingsRepo_Create_StoresAndReturns(t *testing.T) {
+	repo := postgres.NewFakeCreditCardSettingsRepository()
+
+	s, err := repo.Create(context.Background(), fakeCCAccountID, defaultCCCreateInput(), fakeCCCallerID)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, s.ID)
+	assert.Equal(t, fakeCCAccountID, s.AccountID)
+	assert.Equal(t, 25, s.ClosingDay)
+	assert.Equal(t, 10, s.DueDay)
+	assert.Equal(t, int64(500000), s.LimitAmount)
+	assert.Equal(t, 1, s.Version)
+}
+
+func TestFakeCCSettingsRepo_Create_Duplicate_ReturnsExists(t *testing.T) {
+	repo := postgres.NewFakeCreditCardSettingsRepository()
+
+	_, err := repo.Create(context.Background(), fakeCCAccountID, defaultCCCreateInput(), fakeCCCallerID)
+	require.NoError(t, err)
+
+	_, err = repo.Create(context.Background(), fakeCCAccountID, defaultCCCreateInput(), fakeCCCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrCreditCardSettingsExists))
+}
+
+// ---------------------------------------------------------------------------
+// FindByAccountID
+// ---------------------------------------------------------------------------
+
+func TestFakeCCSettingsRepo_FindByAccountID_ReturnsSettings(t *testing.T) {
+	repo := postgres.NewFakeCreditCardSettingsRepository()
+
+	created, err := repo.Create(context.Background(), fakeCCAccountID, defaultCCCreateInput(), fakeCCCallerID)
+	require.NoError(t, err)
+
+	found, err := repo.FindByAccountID(context.Background(), fakeCCAccountID)
+
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, found.ID)
+}
+
+func TestFakeCCSettingsRepo_FindByAccountID_NotFound(t *testing.T) {
+	repo := postgres.NewFakeCreditCardSettingsRepository()
+
+	_, err := repo.FindByAccountID(context.Background(), uuid.New())
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrCreditCardSettingsNotFound))
+}
+
+// ---------------------------------------------------------------------------
+// UpdateClosingDay
+// ---------------------------------------------------------------------------
+
+func TestFakeCCSettingsRepo_UpdateClosingDay_ChangesAndVersions(t *testing.T) {
+	repo := postgres.NewFakeCreditCardSettingsRepository()
+
+	created, err := repo.Create(context.Background(), fakeCCAccountID, defaultCCCreateInput(), fakeCCCallerID)
+	require.NoError(t, err)
+
+	updated, err := repo.UpdateClosingDay(context.Background(), fakeCCAccountID,
+		creditcard.UpdateClosingDayInput{ClosingDay: 15}, created.Version, fakeCCCallerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 15, updated.ClosingDay)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+func TestFakeCCSettingsRepo_UpdateClosingDay_VersionConflict(t *testing.T) {
+	repo := postgres.NewFakeCreditCardSettingsRepository()
+
+	created, err := repo.Create(context.Background(), fakeCCAccountID, defaultCCCreateInput(), fakeCCCallerID)
+	require.NoError(t, err)
+
+	_, err = repo.UpdateClosingDay(context.Background(), fakeCCAccountID,
+		creditcard.UpdateClosingDayInput{ClosingDay: 15}, created.Version+99, fakeCCCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrCreditCardSettingsVersionConflict))
+}
+
+// ---------------------------------------------------------------------------
+// UpdateDueDay
+// ---------------------------------------------------------------------------
+
+func TestFakeCCSettingsRepo_UpdateDueDay_ChangesAndVersions(t *testing.T) {
+	repo := postgres.NewFakeCreditCardSettingsRepository()
+
+	created, err := repo.Create(context.Background(), fakeCCAccountID, defaultCCCreateInput(), fakeCCCallerID)
+	require.NoError(t, err)
+
+	updated, err := repo.UpdateDueDay(context.Background(), fakeCCAccountID,
+		creditcard.UpdateDueDayInput{DueDay: 5}, created.Version, fakeCCCallerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 5, updated.DueDay)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+// ---------------------------------------------------------------------------
+// UpdateLimit
+// ---------------------------------------------------------------------------
+
+func TestFakeCCSettingsRepo_UpdateLimit_ChangesAndVersions(t *testing.T) {
+	repo := postgres.NewFakeCreditCardSettingsRepository()
+
+	created, err := repo.Create(context.Background(), fakeCCAccountID, defaultCCCreateInput(), fakeCCCallerID)
+	require.NoError(t, err)
+
+	updated, err := repo.UpdateLimit(context.Background(), fakeCCAccountID,
+		creditcard.UpdateLimitInput{LimitAmount: 1000000}, created.Version, fakeCCCallerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(1000000), updated.LimitAmount)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+func TestFakeCCSettingsRepo_Delete_RemovesSettings(t *testing.T) {
+	repo := postgres.NewFakeCreditCardSettingsRepository()
+
+	_, err := repo.Create(context.Background(), fakeCCAccountID, defaultCCCreateInput(), fakeCCCallerID)
+	require.NoError(t, err)
+
+	err = repo.Delete(context.Background(), fakeCCAccountID, fakeCCCallerID)
+	require.NoError(t, err)
+
+	_, err = repo.FindByAccountID(context.Background(), fakeCCAccountID)
+	assert.True(t, errors.Is(err, message.ErrCreditCardSettingsNotFound))
+}
+
+func TestFakeCCSettingsRepo_Delete_IsIdempotent(t *testing.T) {
+	repo := postgres.NewFakeCreditCardSettingsRepository()
+
+	err := repo.Delete(context.Background(), uuid.New(), fakeCCCallerID)
+	assert.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// SetError
+// ---------------------------------------------------------------------------
+
+func TestFakeCCSettingsRepo_SetError_InjectsError(t *testing.T) {
+	repo := postgres.NewFakeCreditCardSettingsRepository()
+	injected := errors.New("injected")
+
+	repo.SetError(injected)
+
+	_, err := repo.FindByAccountID(context.Background(), uuid.New())
+	assert.ErrorIs(t, err, injected)
+}

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -255,6 +255,28 @@ const (
 	ErrAccountLogicDeactivate    = "account logic: deactivate: %w"
 )
 
+// Credit card settings repository errors.
+var (
+	// ErrCreditCardSettingsNotFound is returned when settings lookup finds no active record.
+	ErrCreditCardSettingsNotFound = errors.New("credit card settings: not found")
+	// ErrCreditCardSettingsExists is returned when creating settings for an account that already has them.
+	ErrCreditCardSettingsExists = errors.New("credit card settings: already exist for account")
+	// ErrCreditCardSettingsVersionConflict is returned when an optimistic-lock update finds a stale version.
+	ErrCreditCardSettingsVersionConflict = errors.New("credit card settings: version conflict")
+	// ErrCreditCardSettingsNotCreditCard is returned when creating settings for a non-credit-card account.
+	ErrCreditCardSettingsNotCreditCard = errors.New("credit card settings: account is not a credit card")
+)
+
+// Credit card settings repository format strings (adapter layer).
+const (
+	ErrCCSettingsCreate         = "credit card settings: create: %w"
+	ErrCCSettingsFindByAccount  = "credit card settings: find by account: %w"
+	ErrCCSettingsUpdateClosing  = "credit card settings: update closing day: %w"
+	ErrCCSettingsUpdateDueDay   = "credit card settings: update due day: %w"
+	ErrCCSettingsUpdateLimit    = "credit card settings: update limit: %w"
+	ErrCCSettingsDelete         = "credit card settings: delete: %w"
+)
+
 // Startup errors (used by cmd/pfm/main.go composition root).
 const (
 	ErrRunLoadConfig = "load config: %w"


### PR DESCRIPTION
## Summary
- Add `FakeCreditCardSettingsRepository` implementing `creditcard.Repository` with in-memory map keyed by account ID (one-to-one constraint)
- Add CreditCard error sentinels (`ErrCreditCardSettingsNotFound`, `ErrCreditCardSettingsExists`, `ErrCreditCardSettingsVersionConflict`, `ErrCreditCardSettingsNotCreditCard`) and 6 format strings
- Thread-safe via `sync.RWMutex` with `testing.Testing()` production guard
- 12 tests covering Create, FindByAccountID, UpdateClosingDay, UpdateDueDay, UpdateLimit, Delete, duplicate create, version conflicts, and error injection

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 8 acceptance criteria COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)