### PR TITLE
feat(ledger): implement LedgerLogic domain service with TDD

### DIFF
--- a/internal/domain/ledger/ledger_logic.go
+++ b/internal/domain/ledger/ledger_logic.go
@@ -1,0 +1,117 @@
+package ledger
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+// transactor abstracts atomic multi-table operations.
+// Structurally satisfied by platform/database.Transactor.
+type transactor interface {
+	RunAtomic(ctx context.Context, fn func(ctx context.Context) error) error
+}
+
+// clocker abstracts the current time.
+// Structurally satisfied by platform/clock.Clock.
+type clocker interface {
+	Now() time.Time
+}
+
+// LedgerLogic orchestrates double-entry transaction posting, balance queries,
+// and transaction history. It enforces the critical invariant: every transaction
+// must have balanced entries (total debits = total credits).
+type LedgerLogic struct {
+	repo Repository
+	tx   transactor
+	clk  clocker
+}
+
+// NewLedgerLogic constructs a LedgerLogic. Panics if any dependency is nil.
+func NewLedgerLogic(repo Repository, tx transactor, clk clocker) *LedgerLogic {
+	if repo == nil {
+		panic("ledger: NewLedgerLogic requires non-nil repo")
+	}
+	if tx == nil {
+		panic("ledger: NewLedgerLogic requires non-nil tx")
+	}
+	if clk == nil {
+		panic("ledger: NewLedgerLogic requires non-nil clk")
+	}
+	return &LedgerLogic{repo: repo, tx: tx, clk: clk}
+}
+
+// PostTransaction validates the input, enforces the balanced-entries invariant,
+// and persists the transaction with its entries atomically via the Transactor.
+func (l *LedgerLogic) PostTransaction(ctx context.Context, householdID uuid.UUID, input PostTransactionInput, callerID uuid.UUID) (Transaction, []Entry, error) {
+	// Validate description and entry count.
+	r := validate.NewResult()
+	r.Field("description", input.Description, validate.Required)
+	r.Field("entries", len(input.Entries), validate.Positive)
+	if err := r.Error(); err != nil {
+		return Transaction{}, nil, err
+	}
+
+	// Validate each entry's amount is positive.
+	for i, e := range input.Entries {
+		er := validate.NewResult()
+		er.Field(fmt.Sprintf("entries[%d].amount", i), e.Amount, validate.Positive)
+		if err := er.Error(); err != nil {
+			return Transaction{}, nil, err
+		}
+	}
+
+	// Enforce balanced-entries invariant: total debits must equal total credits.
+	var debitSum, creditSum int64
+	for _, e := range input.Entries {
+		switch e.EntryType {
+		case types.EntryTypeDebit:
+			debitSum += e.Amount
+		case types.EntryTypeCredit:
+			creditSum += e.Amount
+		}
+	}
+	if debitSum != creditSum {
+		return Transaction{}, nil, fmt.Errorf(message.ErrLedgerLogicPost, message.ErrLedgerUnbalanced)
+	}
+
+	// Persist atomically via Transactor.
+	var postedTx Transaction
+	var postedEntries []Entry
+	if err := l.tx.RunAtomic(ctx, func(txCtx context.Context) error {
+		tx, entries, err := l.repo.PostTransaction(txCtx, householdID, input, callerID)
+		if err != nil {
+			return err
+		}
+		postedTx = tx
+		postedEntries = entries
+		return nil
+	}); err != nil {
+		return Transaction{}, nil, fmt.Errorf(message.ErrLedgerLogicPost, err)
+	}
+	return postedTx, postedEntries, nil
+}
+
+// GetBalance returns the current balance for the given account.
+func (l *LedgerLogic) GetBalance(ctx context.Context, accountID uuid.UUID) (int64, error) {
+	bal, err := l.repo.GetBalance(ctx, accountID)
+	if err != nil {
+		return 0, fmt.Errorf(message.ErrLedgerLogicGetBalance, err)
+	}
+	return bal, nil
+}
+
+// GetTransactionHistory returns transactions with their entries, filtered and paginated.
+func (l *LedgerLogic) GetTransactionHistory(ctx context.Context, householdID uuid.UUID, query HistoryQuery) ([]TransactionWithEntries, error) {
+	history, err := l.repo.GetTransactionHistory(ctx, householdID, query)
+	if err != nil {
+		return nil, fmt.Errorf(message.ErrLedgerLogicGetHistory, err)
+	}
+	return history, nil
+}

