### PR TITLE
feat(http): add response infrastructure and domain-error-to-HTTP mapper

### DIFF
--- a/internal/adapter/http/auth.go
+++ b/internal/adapter/http/auth.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -40,8 +39,8 @@ func LoginHandler(svc loginService) http.HandlerFunc {
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req loginRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSONError(w, http.StatusBadRequest, message.MsgLoginBadRequest)
+		if err := DecodeBody(r, &req); err != nil {
+			WriteJSON(w, http.StatusBadRequest, map[string]string{"error": message.MsgLoginBadRequest})
 			return
 		}
 
@@ -51,47 +50,25 @@ func LoginHandler(svc loginService) http.HandlerFunc {
 		if err := v.Error(); err != nil {
 			var ve *validate.ValidationError
 			errors.As(err, &ve)
-			writeJSONValidationError(w, ve)
+			WriteValidationError(w, ve)
 			return
 		}
 
 		result, err := svc.Login(r.Context(), req.Email, req.Password)
 		if err != nil {
 			if errors.Is(err, message.ErrLoginInvalidCredentials) {
-				writeJSONError(w, http.StatusUnauthorized, message.MsgLoginInvalidCredentials)
+				WriteError(w, err)
 				return
 			}
 			slog.ErrorContext(r.Context(), message.MsgServerError, "error", err)
-			writeJSONError(w, http.StatusInternalServerError, message.MsgServerError)
+			WriteError(w, err)
 			return
 		}
 
-		w.Header().Set(headerContentType, mimeJSON)
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(loginResponse{ // best-effort
+		WriteJSON(w, http.StatusOK, loginResponse{
 			Token:     result.Token,
 			ExpiresAt: result.ExpiresAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		})
 	}
 }
 
-// writeJSONError writes {"error": msg} with the given HTTP status.
-func writeJSONError(w http.ResponseWriter, status int, msg string) {
-	w.Header().Set(headerContentType, mimeJSON)
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg}) // best-effort
-}
-
-// writeJSONValidationError writes a 400 response with per-field validation details.
-func writeJSONValidationError(w http.ResponseWriter, ve *validate.ValidationError) {
-	fields := make(map[string]string, len(ve.Violations))
-	for _, v := range ve.Violations {
-		fields[v.Field] = v.Message
-	}
-	w.Header().Set(headerContentType, mimeJSON)
-	w.WriteHeader(http.StatusBadRequest)
-	_ = json.NewEncoder(w).Encode(map[string]any{ // best-effort
-		"error":  message.MsgValidationFailed,
-		"fields": fields,
-	})
-}

--- a/internal/adapter/http/auth_test.go
+++ b/internal/adapter/http/auth_test.go
@@ -160,7 +160,7 @@ func TestLoginHandler_InfraError_Returns500(t *testing.T) {
 
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 	body := decodeBody(t, w)
-	assert.Equal(t, message.MsgServerError, body["error"])
+	assert.Equal(t, message.MsgInternalError, body["error"])
 }
 
 // TestLoginHandler_NilService_Panics verifies the nil guard fires at wiring time.

