### PR TITLE
feat(ledger): create transactions and ledger_entries migrations

### DIFF
--- a/db/migrations/20260304000004_create_ledger.sql
+++ b/db/migrations/20260304000004_create_ledger.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+
+-- transactions groups related ledger entries into a single business event.
+-- Immutable: no updated_at, updated_by, version, or deleted_at.
+CREATE TABLE transactions (
+    id               UUID        NOT NULL DEFAULT uuidv7()  PRIMARY KEY,
+    household_id     UUID        NOT NULL REFERENCES households(id),
+    description      TEXT        NOT NULL,
+    transaction_date DATE        NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by       UUID        REFERENCES users(id)
+);
+
+-- ledger_entries records individual debit/credit lines within a transaction.
+-- Immutable: no updated_at, updated_by, version, or deleted_at.
+-- Amount is always positive — entry_type (DEBIT/CREDIT) determines direction.
+CREATE TABLE ledger_entries (
+    id             UUID        NOT NULL DEFAULT uuidv7()  PRIMARY KEY,
+    transaction_id UUID        NOT NULL REFERENCES transactions(id),
+    account_id     UUID        NOT NULL REFERENCES accounts(id),
+    entry_type     TEXT        NOT NULL CHECK (entry_type IN ('DEBIT', 'CREDIT')),
+    amount         BIGINT      NOT NULL CHECK (amount > 0),
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS ledger_entries;
+DROP TABLE IF EXISTS transactions;


### PR DESCRIPTION
## Summary
- Add `transactions` table: UUIDv7 PK, household_id FK, description, transaction_date (DATE), created_at, created_by — immutable (no version, updated_at, deleted_at)
- Add `ledger_entries` table: UUIDv7 PK, transaction_id FK, account_id FK, entry_type (DEBIT/CREDIT CHECK), amount (BIGINT > 0 CHECK), created_at — immutable
- Both tables use FK references without CASCADE (explicit management)
- Goose Up/Down blocks for forward and rollback

## Test plan
- [x] `make ci` passes — migration applies cleanly across all testcontainer instances
- [x] `/project:verify-issue` verdict: PASS (all 5 ACs COVERED)
- [x] `/project:review` verdict: PASS (SQL conventions, Up+Down blocks, backward-compatible)

closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)