### PR TITLE
feat(ledger): define Repository port with reader/writer segregation

### DIFF
--- a/internal/domain/ledger/ledger.go
+++ b/internal/domain/ledger/ledger.go
@@ -2,6 +2,7 @@
 package ledger
 
 import (
+	"context"
 	"time"
 
 	"github.com/google/uuid"
@@ -45,4 +46,40 @@ type PostTransactionInput struct {
 	Description     string
 	TransactionDate time.Time
 	Entries         []EntryInput
+}
+
+// HistoryQuery carries pagination and filter parameters for transaction history.
+type HistoryQuery struct {
+	AccountID uuid.UUID // filter entries by account; uuid.Nil means no filter
+	Offset    int
+	Limit     int
+}
+
+// TransactionWithEntries pairs a transaction with its entries for history results.
+type TransactionWithEntries struct {
+	Transaction Transaction
+	Entries     []Entry
+}
+
+// LedgerReader defines the read-only storage contract for the ledger domain.
+type LedgerReader interface {
+	// GetBalance returns the current balance for the given account.
+	// Balance is computed as sum of credits minus sum of debits for the account.
+	GetBalance(ctx context.Context, accountID uuid.UUID) (int64, error)
+	// GetTransactionHistory returns transactions with their entries, filtered and paginated.
+	GetTransactionHistory(ctx context.Context, householdID uuid.UUID, query HistoryQuery) ([]TransactionWithEntries, error)
+}
+
+// LedgerWriter defines the write-only storage contract for the ledger domain.
+type LedgerWriter interface {
+	// PostTransaction creates a transaction with its entries and updates account balances
+	// atomically. The caller is responsible for ensuring entries balance before calling.
+	PostTransaction(ctx context.Context, householdID uuid.UUID, input PostTransactionInput, callerID uuid.UUID) (Transaction, []Entry, error)
+}
+
+// Repository defines the full storage contract for the ledger domain.
+// Defined at the consumer (domain) rather than the provider (adapter) per interface segregation.
+type Repository interface {
+	LedgerReader
+	LedgerWriter
 }

--- a/internal/domain/ledger/ledger_port_test.go
+++ b/internal/domain/ledger/ledger_port_test.go
@@ -1,0 +1,34 @@
+package ledger_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zambone/pfm-go/internal/domain/ledger"
+)
+
+// TestRepository_ComposesReaderAndWriter is a compile-time verification that
+// Repository composes LedgerReader (2 methods) and LedgerWriter (1 method).
+// If the interface changes, the stub breaks and this test fails to compile.
+func TestRepository_ComposesReaderAndWriter(t *testing.T) {
+	var _ ledger.Repository = (*repoStub)(nil)
+	assert.True(t, true, "Repository composes LedgerReader and LedgerWriter")
+}
+
+// repoStub satisfies ledger.Repository at compile time.
+type repoStub struct{}
+
+func (repoStub) GetBalance(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+
+func (repoStub) GetTransactionHistory(_ context.Context, _ uuid.UUID, _ ledger.HistoryQuery) ([]ledger.TransactionWithEntries, error) {
+	return nil, nil
+}
+
+func (repoStub) PostTransaction(_ context.Context, _ uuid.UUID, _ ledger.PostTransactionInput, _ uuid.UUID) (ledger.Transaction, []ledger.Entry, error) {
+	return ledger.Transaction{}, nil, nil
+}


### PR DESCRIPTION
## Summary
- Add `LedgerReader` interface (GetBalance, GetTransactionHistory)
- Add `LedgerWriter` interface (PostTransaction — atomic entries + balance updates)
- Compose into `Repository` (3 total methods — leanest port in the project)
- Add `HistoryQuery` for pagination (offset + limit) and account filtering
- Add `TransactionWithEntries` for bundling transaction + entries in history results
- Compile-time verification test with `repoStub` proving interface composition

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 6 acceptance criteria COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)