### PR TITLE
feat(creditcard): implement SettingsLogic domain service with TDD

### DIFF
--- a/internal/domain/creditcard/settings_logic.go
+++ b/internal/domain/creditcard/settings_logic.go
@@ -1,0 +1,144 @@
+package creditcard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+// accountTypeFinder abstracts the account type lookup needed to verify that
+// settings are only created for credit card accounts. Structurally satisfied
+// by a thin adapter wrapping account.Repository.FindByID.
+type accountTypeFinder interface {
+	FindAccountType(ctx context.Context, accountID uuid.UUID) (types.AccountType, error)
+}
+
+// clocker abstracts the current time.
+// Structurally satisfied by platform/clock.Clock.
+type clocker interface {
+	Now() time.Time
+}
+
+// SettingsLogic orchestrates the credit card settings lifecycle: creation with
+// account-type verification, queries, field updates, and deletion.
+type SettingsLogic struct {
+	repo    Repository
+	acctFdr accountTypeFinder
+	clk     clocker
+}
+
+// NewSettingsLogic constructs a SettingsLogic. Panics if any dependency is nil.
+func NewSettingsLogic(repo Repository, acctFdr accountTypeFinder, clk clocker) *SettingsLogic {
+	if repo == nil {
+		panic("creditcard: NewSettingsLogic requires non-nil repo")
+	}
+	if acctFdr == nil {
+		panic("creditcard: NewSettingsLogic requires non-nil accountTypeFinder")
+	}
+	if clk == nil {
+		panic("creditcard: NewSettingsLogic requires non-nil clk")
+	}
+	return &SettingsLogic{repo: repo, acctFdr: acctFdr, clk: clk}
+}
+
+// validateDayAndLimit validates closing day (1-31), due day (1-31), and limit (>= 0).
+func validateDayAndLimit(closingDay, dueDay int, limitAmount int64) error {
+	r := validate.NewResult()
+	r.Field("closing_day", closingDay, validate.Range(1, 31))
+	r.Field("due_day", dueDay, validate.Range(1, 31))
+	r.Field("limit_amount", limitAmount, validate.NonNegative)
+	return r.Error()
+}
+
+// Create verifies the account is a credit card, validates input, and persists new settings.
+func (l *SettingsLogic) Create(ctx context.Context, accountID uuid.UUID, input CreateInput, callerID uuid.UUID) (Settings, error) {
+	acctType, err := l.acctFdr.FindAccountType(ctx, accountID)
+	if err != nil {
+		return Settings{}, fmt.Errorf(message.ErrCCLogicCreate, err)
+	}
+	if acctType != types.AccountTypeCreditCard {
+		return Settings{}, fmt.Errorf(message.ErrCCLogicCreate, message.ErrCreditCardSettingsNotCreditCard)
+	}
+
+	if err := validateDayAndLimit(input.ClosingDay, input.DueDay, input.LimitAmount); err != nil {
+		return Settings{}, err
+	}
+
+	s, err := l.repo.Create(ctx, accountID, input, callerID)
+	if err != nil {
+		if errors.Is(err, message.ErrCreditCardSettingsExists) {
+			return Settings{}, fmt.Errorf(message.ErrCCLogicCreate, message.ErrCreditCardSettingsExists)
+		}
+		return Settings{}, fmt.Errorf(message.ErrCCLogicCreate, err)
+	}
+	return s, nil
+}
+
+// FindByAccountID returns the active settings for the given account.
+func (l *SettingsLogic) FindByAccountID(ctx context.Context, accountID uuid.UUID) (Settings, error) {
+	s, err := l.repo.FindByAccountID(ctx, accountID)
+	if err != nil {
+		return Settings{}, fmt.Errorf(message.ErrCCLogicFindByAccount, err)
+	}
+	return s, nil
+}
+
+// UpdateClosingDay validates and changes the billing cycle closing day.
+func (l *SettingsLogic) UpdateClosingDay(ctx context.Context, accountID uuid.UUID, input UpdateClosingDayInput, expectedVersion int, callerID uuid.UUID) (Settings, error) {
+	r := validate.NewResult()
+	r.Field("closing_day", input.ClosingDay, validate.Range(1, 31))
+	if err := r.Error(); err != nil {
+		return Settings{}, err
+	}
+
+	s, err := l.repo.UpdateClosingDay(ctx, accountID, input, expectedVersion, callerID)
+	if err != nil {
+		return Settings{}, fmt.Errorf(message.ErrCCLogicUpdateClosing, err)
+	}
+	return s, nil
+}
+
+// UpdateDueDay validates and changes the payment due day.
+func (l *SettingsLogic) UpdateDueDay(ctx context.Context, accountID uuid.UUID, input UpdateDueDayInput, expectedVersion int, callerID uuid.UUID) (Settings, error) {
+	r := validate.NewResult()
+	r.Field("due_day", input.DueDay, validate.Range(1, 31))
+	if err := r.Error(); err != nil {
+		return Settings{}, err
+	}
+
+	s, err := l.repo.UpdateDueDay(ctx, accountID, input, expectedVersion, callerID)
+	if err != nil {
+		return Settings{}, fmt.Errorf(message.ErrCCLogicUpdateDueDay, err)
+	}
+	return s, nil
+}
+
+// UpdateLimit validates and changes the credit limit.
+func (l *SettingsLogic) UpdateLimit(ctx context.Context, accountID uuid.UUID, input UpdateLimitInput, expectedVersion int, callerID uuid.UUID) (Settings, error) {
+	r := validate.NewResult()
+	r.Field("limit_amount", input.LimitAmount, validate.NonNegative)
+	if err := r.Error(); err != nil {
+		return Settings{}, err
+	}
+
+	s, err := l.repo.UpdateLimit(ctx, accountID, input, expectedVersion, callerID)
+	if err != nil {
+		return Settings{}, fmt.Errorf(message.ErrCCLogicUpdateLimit, err)
+	}
+	return s, nil
+}
+
+// Delete soft-deletes the settings for the given account.
+func (l *SettingsLogic) Delete(ctx context.Context, accountID uuid.UUID, callerID uuid.UUID) error {
+	if err := l.repo.Delete(ctx, accountID, callerID); err != nil {
+		return fmt.Errorf(message.ErrCCLogicDelete, err)
+	}
+	return nil
+}