--- a/internal/domain/ledger/ledger_logic_test.go
+++ b/internal/domain/ledger/ledger_logic_test.go
@@ -1,0 +1,189 @@
+package ledger_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zambone/pfm-go/internal/adapter/postgres"
+	"github.com/zambone/pfm-go/internal/domain/ledger"
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/clock"
+	"github.com/zambone/pfm-go/internal/platform/database"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+func newLedgerLogic() (*ledger.LedgerLogic, *postgres.FakeLedgerRepository) {
+	repo := postgres.NewFakeLedgerRepository()
+	tx := database.NewFakeTransactor()
+	clk := clock.NewFakeClock(fixedTime)
+	logic := ledger.NewLedgerLogic(repo, tx, clk)
+	return logic, repo
+}
+
+// ---------------------------------------------------------------------------
+// PostTransaction
+// ---------------------------------------------------------------------------
+
+func TestLedgerLogic_PostTransaction_BalancedSucceeds(t *testing.T) {
+	logic, _ := newLedgerLogic()
+
+	tx, entries, err := logic.PostTransaction(context.Background(), testHouseholdID,
+		postTransactionInputFactory(), testCallerID)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, tx.ID)
+	assert.Equal(t, "Test Transaction", tx.Description)
+	assert.Len(t, entries, 2)
+}
+
+func TestLedgerLogic_PostTransaction_UnbalancedFails(t *testing.T) {
+	logic, _ := newLedgerLogic()
+	input := ledger.PostTransactionInput{
+		Description:     "Unbalanced",
+		TransactionDate: fixedTime,
+		Entries: []ledger.EntryInput{
+			{AccountID: testDebitAcctID, EntryType: types.EntryTypeDebit, Amount: 10000},
+			{AccountID: testCreditAcctID, EntryType: types.EntryTypeCredit, Amount: 5000},
+		},
+	}
+
+	_, _, err := logic.PostTransaction(context.Background(), testHouseholdID, input, testCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrLedgerUnbalanced))
+}
+
+func TestLedgerLogic_PostTransaction_ZeroEntries_FailsValidation(t *testing.T) {
+	logic, _ := newLedgerLogic()
+	input := ledger.PostTransactionInput{
+		Description:     "Empty",
+		TransactionDate: fixedTime,
+		Entries:         []ledger.EntryInput{},
+	}
+
+	_, _, err := logic.PostTransaction(context.Background(), testHouseholdID, input, testCallerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+func TestLedgerLogic_PostTransaction_NonPositiveAmount_FailsValidation(t *testing.T) {
+	logic, _ := newLedgerLogic()
+	input := ledger.PostTransactionInput{
+		Description:     "Bad Amount",
+		TransactionDate: fixedTime,
+		Entries: []ledger.EntryInput{
+			{AccountID: testDebitAcctID, EntryType: types.EntryTypeDebit, Amount: 0},
+			{AccountID: testCreditAcctID, EntryType: types.EntryTypeCredit, Amount: 0},
+		},
+	}
+
+	_, _, err := logic.PostTransaction(context.Background(), testHouseholdID, input, testCallerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+func TestLedgerLogic_PostTransaction_EmptyDescription_FailsValidation(t *testing.T) {
+	logic, _ := newLedgerLogic()
+	input := postTransactionInputFactory(func(i *ledger.PostTransactionInput) { i.Description = "" })
+
+	_, _, err := logic.PostTransaction(context.Background(), testHouseholdID, input, testCallerID)
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+func TestLedgerLogic_PostTransaction_SingleEntry_FailsBalance(t *testing.T) {
+	logic, _ := newLedgerLogic()
+	input := ledger.PostTransactionInput{
+		Description:     "Single entry",
+		TransactionDate: fixedTime,
+		Entries: []ledger.EntryInput{
+			{AccountID: testDebitAcctID, EntryType: types.EntryTypeDebit, Amount: 10000},
+		},
+	}
+
+	_, _, err := logic.PostTransaction(context.Background(), testHouseholdID, input, testCallerID)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, message.ErrLedgerUnbalanced))
+}
+
+func TestLedgerLogic_PostTransaction_MultipleDebitsOneCredit_Succeeds(t *testing.T) {
+	logic, _ := newLedgerLogic()
+	thirdAcct := uuid.New()
+	input := ledger.PostTransactionInput{
+		Description:     "Split debit",
+		TransactionDate: fixedTime,
+		Entries: []ledger.EntryInput{
+			{AccountID: testDebitAcctID, EntryType: types.EntryTypeDebit, Amount: 3000},
+			{AccountID: thirdAcct, EntryType: types.EntryTypeDebit, Amount: 7000},
+			{AccountID: testCreditAcctID, EntryType: types.EntryTypeCredit, Amount: 10000},
+		},
+	}
+
+	tx, entries, err := logic.PostTransaction(context.Background(), testHouseholdID, input, testCallerID)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, tx.ID)
+	assert.Len(t, entries, 3)
+}
+
+// ---------------------------------------------------------------------------
+// GetBalance
+// ---------------------------------------------------------------------------
+
+func TestLedgerLogic_GetBalance_ReturnsCorrectBalance(t *testing.T) {
+	logic, _ := newLedgerLogic()
+
+	_, _, err := logic.PostTransaction(context.Background(), testHouseholdID,
+		postTransactionInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	bal, err := logic.GetBalance(context.Background(), testCreditAcctID)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(10000), bal)
+}
+
+func TestLedgerLogic_GetBalance_NegativeBalanceAllowed(t *testing.T) {
+	logic, _ := newLedgerLogic()
+
+	_, _, err := logic.PostTransaction(context.Background(), testHouseholdID,
+		postTransactionInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	bal, err := logic.GetBalance(context.Background(), testDebitAcctID)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(-10000), bal, "debit account has negative balance")
+}
+
+// ---------------------------------------------------------------------------
+// GetTransactionHistory
+// ---------------------------------------------------------------------------
+
+func TestLedgerLogic_GetTransactionHistory_ReturnsEntries(t *testing.T) {
+	logic, _ := newLedgerLogic()
+
+	_, _, err := logic.PostTransaction(context.Background(), testHouseholdID,
+		postTransactionInputFactory(), testCallerID)
+	require.NoError(t, err)
+
+	history, err := logic.GetTransactionHistory(context.Background(), testHouseholdID,
+		ledger.HistoryQuery{AccountID: testDebitAcctID, Offset: 0, Limit: 10})
+
+	require.NoError(t, err)
+	assert.Len(t, history, 1)
+	assert.Equal(t, "Test Transaction", history[0].Transaction.Description)
+}

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -300,6 +300,13 @@ const (
 	ErrLedgerGetHistory      = "ledger: get transaction history: %w"
 )
 
+// Ledger logic format strings (domain layer).
+const (
+	ErrLedgerLogicPost       = "ledger logic: post transaction: %w"
+	ErrLedgerLogicGetBalance = "ledger logic: get balance: %w"
+	ErrLedgerLogicGetHistory = "ledger logic: get history: %w"
+)
+
 // Startup errors (used by cmd/pfm/main.go composition root).
 const (
 	ErrRunLoadConfig = "load config: %w"


### PR DESCRIPTION
## Summary
- Add `LedgerLogic` with 3 methods: PostTransaction, GetBalance, GetTransactionHistory
- PostTransaction enforces the critical balanced-entries invariant (debit sum == credit sum) before any persistence
- Validates description (required), entry count (> 0), and each entry amount (> 0) via centralized validation engine
- Uses Transactor for atomic multi-account operations
- Single-entry transactions correctly fail balance check; multi-debit splits succeed when balanced
- Negative balances allowed (the system tracks debt)
- 10 unit tests covering all ACs and edge cases

## Test plan
- [x] `make ci` passes (lint + unit tests + vuln scan + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 9 ACs + 4 edge cases COVERED)
- [x] `/project:review` verdict: PASS (all applicable categories)

closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)