--- a/internal/adapter/http/response.go
+++ b/internal/adapter/http/response.go
@@ -1,0 +1,123 @@
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+)
+
+const headerLocation = "Location"
+
+// WriteJSON serializes v as JSON and writes it to w with the given HTTP status code.
+// Content-Type is set to application/json. If v is nil, the body is "null".
+// Encoding errors are best-effort — the status code has already been sent.
+func WriteJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set(headerContentType, mimeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v) // best-effort
+}
+
+// WriteCreated writes a 201 Created response with a Location header pointing to
+// the newly created resource and the resource serialized as JSON in the body.
+func WriteCreated(w http.ResponseWriter, location string, v any) {
+	w.Header().Set(headerLocation, location)
+	WriteJSON(w, http.StatusCreated, v)
+}
+
+// WriteNoContent writes a 204 No Content response with an empty body.
+// Used for delete and deactivate operations where no response payload is needed.
+func WriteNoContent(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// DecodeBody reads the request body and decodes it as JSON into dst.
+// Returns an error if the body is empty or contains malformed JSON.
+func DecodeBody(r *http.Request, dst any) error {
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		return fmt.Errorf("decode request body: %w", err)
+	}
+	return nil
+}
+
+// errorMapping pairs a domain error sentinel with the HTTP status code and
+// user-facing message it should produce. Order matters: the first match wins,
+// so more specific errors should appear before generic ones.
+type errorMapping struct {
+	sentinel error
+	status   int
+	message  string
+}
+
+// errMappings is the single source of truth for domain-error-to-HTTP translation.
+// Each entry uses errors.Is for matching, so wrapped errors are handled correctly.
+var errMappings = []errorMapping{
+	// Authentication
+	{message.ErrLoginInvalidCredentials, http.StatusUnauthorized, message.MsgLoginInvalidCredentials},
+
+	// Not found → 404
+	{message.ErrUserNotFound, http.StatusNotFound, message.MsgNotFound},
+	{message.ErrHouseholdNotFound, http.StatusNotFound, message.MsgNotFound},
+	{message.ErrHouseholdMemberNotFound, http.StatusNotFound, message.MsgNotFound},
+	{message.ErrAccountNotFound, http.StatusNotFound, message.MsgNotFound},
+	{message.ErrCreditCardSettingsNotFound, http.StatusNotFound, message.MsgNotFound},
+
+	// Version conflict → 409
+	{message.ErrUserVersionConflict, http.StatusConflict, message.MsgConflict},
+	{message.ErrHouseholdVersionConflict, http.StatusConflict, message.MsgConflict},
+	{message.ErrAccountVersionConflict, http.StatusConflict, message.MsgConflict},
+	{message.ErrCreditCardSettingsVersionConflict, http.StatusConflict, message.MsgConflict},
+
+	// Already exists / duplicates → 409
+	{message.ErrUserEmailTaken, http.StatusConflict, message.MsgConflict},
+	{message.ErrHouseholdMemberExists, http.StatusConflict, message.MsgConflict},
+	{message.ErrAccountNameTaken, http.StatusConflict, message.MsgConflict},
+	{message.ErrCreditCardSettingsExists, http.StatusConflict, message.MsgConflict},
+
+	// Domain-specific business rule violations
+	{message.ErrLedgerUnbalanced, http.StatusUnprocessableEntity, message.MsgUnbalancedLedger},
+	{message.ErrAccountBalanceNotZero, http.StatusConflict, message.MsgBalanceNotZero},
+	{message.ErrCreditCardSettingsNotCreditCard, http.StatusConflict, message.MsgNotCreditCard},
+	{message.ErrHouseholdLastAdmin, http.StatusConflict, message.MsgLastAdmin},
+}
+
+// MapError translates a domain error into an HTTP status code and user-facing
+// message. It uses errors.Is to match wrapped errors against known sentinels.
+// Unrecognized errors default to 500 Internal Server Error with a generic message
+// so that internal details are never leaked to the client.
+func MapError(err error) (status int, msg string) {
+	for _, m := range errMappings {
+		if errors.Is(err, m.sentinel) {
+			return m.status, m.message
+		}
+	}
+	return http.StatusInternalServerError, message.MsgInternalError
+}
+
+// WriteError maps a domain error to an HTTP status code and writes a structured
+// JSON error response. Unrecognized errors produce a 500 with a generic message.
+func WriteError(w http.ResponseWriter, err error) {
+	status, msg := MapError(err)
+	w.Header().Set(headerContentType, mimeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg}) // best-effort
+}
+
+// WriteValidationError writes a 400 Bad Request response with per-field violation
+// details. The response body contains an "error" key with a summary message and
+// a "fields" object mapping field names to their validation failure messages.
+func WriteValidationError(w http.ResponseWriter, ve *validate.ValidationError) {
+	fields := make(map[string]string, len(ve.Violations))
+	for _, v := range ve.Violations {
+		fields[v.Field] = v.Message
+	}
+	w.Header().Set(headerContentType, mimeJSON)
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]any{ // best-effort
+		"error":  message.MsgValidationFailed,
+		"fields": fields,
+	})
+}

