### PR TITLE
feat(http): add user domain REST handlers

### DIFF
--- a/internal/adapter/http/user.go
+++ b/internal/adapter/http/user.go
@@ -1,0 +1,270 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	domainuser "github.com/zambone/pfm-go/internal/domain/user"
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/ctxutil"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+)
+
+// userResponse is the JSON representation of a user. It deliberately excludes
+// PasswordHash so that sensitive data never reaches the wire.
+type userResponse struct {
+	ID          string `json:"id"`
+	Email       string `json:"email"`
+	DisplayName string `json:"display_name"`
+	Version     int    `json:"version"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// toUserResponse maps a domain User to its JSON-safe response representation.
+func toUserResponse(u domainuser.User) userResponse {
+	return userResponse{
+		ID:          u.ID.String(),
+		Email:       u.Email,
+		DisplayName: u.DisplayName,
+		Version:     u.Version,
+		CreatedAt:   u.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:   u.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// handleDomainError writes the appropriate HTTP error response for a domain error.
+// It checks for ValidationError first (400), then delegates to WriteError for all
+// other domain errors (404, 409, 500, etc.). Unexpected errors are logged at ERROR.
+func handleDomainError(w http.ResponseWriter, r *http.Request, err error) {
+	var ve *validate.ValidationError
+	if errors.As(err, &ve) {
+		WriteValidationError(w, ve)
+		return
+	}
+
+	// Log unexpected errors (5xx) at ERROR; known domain errors need no logging
+	// because they represent expected business outcomes (not found, conflict, etc.).
+	status, _ := MapError(err)
+	if status >= http.StatusInternalServerError {
+		slog.ErrorContext(r.Context(), message.MsgServerError, "error", err)
+	}
+
+	WriteError(w, err)
+}
+
+// parseUUID parses a UUID string from a path parameter. Returns an error
+// if the value is not a valid UUID, which handlers translate to 400 Bad Request.
+func parseUUID(value string) (uuid.UUID, error) {
+	id, err := uuid.Parse(value)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("parse uuid %q: %w", value, err)
+	}
+	return id, nil
+}
+
+// --- Register ---
+
+// registerService is the subset of UserLogic required by RegisterHandler.
+type registerService interface {
+	Register(ctx context.Context, input domainuser.RegisterInput, callerID uuid.UUID) (domainuser.User, error)
+}
+
+type registerRequest struct {
+	Email       string `json:"email"`
+	DisplayName string `json:"display_name"`
+	Password    string `json:"password"`
+}
+
+// RegisterHandler returns an http.HandlerFunc that handles user registration.
+// On success it writes a 201 Created response with the new user and a Location header.
+// Panics if svc is nil.
+func RegisterHandler(svc registerService) http.HandlerFunc {
+	if svc == nil {
+		panic("http: RegisterHandler requires non-nil registerService")
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req registerRequest
+		if err := DecodeBody(r, &req); err != nil {
+			WriteJSON(w, http.StatusBadRequest, map[string]string{"error": message.MsgBadRequestBody})
+			return
+		}
+
+		// callerID: for self-registration there is no authenticated user yet,
+		// so we use uuid.Nil as a sentinel meaning "self-created".
+		callerID, _ := ctxutil.UserID(r.Context())
+
+		u, err := svc.Register(r.Context(), domainuser.RegisterInput{
+			Email:       req.Email,
+			DisplayName: req.DisplayName,
+			Password:    req.Password,
+		}, callerID)
+		if err != nil {
+			handleDomainError(w, r, err)
+			return
+		}
+
+		location := fmt.Sprintf("/api/v1/users/%s", u.ID)
+		WriteCreated(w, location, toUserResponse(u))
+	}
+}
+
+// --- GetUser ---
+
+// getUserService is the subset of UserLogic required by GetUserHandler.
+type getUserService interface {
+	FindByID(ctx context.Context, id uuid.UUID) (domainuser.User, error)
+}
+
+// GetUserHandler returns an http.HandlerFunc that retrieves a user by ID.
+// The user ID is read from the URL path parameter "id". Panics if svc is nil.
+func GetUserHandler(svc getUserService) http.HandlerFunc {
+	if svc == nil {
+		panic("http: GetUserHandler requires non-nil getUserService")
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := parseUUID(r.PathValue("id"))
+		if err != nil {
+			WriteJSON(w, http.StatusBadRequest, map[string]string{"error": message.MsgAuthzBadRequest})
+			return
+		}
+
+		u, err := svc.FindByID(r.Context(), id)
+		if err != nil {
+			handleDomainError(w, r, err)
+			return
+		}
+
+		WriteJSON(w, http.StatusOK, toUserResponse(u))
+	}
+}
+
+// --- ChangePassword ---
+
+// changePasswordService is the subset of UserLogic required by ChangePasswordHandler.
+type changePasswordService interface {
+	ChangePassword(ctx context.Context, id uuid.UUID, input domainuser.ChangePasswordInput, expectedVersion int, callerID uuid.UUID) (domainuser.User, error)
+}
+
+type changePasswordRequest struct {
+	OldPassword string `json:"old_password"`
+	NewPassword string `json:"new_password"`
+	Version     int    `json:"version"`
+}
+
+// ChangePasswordHandler returns an http.HandlerFunc that changes a user's password.
+// The user ID is read from the URL path parameter "id". Panics if svc is nil.
+func ChangePasswordHandler(svc changePasswordService) http.HandlerFunc {
+	if svc == nil {
+		panic("http: ChangePasswordHandler requires non-nil changePasswordService")
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := parseUUID(r.PathValue("id"))
+		if err != nil {
+			WriteJSON(w, http.StatusBadRequest, map[string]string{"error": message.MsgAuthzBadRequest})
+			return
+		}
+
+		var req changePasswordRequest
+		if err := DecodeBody(r, &req); err != nil {
+			WriteJSON(w, http.StatusBadRequest, map[string]string{"error": message.MsgBadRequestBody})
+			return
+		}
+
+		callerID, _ := ctxutil.UserID(r.Context())
+
+		u, err := svc.ChangePassword(r.Context(), id, domainuser.ChangePasswordInput{
+			OldPassword: req.OldPassword,
+			NewPassword: req.NewPassword,
+		}, req.Version, callerID)
+		if err != nil {
+			handleDomainError(w, r, err)
+			return
+		}
+
+		WriteJSON(w, http.StatusOK, toUserResponse(u))
+	}
+}
+
+// --- Deactivate ---
+
+// deactivateUserService is the subset of UserLogic required by DeactivateUserHandler.
+type deactivateUserService interface {
+	Deactivate(ctx context.Context, id uuid.UUID, callerID uuid.UUID) error
+}
+
+// DeactivateUserHandler returns an http.HandlerFunc that soft-deletes a user.
+// The user ID is read from the URL path parameter "id". Panics if svc is nil.
+func DeactivateUserHandler(svc deactivateUserService) http.HandlerFunc {
+	if svc == nil {
+		panic("http: DeactivateUserHandler requires non-nil deactivateUserService")
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := parseUUID(r.PathValue("id"))
+		if err != nil {
+			WriteJSON(w, http.StatusBadRequest, map[string]string{"error": message.MsgAuthzBadRequest})
+			return
+		}
+
+		callerID, _ := ctxutil.UserID(r.Context())
+
+		if err := svc.Deactivate(r.Context(), id, callerID); err != nil {
+			handleDomainError(w, r, err)
+			return
+		}
+
+		WriteNoContent(w)
+	}
+}
+
+// --- UpdateProfile ---
+
+// updateProfileService is the subset of UserLogic required by UpdateProfileHandler.
+type updateProfileService interface {
+	UpdateProfile(ctx context.Context, id uuid.UUID, input domainuser.UpdateProfileInput, expectedVersion int, callerID uuid.UUID) (domainuser.User, error)
+}
+
+type updateProfileRequest struct {
+	DisplayName string `json:"display_name"`
+	Version     int    `json:"version"`
+}
+
+// UpdateProfileHandler returns an http.HandlerFunc that updates a user's profile.
+// The user ID is read from the URL path parameter "id". The caller ID is read from
+// the request context (set by authn middleware). Panics if svc is nil.
+func UpdateProfileHandler(svc updateProfileService) http.HandlerFunc {
+	if svc == nil {
+		panic("http: UpdateProfileHandler requires non-nil updateProfileService")
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := parseUUID(r.PathValue("id"))
+		if err != nil {
+			WriteJSON(w, http.StatusBadRequest, map[string]string{"error": message.MsgAuthzBadRequest})
+			return
+		}
+
+		var req updateProfileRequest
+		if err := DecodeBody(r, &req); err != nil {
+			WriteJSON(w, http.StatusBadRequest, map[string]string{"error": message.MsgBadRequestBody})
+			return
+		}
+
+		callerID, _ := ctxutil.UserID(r.Context())
+
+		u, err := svc.UpdateProfile(r.Context(), id, domainuser.UpdateProfileInput{
+			DisplayName: req.DisplayName,
+		}, req.Version, callerID)
+		if err != nil {
+			handleDomainError(w, r, err)
+			return
+		}
+
+		WriteJSON(w, http.StatusOK, toUserResponse(u))
+	}
+}

--- a/internal/adapter/http/user_test.go
+++ b/internal/adapter/http/user_test.go
@@ -1,0 +1,494 @@
+package http_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pfmhttp "github.com/zambone/pfm-go/internal/adapter/http"
+	domainuser "github.com/zambone/pfm-go/internal/domain/user"
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/ctxutil"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+)
+
+// --- Stubs ---
+
+// stubRegisterService is a test double for the registerService interface.
+type stubRegisterService struct {
+	user domainuser.User
+	err  error
+}
+
+func (s *stubRegisterService) Register(_ context.Context, _ domainuser.RegisterInput, _ uuid.UUID) (domainuser.User, error) {
+	return s.user, s.err
+}
+
+// testUser returns a User with all fields populated for test assertions.
+func testUser() domainuser.User {
+	return domainuser.User{
+		ID:          uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		Email:       "alice@example.com",
+		DisplayName: "Alice",
+		Version:     1,
+		CreatedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		CreatedBy:   uuid.MustParse("00000000-0000-0000-0000-000000000099"),
+		UpdatedBy:   uuid.MustParse("00000000-0000-0000-0000-000000000099"),
+	}
+}
+
+// ctxWithUser returns a context with the given user ID set, simulating an
+// authenticated request that has passed through the authn middleware.
+func ctxWithUser(id uuid.UUID) context.Context {
+	return ctxutil.WithUserID(context.Background(), id)
+}
+
+// --- RegisterHandler tests ---
+
+// TestRegisterHandler_ValidRequest_Returns201 verifies AC1: a valid registration
+// request returns 201 Created with the new user and a Location header.
+func TestRegisterHandler_ValidRequest_Returns201(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubRegisterService{user: testUser()}
+	handler := pfmhttp.RegisterHandler(svc)
+
+	body := `{"email":"alice@example.com","display_name":"Alice","password":"secret123"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	assert.Contains(t, w.Header().Get("Location"), testUser().ID.String())
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "alice@example.com", resp["email"])
+	assert.Equal(t, "Alice", resp["display_name"])
+	// PasswordHash must NEVER appear in the response
+	assert.NotContains(t, w.Body.String(), "password_hash")
+}
+
+// TestRegisterHandler_EmailTaken_Returns409 verifies AC2: duplicate email
+// returns 409 Conflict.
+func TestRegisterHandler_EmailTaken_Returns409(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubRegisterService{err: message.ErrUserEmailTaken}
+	handler := pfmhttp.RegisterHandler(svc)
+
+	body := `{"email":"taken@example.com","display_name":"Bob","password":"secret123"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+}
+
+// TestRegisterHandler_MissingFields_Returns400 verifies AC10: missing required
+// fields return 400 with per-field validation details.
+func TestRegisterHandler_MissingFields_Returns400(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubRegisterService{}
+	handler := pfmhttp.RegisterHandler(svc)
+
+	// All fields empty — domain logic returns ValidationError
+	svc.err = &validate.ValidationError{
+		Violations: []validate.Violation{
+			{Field: "email", Message: "is required"},
+			{Field: "display_name", Message: "is required"},
+			{Field: "password", Message: "is required"},
+		},
+	}
+
+	body := `{"email":"","display_name":"","password":""}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, message.MsgValidationFailed, resp["error"])
+	fields, ok := resp["fields"].(map[string]any)
+	require.True(t, ok)
+	assert.Len(t, fields, 3)
+}
+
+// TestRegisterHandler_MalformedJSON_Returns400 verifies edge case: unparseable
+// body returns 400, not 500.
+func TestRegisterHandler_MalformedJSON_Returns400(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubRegisterService{}
+	handler := pfmhttp.RegisterHandler(svc)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader("{bad"))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestRegisterHandler_InternalError_Returns500 verifies AC6 (from #122):
+// unexpected errors return 500 with generic message.
+func TestRegisterHandler_InternalError_Returns500(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubRegisterService{err: assert.AnError}
+	handler := pfmhttp.RegisterHandler(svc)
+
+	body := `{"email":"a@b.com","display_name":"X","password":"secret123"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestRegisterHandler_NilService_Panics verifies the nil guard fires at wiring time.
+func TestRegisterHandler_NilService_Panics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { pfmhttp.RegisterHandler(nil) })
+}
+
+// --- GetUserHandler tests ---
+
+// stubGetUserService is a test double for the getUserService interface.
+type stubGetUserService struct {
+	user domainuser.User
+	err  error
+}
+
+func (s *stubGetUserService) FindByID(_ context.Context, _ uuid.UUID) (domainuser.User, error) {
+	return s.user, s.err
+}
+
+// TestGetUserHandler_ValidID_Returns200 verifies AC3: an authenticated user
+// can retrieve a profile by ID, getting a 200 OK with the user.
+func TestGetUserHandler_ValidID_Returns200(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubGetUserService{user: testUser()}
+	handler := pfmhttp.GetUserHandler(svc)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/users/"+testUser().ID.String(), nil)
+	r.SetPathValue("id", testUser().ID.String())
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "alice@example.com", resp["email"])
+	assert.NotContains(t, w.Body.String(), "password_hash")
+}
+
+// TestGetUserHandler_NotFound_Returns404 verifies AC4: a non-existent user ID
+// returns 404 Not Found.
+func TestGetUserHandler_NotFound_Returns404(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubGetUserService{err: message.ErrUserNotFound}
+	handler := pfmhttp.GetUserHandler(svc)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/users/"+uuid.Nil.String(), nil)
+	r.SetPathValue("id", uuid.Nil.String())
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestGetUserHandler_InvalidUUID_Returns400 verifies edge case: a malformed UUID
+// in the path returns 400, not 500.
+func TestGetUserHandler_InvalidUUID_Returns400(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubGetUserService{}
+	handler := pfmhttp.GetUserHandler(svc)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/users/not-a-uuid", nil)
+	r.SetPathValue("id", "not-a-uuid")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestGetUserHandler_NilService_Panics verifies the nil guard fires at wiring time.
+func TestGetUserHandler_NilService_Panics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { pfmhttp.GetUserHandler(nil) })
+}
+
+// --- UpdateProfileHandler tests ---
+
+// stubUpdateProfileService is a test double for the updateProfileService interface.
+type stubUpdateProfileService struct {
+	user domainuser.User
+	err  error
+}
+
+func (s *stubUpdateProfileService) UpdateProfile(_ context.Context, _ uuid.UUID, _ domainuser.UpdateProfileInput, _ int, _ uuid.UUID) (domainuser.User, error) {
+	return s.user, s.err
+}
+
+// TestUpdateProfileHandler_ValidRequest_Returns200 verifies AC5: a valid update
+// with correct version returns 200 OK with the updated user.
+func TestUpdateProfileHandler_ValidRequest_Returns200(t *testing.T) {
+	t.Parallel()
+
+	updated := testUser()
+	updated.DisplayName = "Alice Updated"
+	svc := &stubUpdateProfileService{user: updated}
+	handler := pfmhttp.UpdateProfileHandler(svc)
+
+	body := `{"display_name":"Alice Updated","version":1}`
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/users/"+testUser().ID.String(), strings.NewReader(body))
+	r.SetPathValue("id", testUser().ID.String())
+	r = r.WithContext(ctxWithUser(testUser().ID))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "Alice Updated", resp["display_name"])
+}
+
+// TestUpdateProfileHandler_StaleVersion_Returns409 verifies AC6: a stale version
+// returns 409 Conflict.
+func TestUpdateProfileHandler_StaleVersion_Returns409(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubUpdateProfileService{err: message.ErrUserVersionConflict}
+	handler := pfmhttp.UpdateProfileHandler(svc)
+
+	body := `{"display_name":"New Name","version":1}`
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/users/"+testUser().ID.String(), strings.NewReader(body))
+	r.SetPathValue("id", testUser().ID.String())
+	r = r.WithContext(ctxWithUser(testUser().ID))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+}
+
+// TestUpdateProfileHandler_ValidationError_Returns400 verifies AC10: missing
+// display_name returns 400 with field-level details.
+func TestUpdateProfileHandler_ValidationError_Returns400(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubUpdateProfileService{
+		err: &validate.ValidationError{
+			Violations: []validate.Violation{{Field: "display_name", Message: "is required"}},
+		},
+	}
+	handler := pfmhttp.UpdateProfileHandler(svc)
+
+	body := `{"display_name":"","version":1}`
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/users/"+testUser().ID.String(), strings.NewReader(body))
+	r.SetPathValue("id", testUser().ID.String())
+	r = r.WithContext(ctxWithUser(testUser().ID))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestUpdateProfileHandler_MalformedJSON_Returns400 verifies edge case.
+func TestUpdateProfileHandler_MalformedJSON_Returns400(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubUpdateProfileService{}
+	handler := pfmhttp.UpdateProfileHandler(svc)
+
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/users/"+testUser().ID.String(), strings.NewReader("{bad"))
+	r.SetPathValue("id", testUser().ID.String())
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestUpdateProfileHandler_NilService_Panics verifies the nil guard.
+func TestUpdateProfileHandler_NilService_Panics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { pfmhttp.UpdateProfileHandler(nil) })
+}
+
+// --- ChangePasswordHandler tests ---
+
+// stubChangePasswordService is a test double for the changePasswordService interface.
+type stubChangePasswordService struct {
+	user domainuser.User
+	err  error
+}
+
+func (s *stubChangePasswordService) ChangePassword(_ context.Context, _ uuid.UUID, _ domainuser.ChangePasswordInput, _ int, _ uuid.UUID) (domainuser.User, error) {
+	return s.user, s.err
+}
+
+// TestChangePasswordHandler_ValidRequest_Returns200 verifies AC7: a valid password
+// change with correct old password returns 200 OK.
+func TestChangePasswordHandler_ValidRequest_Returns200(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubChangePasswordService{user: testUser()}
+	handler := pfmhttp.ChangePasswordHandler(svc)
+
+	body := `{"old_password":"oldpass123","new_password":"newpass123","version":1}`
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/users/"+testUser().ID.String()+"/password", strings.NewReader(body))
+	r.SetPathValue("id", testUser().ID.String())
+	r = r.WithContext(ctxWithUser(testUser().ID))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.NotContains(t, w.Body.String(), "password_hash")
+}
+
+// TestChangePasswordHandler_WrongPassword_Returns401 verifies AC8: incorrect
+// old password returns the appropriate error response.
+func TestChangePasswordHandler_WrongPassword_Returns401(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubChangePasswordService{err: message.ErrLoginInvalidCredentials}
+	handler := pfmhttp.ChangePasswordHandler(svc)
+
+	body := `{"old_password":"wrong","new_password":"newpass123","version":1}`
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/users/"+testUser().ID.String()+"/password", strings.NewReader(body))
+	r.SetPathValue("id", testUser().ID.String())
+	r = r.WithContext(ctxWithUser(testUser().ID))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestChangePasswordHandler_ValidationError_Returns400 verifies AC10: missing
+// fields return 400.
+func TestChangePasswordHandler_ValidationError_Returns400(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubChangePasswordService{
+		err: &validate.ValidationError{
+			Violations: []validate.Violation{
+				{Field: "old_password", Message: "is required"},
+				{Field: "new_password", Message: "is required"},
+			},
+		},
+	}
+	handler := pfmhttp.ChangePasswordHandler(svc)
+
+	body := `{"old_password":"","new_password":"","version":1}`
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/users/"+testUser().ID.String()+"/password", strings.NewReader(body))
+	r.SetPathValue("id", testUser().ID.String())
+	r = r.WithContext(ctxWithUser(testUser().ID))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestChangePasswordHandler_MalformedJSON_Returns400 verifies edge case.
+func TestChangePasswordHandler_MalformedJSON_Returns400(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubChangePasswordService{}
+	handler := pfmhttp.ChangePasswordHandler(svc)
+
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/users/"+testUser().ID.String()+"/password", strings.NewReader("{bad"))
+	r.SetPathValue("id", testUser().ID.String())
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestChangePasswordHandler_NilService_Panics verifies the nil guard.
+func TestChangePasswordHandler_NilService_Panics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { pfmhttp.ChangePasswordHandler(nil) })
+}
+
+// --- DeactivateUserHandler tests ---
+
+// stubDeactivateUserService is a test double for the deactivateUserService interface.
+type stubDeactivateUserService struct {
+	err error
+}
+
+func (s *stubDeactivateUserService) Deactivate(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+	return s.err
+}
+
+// TestDeactivateUserHandler_Success_Returns204 verifies AC9: deactivating a user
+// returns 204 No Content with an empty body.
+func TestDeactivateUserHandler_Success_Returns204(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubDeactivateUserService{}
+	handler := pfmhttp.DeactivateUserHandler(svc)
+
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+testUser().ID.String(), nil)
+	r.SetPathValue("id", testUser().ID.String())
+	r = r.WithContext(ctxWithUser(testUser().ID))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, w.Body.String())
+}
+
+// TestDeactivateUserHandler_NotFound_Returns404 verifies edge case: deactivating
+// a non-existent user returns 404.
+func TestDeactivateUserHandler_NotFound_Returns404(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubDeactivateUserService{err: message.ErrUserNotFound}
+	handler := pfmhttp.DeactivateUserHandler(svc)
+
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+uuid.Nil.String(), nil)
+	r.SetPathValue("id", uuid.Nil.String())
+	r = r.WithContext(ctxWithUser(testUser().ID))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestDeactivateUserHandler_InvalidUUID_Returns400 verifies edge case.
+func TestDeactivateUserHandler_InvalidUUID_Returns400(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubDeactivateUserService{}
+	handler := pfmhttp.DeactivateUserHandler(svc)
+
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/not-a-uuid", nil)
+	r.SetPathValue("id", "not-a-uuid")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestDeactivateUserHandler_NilService_Panics verifies the nil guard.
+func TestDeactivateUserHandler_NilService_Panics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { pfmhttp.DeactivateUserHandler(nil) })
+}


### PR DESCRIPTION
## Summary
- Add 5 REST handler factories for the User domain: Register, GetUser, UpdateProfile, ChangePassword, Deactivate
- Add `handleDomainError` helper for consistent ValidationError/domain error handling across handlers
- Add `userResponse` type to exclude `PasswordHash` from API responses
- Each handler uses narrow 1-method interface (interface segregation) and the shared response infrastructure from #122

## Test plan
- [x] `make ci` passes (lint + test -race + build)
- [x] `/project:verify-issue` verdict: PASS (all 11 acceptance criteria)
- [x] `/project:review` verdict: PASS (all 9 applicable categories)
- [x] 24 unit tests covering success, validation, domain errors, malformed input, invalid UUIDs, nil guards