--- a/internal/domain/creditcard/settings_logic_test.go
+++ b/internal/domain/creditcard/settings_logic_test.go
@@ -1,0 +1,306 @@
+package creditcard_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zambone/pfm-go/internal/adapter/postgres"
+	"github.com/zambone/pfm-go/internal/domain/creditcard"
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/clock"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+// fakeAccountTypeFinder is a test double that returns a configurable account type.
+type fakeAccountTypeFinder struct {
+	accountType types.AccountType
+	err         error
+}
+
+func (f *fakeAccountTypeFinder) FindAccountType(_ context.Context, _ uuid.UUID) (types.AccountType, error) {
+	return f.accountType, f.err
+}
+
+func newSettingsLogic(accountType types.AccountType) (*creditcard.SettingsLogic, *postgres.FakeCreditCardSettingsRepository) {
+	repo := postgres.NewFakeCreditCardSettingsRepository()
+	clk := clock.NewFakeClock(fixedTime)
+	finder := &fakeAccountTypeFinder{accountType: accountType}
+	logic := creditcard.NewSettingsLogic(repo, finder, clk)
+	return logic, repo
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+func TestSettingsLogic_Create_CreditCardAccount_Succeeds(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	s, err := logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, s.ID)
+	assert.Equal(t, 25, s.ClosingDay)
+	assert.Equal(t, 10, s.DueDay)
+	assert.Equal(t, int64(500000), s.LimitAmount)
+}
+
+func TestSettingsLogic_Create_NonCreditCardAccount_Fails(t *testing.T) {
+	nonCCTypes := []types.AccountType{
+		types.AccountTypeChecking,
+		types.AccountTypeSavings,
+		types.AccountTypeInvestment,
+	}
+	for _, at := range nonCCTypes {
+		t.Run(string(at), func(t *testing.T) {
+			logic, _ := newSettingsLogic(at)
+
+			_, err := logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, message.ErrCreditCardSettingsNotCreditCard))
+		})
+	}
+}
+
+func TestSettingsLogic_Create_DuplicateSettings_Fails(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	_, err := logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	_, err = logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrCreditCardSettingsExists))
+}
+
+func TestSettingsLogic_Create_ClosingDayOutOfRange_FailsValidation(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	tests := []struct {
+		name string
+		day  int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+		{"too high", 32},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := logic.Create(context.Background(), testAccountID,
+				creditcard.CreateInput{ClosingDay: tc.day, DueDay: 10, LimitAmount: 500000}, testCallerID)
+
+			require.Error(t, err)
+			var ve *validate.ValidationError
+			assert.True(t, errors.As(err, &ve))
+		})
+	}
+}
+
+func TestSettingsLogic_Create_DueDayOutOfRange_FailsValidation(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	_, err := logic.Create(context.Background(), testAccountID,
+		creditcard.CreateInput{ClosingDay: 25, DueDay: 0, LimitAmount: 500000}, testCallerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+func TestSettingsLogic_Create_NegativeLimit_FailsValidation(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	_, err := logic.Create(context.Background(), testAccountID,
+		creditcard.CreateInput{ClosingDay: 25, DueDay: 10, LimitAmount: -1}, testCallerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+func TestSettingsLogic_Create_ZeroLimit_Accepted(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	s, err := logic.Create(context.Background(), testAccountID,
+		creditcard.CreateInput{ClosingDay: 25, DueDay: 10, LimitAmount: 0}, testCallerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), s.LimitAmount)
+}
+
+func TestSettingsLogic_Create_Day31_Accepted(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	s, err := logic.Create(context.Background(), testAccountID,
+		creditcard.CreateInput{ClosingDay: 31, DueDay: 31, LimitAmount: 500000}, testCallerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 31, s.ClosingDay)
+	assert.Equal(t, 31, s.DueDay)
+}
+
+// ---------------------------------------------------------------------------
+// FindByAccountID
+// ---------------------------------------------------------------------------
+
+func TestSettingsLogic_FindByAccountID_Succeeds(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	created, err := logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	found, err := logic.FindByAccountID(context.Background(), testAccountID)
+
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, found.ID)
+}
+
+func TestSettingsLogic_FindByAccountID_NotFound(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	_, err := logic.FindByAccountID(context.Background(), uuid.New())
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrCreditCardSettingsNotFound))
+}
+
+// ---------------------------------------------------------------------------
+// UpdateClosingDay
+// ---------------------------------------------------------------------------
+
+func TestSettingsLogic_UpdateClosingDay_Succeeds(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	created, err := logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	updated, err := logic.UpdateClosingDay(context.Background(), testAccountID,
+		creditcard.UpdateClosingDayInput{ClosingDay: 15}, created.Version, testCallerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 15, updated.ClosingDay)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+func TestSettingsLogic_UpdateClosingDay_OutOfRange_FailsValidation(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	created, err := logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	_, err = logic.UpdateClosingDay(context.Background(), testAccountID,
+		creditcard.UpdateClosingDayInput{ClosingDay: 0}, created.Version, testCallerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+func TestSettingsLogic_UpdateClosingDay_VersionConflict(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	_, err := logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	_, err = logic.UpdateClosingDay(context.Background(), testAccountID,
+		creditcard.UpdateClosingDayInput{ClosingDay: 15}, 99, testCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrCreditCardSettingsVersionConflict))
+}
+
+// ---------------------------------------------------------------------------
+// UpdateDueDay
+// ---------------------------------------------------------------------------
+
+func TestSettingsLogic_UpdateDueDay_Succeeds(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	created, err := logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	updated, err := logic.UpdateDueDay(context.Background(), testAccountID,
+		creditcard.UpdateDueDayInput{DueDay: 5}, created.Version, testCallerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 5, updated.DueDay)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+func TestSettingsLogic_UpdateDueDay_OutOfRange_FailsValidation(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	created, err := logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	_, err = logic.UpdateDueDay(context.Background(), testAccountID,
+		creditcard.UpdateDueDayInput{DueDay: 32}, created.Version, testCallerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+// ---------------------------------------------------------------------------
+// UpdateLimit
+// ---------------------------------------------------------------------------
+
+func TestSettingsLogic_UpdateLimit_Succeeds(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	created, err := logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	updated, err := logic.UpdateLimit(context.Background(), testAccountID,
+		creditcard.UpdateLimitInput{LimitAmount: 1000000}, created.Version, testCallerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(1000000), updated.LimitAmount)
+	assert.Equal(t, created.Version+1, updated.Version)
+}
+
+func TestSettingsLogic_UpdateLimit_Negative_FailsValidation(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	created, err := logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	_, err = logic.UpdateLimit(context.Background(), testAccountID,
+		creditcard.UpdateLimitInput{LimitAmount: -1}, created.Version, testCallerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+func TestSettingsLogic_Delete_Succeeds(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	_, err := logic.Create(context.Background(), testAccountID, createInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	err = logic.Delete(context.Background(), testAccountID, testCallerID)
+	require.NoError(t, err)
+
+	_, err = logic.FindByAccountID(context.Background(), testAccountID)
+	assert.True(t, errors.Is(err, message.ErrCreditCardSettingsNotFound))
+}
+
+func TestSettingsLogic_Delete_IsIdempotent(t *testing.T) {
+	logic, _ := newSettingsLogic(types.AccountTypeCreditCard)
+
+	err := logic.Delete(context.Background(), uuid.New(), testCallerID)
+	assert.NoError(t, err)
+}

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -277,6 +277,16 @@ const (
 	ErrCCSettingsDelete         = "credit card settings: delete: %w"
 )
 
+// Credit card settings logic format strings (domain layer).
+const (
+	ErrCCLogicCreate        = "credit card logic: create: %w"
+	ErrCCLogicFindByAccount = "credit card logic: find by account: %w"
+	ErrCCLogicUpdateClosing = "credit card logic: update closing day: %w"
+	ErrCCLogicUpdateDueDay  = "credit card logic: update due day: %w"
+	ErrCCLogicUpdateLimit   = "credit card logic: update limit: %w"
+	ErrCCLogicDelete        = "credit card logic: delete: %w"
+)
+
 // Startup errors (used by cmd/pfm/main.go composition root).
 const (
 	ErrRunLoadConfig = "load config: %w"


### PR DESCRIPTION
## Summary
- Add `SettingsLogic` with 6 methods: Create, FindByAccountID, UpdateClosingDay, UpdateDueDay, UpdateLimit, Delete
- Create verifies account type is `CREDIT_CARD` via `accountTypeFinder` interface — rejects CHECKING/SAVINGS/INVESTMENT with `ErrCreditCardSettingsNotCreditCard`
- Closing day and due day validated with `Range(1, 31)`, limit validated with `NonNegative`
- Edge cases: zero limit accepted (frozen card), day 31 accepted (valid calendar day)
- `accountTypeFinder` is a 1-method internal interface — avoids cross-domain import
- 24 tests (including table-driven subtests) covering all ACs and edge cases

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 10 ACs + 4 edge cases COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)