--- a/internal/adapter/http/response_test.go
+++ b/internal/adapter/http/response_test.go
@@ -1,0 +1,289 @@
+package http_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pfmhttp "github.com/zambone/pfm-go/internal/adapter/http"
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+)
+
+// TestHTTPMessageConstants_Exist verifies that all HTTP-layer message constants
+// are defined in the message package. These constants provide user-facing error
+// messages for the response infrastructure.
+func TestHTTPMessageConstants_Exist(t *testing.T) {
+	t.Parallel()
+
+	// Each constant must be a non-empty string — the exact wording is tested
+	// by the response helper tests that use them.
+	constants := map[string]string{
+		"MsgBadRequestBody":   message.MsgBadRequestBody,
+		"MsgNotFound":         message.MsgNotFound,
+		"MsgConflict":         message.MsgConflict,
+		"MsgInternalError":    message.MsgInternalError,
+		"MsgUnbalancedLedger": message.MsgUnbalancedLedger,
+		"MsgBalanceNotZero":   message.MsgBalanceNotZero,
+		"MsgNotCreditCard":    message.MsgNotCreditCard,
+		"MsgLastAdmin":        message.MsgLastAdmin,
+	}
+
+	for name, val := range constants {
+		assert.NotEmpty(t, val, "%s must not be empty", name)
+	}
+}
+
+// --- WriteJSON tests ---
+
+// TestWriteJSON_SerializesStruct verifies AC9: a success response helper
+// serializes a struct to JSON with Content-Type application/json.
+func TestWriteJSON_SerializesStruct(t *testing.T) {
+	t.Parallel()
+
+	type payload struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+
+	w := httptest.NewRecorder()
+	pfmhttp.WriteJSON(w, http.StatusOK, payload{Name: "Alice", Age: 30})
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var got payload
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	assert.Equal(t, "Alice", got.Name)
+	assert.Equal(t, 30, got.Age)
+}
+
+// TestWriteJSON_NilValue verifies edge case: nil value does not panic.
+func TestWriteJSON_NilValue(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	pfmhttp.WriteJSON(w, http.StatusOK, nil)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+}
+
+// --- WriteCreated tests ---
+
+// TestWriteCreated_Returns201WithLocation verifies AC10: a 201 Created response
+// includes the Location header and serialized JSON body.
+func TestWriteCreated_Returns201WithLocation(t *testing.T) {
+	t.Parallel()
+
+	type resource struct {
+		ID string `json:"id"`
+	}
+
+	w := httptest.NewRecorder()
+	pfmhttp.WriteCreated(w, "/api/v1/users/abc-123", resource{ID: "abc-123"})
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, "/api/v1/users/abc-123", w.Header().Get("Location"))
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var got resource
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	assert.Equal(t, "abc-123", got.ID)
+}
+
+// --- WriteNoContent tests ---
+
+// TestWriteNoContent_Returns204WithEmptyBody verifies edge case: 204 No Content
+// has an empty body (e.g., deactivate, delete operations).
+func TestWriteNoContent_Returns204WithEmptyBody(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	pfmhttp.WriteNoContent(w)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, w.Body.String())
+}
+
+// --- DecodeBody tests ---
+
+// TestDecodeBody_ValidJSON verifies AC7 happy path: a well-formed JSON body
+// is decoded into the target struct without error.
+func TestDecodeBody_ValidJSON(t *testing.T) {
+	t.Parallel()
+
+	type input struct {
+		Name string `json:"name"`
+	}
+
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"Bob"}`))
+	var got input
+	err := pfmhttp.DecodeBody(r, &got)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Bob", got.Name)
+}
+
+// TestDecodeBody_MalformedJSON verifies AC7: malformed JSON returns an error.
+func TestDecodeBody_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	type input struct {
+		Name string `json:"name"`
+	}
+
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{bad json}"))
+	var got input
+	err := pfmhttp.DecodeBody(r, &got)
+
+	require.Error(t, err)
+}
+
+// TestDecodeBody_EmptyBody verifies AC7 edge case: empty body returns an error.
+func TestDecodeBody_EmptyBody(t *testing.T) {
+	t.Parallel()
+
+	type input struct {
+		Name string `json:"name"`
+	}
+
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(""))
+	var got input
+	err := pfmhttp.DecodeBody(r, &got)
+
+	require.Error(t, err)
+}
+
+// --- MapError tests ---
+
+// TestMapError_DomainErrors verifies AC2–AC4 and AC8: each domain error sentinel
+// maps to the correct HTTP status code and user-facing message.
+func TestMapError_DomainErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantMsg    string
+	}{
+		// AC2: not found errors → 404
+		{"user not found", message.ErrUserNotFound, http.StatusNotFound, message.MsgNotFound},
+		{"household not found", message.ErrHouseholdNotFound, http.StatusNotFound, message.MsgNotFound},
+		{"account not found", message.ErrAccountNotFound, http.StatusNotFound, message.MsgNotFound},
+		{"cc settings not found", message.ErrCreditCardSettingsNotFound, http.StatusNotFound, message.MsgNotFound},
+
+		// AC3: version conflict errors → 409
+		{"user version conflict", message.ErrUserVersionConflict, http.StatusConflict, message.MsgConflict},
+		{"household version conflict", message.ErrHouseholdVersionConflict, http.StatusConflict, message.MsgConflict},
+		{"account version conflict", message.ErrAccountVersionConflict, http.StatusConflict, message.MsgConflict},
+		{"cc settings version conflict", message.ErrCreditCardSettingsVersionConflict, http.StatusConflict, message.MsgConflict},
+
+		// AC4: already-exists / duplicate errors → 409
+		{"email taken", message.ErrUserEmailTaken, http.StatusConflict, message.MsgConflict},
+		{"member exists", message.ErrHouseholdMemberExists, http.StatusConflict, message.MsgConflict},
+		{"account name taken", message.ErrAccountNameTaken, http.StatusConflict, message.MsgConflict},
+		{"cc settings exists", message.ErrCreditCardSettingsExists, http.StatusConflict, message.MsgConflict},
+
+		// Domain-specific errors with specific messages
+		{"unbalanced ledger", message.ErrLedgerUnbalanced, http.StatusUnprocessableEntity, message.MsgUnbalancedLedger},
+		{"balance not zero", message.ErrAccountBalanceNotZero, http.StatusConflict, message.MsgBalanceNotZero},
+		{"not credit card", message.ErrCreditCardSettingsNotCreditCard, http.StatusConflict, message.MsgNotCreditCard},
+		{"last admin", message.ErrHouseholdLastAdmin, http.StatusConflict, message.MsgLastAdmin},
+		{"member not found", message.ErrHouseholdMemberNotFound, http.StatusNotFound, message.MsgNotFound},
+		{"invalid credentials", message.ErrLoginInvalidCredentials, http.StatusUnauthorized, message.MsgLoginInvalidCredentials},
+
+		// AC8: unrecognized error → 500
+		{"unknown error", errors.New("something unexpected"), http.StatusInternalServerError, message.MsgInternalError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			status, msg := pfmhttp.MapError(tc.err)
+			assert.Equal(t, tc.wantStatus, status)
+			assert.Equal(t, tc.wantMsg, msg)
+		})
+	}
+}
+
+// TestMapError_WrappedErrors verifies that errors.Is unwrapping works — a domain
+// sentinel wrapped with fmt.Errorf still maps correctly.
+func TestMapError_WrappedErrors(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("user logic: find by id: %w", message.ErrUserNotFound)
+	status, msg := pfmhttp.MapError(wrapped)
+
+	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, message.MsgNotFound, msg)
+}
+
+// --- WriteError tests ---
+
+// TestWriteError_DomainError verifies the full flow: WriteError maps a domain
+// error to status + message and writes the structured JSON response.
+func TestWriteError_DomainError(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	pfmhttp.WriteError(w, message.ErrUserNotFound)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	body := decodeBody(t, w)
+	assert.Equal(t, message.MsgNotFound, body["error"])
+}
+
+// TestWriteError_UnknownError verifies AC6: unexpected errors return 500 with
+// a generic message — no internal details leaked.
+func TestWriteError_UnknownError(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	pfmhttp.WriteError(w, errors.New("database connection refused"))
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	body := decodeBody(t, w)
+	assert.Equal(t, message.MsgInternalError, body["error"])
+	// Must NOT contain the original error message
+	assert.NotContains(t, w.Body.String(), "database connection refused")
+}
+
+// --- WriteValidationError tests ---
+
+// TestWriteValidationError_FieldViolations verifies AC5: validation errors return
+// 400 with per-field violation details.
+func TestWriteValidationError_FieldViolations(t *testing.T) {
+	t.Parallel()
+
+	ve := &validate.ValidationError{
+		Violations: []validate.Violation{
+			{Field: "name", Message: "is required"},
+			{Field: "email", Message: "must be at least 3 characters"},
+		},
+	}
+
+	w := httptest.NewRecorder()
+	pfmhttp.WriteValidationError(w, ve)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	body := decodeBody(t, w)
+	assert.Equal(t, message.MsgValidationFailed, body["error"])
+	fields, ok := body["fields"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "is required", fields["name"])
+	assert.Equal(t, "must be at least 3 characters", fields["email"])
+}

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -307,6 +307,18 @@ const (
 	ErrLedgerLogicGetHistory = "ledger logic: get history: %w"
 )
 
+// HTTP response messages (used by adapter/http response infrastructure).
+const (
+	MsgBadRequestBody   = "invalid request body"
+	MsgNotFound         = "resource not found"
+	MsgConflict         = "resource conflict"
+	MsgInternalError    = "internal server error"
+	MsgUnbalancedLedger = "transaction entries do not balance"
+	MsgBalanceNotZero   = "account balance must be zero to deactivate"
+	MsgNotCreditCard    = "account is not a credit card"
+	MsgLastAdmin        = "cannot remove last admin"
+)
+
 // Startup errors (used by cmd/pfm/main.go composition root).
 const (
 	ErrRunLoadConfig = "load config: %w"


### PR DESCRIPTION
## Summary
- Add shared HTTP response helpers (`WriteJSON`, `WriteCreated`, `WriteNoContent`, `WriteError`, `WriteValidationError`, `DecodeBody`) for consistent API responses
- Add centralized `MapError` with 18 domain-error-to-HTTP-status mappings covering all domains (user, household, account, credit card, ledger)
- Add HTTP message constants (`MsgNotFound`, `MsgConflict`, `MsgInternalError`, etc.) in `internal/message/`
- Refactor `LoginHandler` to use new shared helpers, removing old unexported `writeJSONError`/`writeJSONValidationError`

## Test plan
- [x] `make ci` passes (lint + test -race + build)
- [x] `/project:verify-issue` verdict: PASS (all 10 acceptance criteria covered)
- [x] `/project:review` verdict: PASS (all 9 applicable categories)
- [x] 13 new unit tests with 19 subtests covering all helpers and edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)