### PR TITLE
feat(http): wire all routes and add E2E integration tests

### DIFF
--- a/cmd/pfm/main.go
+++ b/cmd/pfm/main.go
@@ -16,6 +16,10 @@ import (
 	pfmhttp "github.com/zambone/pfm-go/internal/adapter/http"
 	authadapter "github.com/zambone/pfm-go/internal/adapter/auth"
 	pgadapter "github.com/zambone/pfm-go/internal/adapter/postgres"
+	domainaccount "github.com/zambone/pfm-go/internal/domain/account"
+	domaincreditcard "github.com/zambone/pfm-go/internal/domain/creditcard"
+	domainhousehold "github.com/zambone/pfm-go/internal/domain/household"
+	domainledger "github.com/zambone/pfm-go/internal/domain/ledger"
 	domainuser "github.com/zambone/pfm-go/internal/domain/user"
 	"github.com/zambone/pfm-go/internal/message"
 	"github.com/zambone/pfm-go/internal/platform/clock"
@@ -90,29 +94,87 @@ func run() error {
 		return fmt.Errorf(message.ErrDBNewPool, err)
 	}
 
-	// Auth wiring.
-	userRepo := pgadapter.NewUserRepo(pool)
-	hasher := authadapter.NewArgon2idHasher(authadapter.DefaultArgon2idParams())
+	// --- Dependency wiring ---
 	realClock := clock.NewRealClock()
+	hasher := authadapter.NewArgon2idHasher(authadapter.DefaultArgon2idParams())
 	tokenSvc, err := authadapter.NewPasetoTokenService(cfg.TokenSecretKey, realClock)
 	if err != nil {
 		return fmt.Errorf(message.ErrRunTokenKey, err)
 	}
+	transactor := database.NewPostgresTransactor(pool)
+
+	// Repositories.
+	userRepo := pgadapter.NewUserRepo(pool)
+	householdRepo := pgadapter.NewHouseholdRepo(pool)
+	accountRepo := pgadapter.NewAccountRepo(pool)
+	ccSettingsRepo := pgadapter.NewCreditCardSettingsRepo(pool)
+	ledgerRepo := pgadapter.NewLedgerRepo(pool)
+
+	// Domain logic.
+	userLogic := domainuser.NewUserLogic(userRepo, hasher, realClock)
 	loginLogic := domainuser.NewLoginLogic(
-		userRepo,
-		hasher,
-		tokenSvc,
-		realClock,
+		userRepo, hasher, tokenSvc, realClock,
 		time.Duration(cfg.TokenExpirationSec)*time.Second,
 	)
+	householdLogic := domainhousehold.NewHouseholdLogic(householdRepo, transactor, realClock)
+	accountLogic := domainaccount.NewAccountLogic(accountRepo, realClock)
+	ccSettingsLogic := domaincreditcard.NewSettingsLogic(
+		ccSettingsRepo,
+		pfmhttp.NewAccountTypeFinder(accountRepo),
+		realClock,
+	)
+	ledgerLogic := domainledger.NewLedgerLogic(ledgerRepo, transactor, realClock)
+
+	// Thin adapters for middleware.
+	membershipFinder := pfmhttp.NewMembershipRoleFinder(householdRepo)
 
 	var shuttingDown atomic.Bool
 
 	mux := http.NewServeMux()
-	mux.Handle("GET /healthz", pfmhttp.HealthHandler(Version))
-	mux.Handle("GET /health/live", pfmhttp.LiveHandler())
-	mux.Handle("GET /health/ready", pfmhttp.ReadyHandler(&shuttingDown))
-	mux.Handle("POST /auth/login", pfmhttp.LoginHandler(loginLogic))
+	pfmhttp.RegisterRoutes(mux, pfmhttp.RouteDeps{
+		Version:        Version,
+		ShuttingDown:   &shuttingDown,
+		TokenValidator: tokenSvc,
+		MembershipFinder: membershipFinder,
+
+		// User
+		LoginSvc:          loginLogic,
+		RegisterSvc:       userLogic,
+		GetUserSvc:        userLogic,
+		UpdateProfileSvc:  userLogic,
+		ChangePasswordSvc: userLogic,
+		DeactivateUserSvc: userLogic,
+
+		// Household
+		CreateHouseholdSvc:     householdLogic,
+		GetHouseholdSvc:        householdLogic,
+		ListHouseholdsSvc:      householdLogic,
+		AddMemberSvc:           householdLogic,
+		RemoveMemberSvc:        householdLogic,
+		UpdateHouseholdNameSvc: householdLogic,
+		DeactivateHouseholdSvc: householdLogic,
+
+		// Account
+		CreateAccountSvc:        accountLogic,
+		GetAccountSvc:           accountLogic,
+		ListAccountsSvc:         accountLogic,
+		UpdateAccountNameSvc:    accountLogic,
+		UpdateAccountBalanceSvc: accountLogic,
+		DeactivateAccountSvc:    accountLogic,
+
+		// Credit Card Settings
+		CreateCCSettingsSvc:  ccSettingsLogic,
+		GetCCSettingsSvc:     ccSettingsLogic,
+		UpdateClosingDaySvc:  ccSettingsLogic,
+		UpdateDueDaySvc:      ccSettingsLogic,
+		UpdateCreditLimitSvc: ccSettingsLogic,
+		DeleteCCSettingsSvc:  ccSettingsLogic,
+
+		// Ledger
+		PostTransactionSvc:       ledgerLogic,
+		GetBalanceSvc:            ledgerLogic,
+		GetTransactionHistorySvc: ledgerLogic,
+	})
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.HTTPPort),

--- a/internal/adapter/http/e2e_integration_test.go
+++ b/internal/adapter/http/e2e_integration_test.go
@@ -1,0 +1,355 @@
+//go:build integration
+
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	pfmdb "github.com/zambone/pfm-go/db"
+	pfmhttp "github.com/zambone/pfm-go/internal/adapter/http"
+	authadapter "github.com/zambone/pfm-go/internal/adapter/auth"
+	pgadapter "github.com/zambone/pfm-go/internal/adapter/postgres"
+	domainaccount "github.com/zambone/pfm-go/internal/domain/account"
+	domaincreditcard "github.com/zambone/pfm-go/internal/domain/creditcard"
+	domainhousehold "github.com/zambone/pfm-go/internal/domain/household"
+	domainledger "github.com/zambone/pfm-go/internal/domain/ledger"
+	domainuser "github.com/zambone/pfm-go/internal/domain/user"
+	"github.com/zambone/pfm-go/internal/platform/clock"
+	"github.com/zambone/pfm-go/internal/platform/config"
+	"github.com/zambone/pfm-go/internal/platform/database"
+)
+
+// e2eEnv holds the fully wired test environment for E2E tests.
+type e2eEnv struct {
+	mux *http.ServeMux
+}
+
+// newE2EEnv spins up a Postgres testcontainer, runs migrations, and wires the
+// full application stack — repos, domain logic, middleware, and HTTP router.
+func newE2EEnv(t *testing.T, ctx context.Context) *e2eEnv {
+	t.Helper()
+
+	pool := newE2EPool(t, ctx)
+	realClock := clock.NewRealClock()
+	hasher := authadapter.NewArgon2idHasher(authadapter.DefaultArgon2idParams())
+	// 32-byte hex-encoded key for PASETO token service (decodes to 32 bytes).
+	tokenKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	tokenSvc, err := authadapter.NewPasetoTokenService(tokenKey, realClock)
+	require.NoError(t, err)
+	transactor := database.NewPostgresTransactor(pool)
+
+	// Repositories.
+	userRepo := pgadapter.NewUserRepo(pool)
+	householdRepo := pgadapter.NewHouseholdRepo(pool)
+	accountRepo := pgadapter.NewAccountRepo(pool)
+	ccSettingsRepo := pgadapter.NewCreditCardSettingsRepo(pool)
+	ledgerRepo := pgadapter.NewLedgerRepo(pool)
+
+	// Domain logic.
+	userLogic := domainuser.NewUserLogic(userRepo, hasher, realClock)
+	loginLogic := domainuser.NewLoginLogic(
+		userRepo, hasher, tokenSvc, realClock,
+		15*time.Minute,
+	)
+	householdLogic := domainhousehold.NewHouseholdLogic(householdRepo, transactor, realClock)
+	accountLogic := domainaccount.NewAccountLogic(accountRepo, realClock)
+	ccSettingsLogic := domaincreditcard.NewSettingsLogic(
+		ccSettingsRepo,
+		pfmhttp.NewAccountTypeFinder(accountRepo),
+		realClock,
+	)
+	ledgerLogic := domainledger.NewLedgerLogic(ledgerRepo, transactor, realClock)
+
+	membershipFinder := pfmhttp.NewMembershipRoleFinder(householdRepo)
+
+	var shuttingDown atomic.Bool
+	mux := http.NewServeMux()
+	pfmhttp.RegisterRoutes(mux, pfmhttp.RouteDeps{
+		Version:      "test",
+		ShuttingDown: &shuttingDown,
+
+		TokenValidator:   tokenSvc,
+		MembershipFinder: membershipFinder,
+
+		LoginSvc:          loginLogic,
+		RegisterSvc:       userLogic,
+		GetUserSvc:        userLogic,
+		UpdateProfileSvc:  userLogic,
+		ChangePasswordSvc: userLogic,
+		DeactivateUserSvc: userLogic,
+
+		CreateHouseholdSvc:     householdLogic,
+		GetHouseholdSvc:        householdLogic,
+		ListHouseholdsSvc:      householdLogic,
+		AddMemberSvc:           householdLogic,
+		RemoveMemberSvc:        householdLogic,
+		UpdateHouseholdNameSvc: householdLogic,
+		DeactivateHouseholdSvc: householdLogic,
+
+		CreateAccountSvc:        accountLogic,
+		GetAccountSvc:           accountLogic,
+		ListAccountsSvc:         accountLogic,
+		UpdateAccountNameSvc:    accountLogic,
+		UpdateAccountBalanceSvc: accountLogic,
+		DeactivateAccountSvc:    accountLogic,
+
+		CreateCCSettingsSvc:  ccSettingsLogic,
+		GetCCSettingsSvc:     ccSettingsLogic,
+		UpdateClosingDaySvc:  ccSettingsLogic,
+		UpdateDueDaySvc:      ccSettingsLogic,
+		UpdateCreditLimitSvc: ccSettingsLogic,
+		DeleteCCSettingsSvc:  ccSettingsLogic,
+
+		PostTransactionSvc:       ledgerLogic,
+		GetBalanceSvc:            ledgerLogic,
+		GetTransactionHistorySvc: ledgerLogic,
+	})
+
+	return &e2eEnv{mux: mux}
+}
+
+// newE2EPool creates a testcontainers PostgreSQL instance with migrations applied.
+func newE2EPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+
+	ctr, err := tcpostgres.Run(ctx,
+		"postgres:18-alpine3.23",
+		tcpostgres.WithDatabase("testdb"),
+		tcpostgres.WithUsername("testuser"),
+		tcpostgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2),
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ctr.Terminate(ctx) })
+
+	host, err := ctr.Host(ctx)
+	require.NoError(t, err)
+	mappedPort, err := ctr.MappedPort(ctx, "5432")
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		DatabaseHost:           host,
+		DatabasePort:           mappedPort.Int(),
+		DatabaseName:           "testdb",
+		DatabaseUser:           "testuser",
+		DatabasePassword:       "testpass",
+		DatabaseSSLMode:        "disable",
+		DBConnectTimeoutSec:    5,
+		DBStartupRetries:       3,
+		DBStartupRetryDelaySec: 1,
+		DBMaxOpenConns:         5,
+		DBMaxIdleConns:         2,
+		DBConnMaxLifetimeSec:   60,
+		DBConnMaxIdleTimeSec:   30,
+	}
+
+	sqlDB, err := database.Open(ctx, cfg)
+	require.NoError(t, err)
+	sub, err := fs.Sub(pfmdb.Migrations, "migrations")
+	require.NoError(t, err)
+	require.NoError(t, database.Migrate(ctx, sqlDB, sub))
+	require.NoError(t, sqlDB.Close())
+
+	pool, err := database.NewPool(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	return pool
+}
+
+// do sends an HTTP request to the mux and returns the recorder.
+func (e *e2eEnv) do(t *testing.T, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var reqBody *bytes.Buffer
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reqBody = bytes.NewBuffer(b)
+	} else {
+		reqBody = &bytes.Buffer{}
+	}
+
+	r := httptest.NewRequest(method, path, reqBody)
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	w := httptest.NewRecorder()
+	e.mux.ServeHTTP(w, r)
+	return w
+}
+
+// decodeJSON decodes a JSON response into a map.
+func decodeJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&m))
+	return m
+}
+
+// TestE2E_FullWorkflow verifies AC5 and AC6: a full register → login → create
+// household → create account → post transaction workflow against a real database.
+func TestE2E_FullWorkflow(t *testing.T) {
+	ctx := context.Background()
+	env := newE2EEnv(t, ctx)
+
+	// Step 1: Register a user.
+	w := env.do(t, http.MethodPost, "/api/v1/users", map[string]string{
+		"email":        "alice@example.com",
+		"display_name": "Alice",
+		"password":     "secret1234",
+	}, "")
+	require.Equal(t, http.StatusCreated, w.Code, "register failed: %s", w.Body.String())
+	user := decodeJSON(t, w)
+	userID := user["id"].(string)
+	assert.NotEmpty(t, userID)
+
+	// Step 2: Login.
+	w = env.do(t, http.MethodPost, "/auth/login", map[string]string{
+		"email":    "alice@example.com",
+		"password": "secret1234",
+	}, "")
+	require.Equal(t, http.StatusOK, w.Code, "login failed: %s", w.Body.String())
+	loginResp := decodeJSON(t, w)
+	token := loginResp["token"].(string)
+	assert.NotEmpty(t, token)
+
+	// Step 3: Create a household.
+	w = env.do(t, http.MethodPost, "/api/v1/households", map[string]string{
+		"name": "Alice's Home",
+	}, token)
+	require.Equal(t, http.StatusCreated, w.Code, "create household failed: %s", w.Body.String())
+	household := decodeJSON(t, w)
+	householdID := household["id"].(string)
+	assert.Equal(t, "Alice's Home", household["name"])
+
+	// Step 4: Create a checking account.
+	w = env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/accounts", map[string]string{
+		"name":          "Checking",
+		"account_type":  "CHECKING",
+		"currency_code": "BRL",
+	}, token)
+	require.Equal(t, http.StatusCreated, w.Code, "create account failed: %s", w.Body.String())
+	account1 := decodeJSON(t, w)
+	account1ID := account1["id"].(string)
+	assert.Equal(t, "Checking", account1["name"])
+
+	// Step 5: Create a savings account (for balanced transaction).
+	w = env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/accounts", map[string]string{
+		"name":          "Savings",
+		"account_type":  "SAVINGS",
+		"currency_code": "BRL",
+	}, token)
+	require.Equal(t, http.StatusCreated, w.Code, "create savings failed: %s", w.Body.String())
+	account2 := decodeJSON(t, w)
+	account2ID := account2["id"].(string)
+
+	// Step 6: Post a balanced transaction.
+	w = env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/transactions", map[string]any{
+		"description":      "Transfer to savings",
+		"transaction_date": "2026-03-15",
+		"entries": []map[string]any{
+			{"account_id": account1ID, "entry_type": "DEBIT", "amount": 10000},
+			{"account_id": account2ID, "entry_type": "CREDIT", "amount": 10000},
+		},
+	}, token)
+	require.Equal(t, http.StatusCreated, w.Code, "post transaction failed: %s", w.Body.String())
+	txn := decodeJSON(t, w)
+	assert.Equal(t, "Transfer to savings", txn["description"])
+	entries, ok := txn["entries"].([]any)
+	require.True(t, ok)
+	assert.Len(t, entries, 2)
+
+	// Step 7: Verify account balances.
+	w = env.do(t, http.MethodGet, "/api/v1/households/"+householdID+"/accounts/"+account1ID+"/balance", nil, token)
+	require.Equal(t, http.StatusOK, w.Code)
+	bal1 := decodeJSON(t, w)
+	assert.Equal(t, float64(-10000), bal1["balance"]) // debit reduces balance
+
+	w = env.do(t, http.MethodGet, "/api/v1/households/"+householdID+"/accounts/"+account2ID+"/balance", nil, token)
+	require.Equal(t, http.StatusOK, w.Code)
+	bal2 := decodeJSON(t, w)
+	assert.Equal(t, float64(10000), bal2["balance"]) // credit increases balance
+
+	// Step 8: Get transaction history.
+	w = env.do(t, http.MethodGet, "/api/v1/households/"+householdID+"/transactions", nil, token)
+	require.Equal(t, http.StatusOK, w.Code)
+	var history []map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&history))
+	assert.Len(t, history, 1)
+}
+
+// TestE2E_UnauthenticatedRequest_Returns401 verifies AC2 against the full stack.
+func TestE2E_UnauthenticatedRequest_Returns401(t *testing.T) {
+	ctx := context.Background()
+	env := newE2EEnv(t, ctx)
+
+	w := env.do(t, http.MethodGet, "/api/v1/households", nil, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestE2E_NonMemberAccess_Returns403 verifies AC3: a user who is not a member
+// of the household gets 403 Forbidden.
+func TestE2E_NonMemberAccess_Returns403(t *testing.T) {
+	ctx := context.Background()
+	env := newE2EEnv(t, ctx)
+
+	// Register user A and get token.
+	w := env.do(t, http.MethodPost, "/api/v1/users", map[string]string{
+		"email": "a@example.com", "display_name": "Alice", "password": "secret1234",
+	}, "")
+	require.Equal(t, http.StatusCreated, w.Code, "register A: %s", w.Body.String())
+
+	w = env.do(t, http.MethodPost, "/auth/login", map[string]string{
+		"email": "a@example.com", "password": "secret1234",
+	}, "")
+	require.Equal(t, http.StatusOK, w.Code, "login A: %s", w.Body.String())
+	loginA := decodeJSON(t, w)
+	tokenA, ok := loginA["token"].(string)
+	require.True(t, ok, "login A response missing token: %v", loginA)
+
+	// User A creates a household.
+	w = env.do(t, http.MethodPost, "/api/v1/households", map[string]string{
+		"name": "A's House",
+	}, tokenA)
+	require.Equal(t, http.StatusCreated, w.Code, "create household: %s", w.Body.String())
+	houseResp := decodeJSON(t, w)
+	householdID, ok := houseResp["id"].(string)
+	require.True(t, ok, "household response missing id: %v", houseResp)
+
+	// Register user B and get token.
+	w = env.do(t, http.MethodPost, "/api/v1/users", map[string]string{
+		"email": "b@example.com", "display_name": "Bob", "password": "secret1234",
+	}, "")
+	require.Equal(t, http.StatusCreated, w.Code, "register B: %s", w.Body.String())
+
+	w = env.do(t, http.MethodPost, "/auth/login", map[string]string{
+		"email": "b@example.com", "password": "secret1234",
+	}, "")
+	require.Equal(t, http.StatusOK, w.Code, "login B: %s", w.Body.String())
+	loginB := decodeJSON(t, w)
+	tokenB, ok := loginB["token"].(string)
+	require.True(t, ok, "login B response missing token: %v", loginB)
+
+	// User B tries to access A's household → 403.
+	w = env.do(t, http.MethodGet, "/api/v1/households/"+householdID, nil, tokenB)
+	require.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/internal/adapter/http/routes.go
+++ b/internal/adapter/http/routes.go
@@ -1,0 +1,191 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/google/uuid"
+
+	domainacct "github.com/zambone/pfm-go/internal/domain/account"
+	domainhouse "github.com/zambone/pfm-go/internal/domain/household"
+	"github.com/zambone/pfm-go/internal/middleware"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+// tokenValidator abstracts token validation for the authn middleware.
+// Structurally satisfied by adapter/auth.PasetoTokenService.
+type tokenValidator interface {
+	Validate(ctx context.Context, token string) (uuid.UUID, error)
+}
+
+// roleFinder abstracts membership role lookup for the authz middleware.
+// Structurally satisfied by MembershipRoleFinder.
+type roleFinder interface {
+	FindRole(ctx context.Context, householdID, userID uuid.UUID) (types.Role, error)
+}
+
+// RouteDeps carries all dependencies needed to register HTTP routes.
+// Each field corresponds to a narrow service interface consumed by a single handler.
+type RouteDeps struct {
+	Version      string
+	ShuttingDown *atomic.Bool
+
+	// Auth
+	TokenValidator tokenValidator
+	MembershipFinder roleFinder
+
+	// User handlers
+	LoginSvc          loginService
+	RegisterSvc       registerService
+	GetUserSvc        getUserService
+	UpdateProfileSvc  updateProfileService
+	ChangePasswordSvc changePasswordService
+	DeactivateUserSvc deactivateUserService
+
+	// Household handlers
+	CreateHouseholdSvc     createHouseholdService
+	GetHouseholdSvc        getHouseholdService
+	ListHouseholdsSvc      listHouseholdsService
+	AddMemberSvc           addMemberService
+	RemoveMemberSvc        removeMemberService
+	UpdateHouseholdNameSvc updateHouseholdNameService
+	DeactivateHouseholdSvc deactivateHouseholdService
+
+	// Account handlers
+	CreateAccountSvc        createAccountService
+	GetAccountSvc           getAccountService
+	ListAccountsSvc         listAccountsService
+	UpdateAccountNameSvc    updateAccountNameService
+	UpdateAccountBalanceSvc updateAccountBalanceService
+	DeactivateAccountSvc    deactivateAccountService
+
+	// Credit card settings handlers
+	CreateCCSettingsSvc createCCSettingsService
+	GetCCSettingsSvc    getCCSettingsService
+	UpdateClosingDaySvc updateClosingDayService
+	UpdateDueDaySvc     updateDueDayService
+	UpdateCreditLimitSvc updateCreditLimitService
+	DeleteCCSettingsSvc  deleteCCSettingsService
+
+	// Ledger handlers
+	PostTransactionSvc       postTransactionService
+	GetBalanceSvc            getBalanceService
+	GetTransactionHistorySvc getTransactionHistoryService
+}
+
+// RegisterRoutes registers all HTTP endpoints on the given mux with the appropriate
+// middleware chains. Routes follow RESTful conventions under /api/v1/ with household
+// scoping for resource endpoints.
+func RegisterRoutes(mux *http.ServeMux, d RouteDeps) {
+	authn := middleware.Authn(d.TokenValidator)
+	guard := middleware.HouseholdGuard(d.MembershipFinder, "household_id")
+	adminGuard := middleware.HouseholdAdminGuard(d.MembershipFinder, "household_id")
+
+	// --- Health (public) ---
+	mux.Handle("GET /healthz", HealthHandler(d.Version))
+	mux.Handle("GET /health/live", LiveHandler())
+	mux.Handle("GET /health/ready", ReadyHandler(d.ShuttingDown))
+
+	// --- Auth (public) ---
+	mux.Handle("POST /auth/login", LoginHandler(d.LoginSvc))
+
+	// --- Users ---
+	// Registration is public (no auth needed to create an account).
+	mux.Handle("POST /api/v1/users", RegisterHandler(d.RegisterSvc))
+	// All other user endpoints require authentication.
+	mux.Handle("GET /api/v1/users/{id}", authn(GetUserHandler(d.GetUserSvc)))
+	mux.Handle("PUT /api/v1/users/{id}", authn(UpdateProfileHandler(d.UpdateProfileSvc)))
+	mux.Handle("PUT /api/v1/users/{id}/password", authn(ChangePasswordHandler(d.ChangePasswordSvc)))
+	mux.Handle("DELETE /api/v1/users/{id}", authn(DeactivateUserHandler(d.DeactivateUserSvc)))
+
+	// --- Households ---
+	// Create and list require authentication but no household guard (user doesn't belong yet).
+	mux.Handle("POST /api/v1/households", authn(CreateHouseholdHandler(d.CreateHouseholdSvc)))
+	mux.Handle("GET /api/v1/households", authn(ListHouseholdsHandler(d.ListHouseholdsSvc)))
+	// Household-scoped: require membership via guard.
+	mux.Handle("GET /api/v1/households/{household_id}", authn(guard(GetHouseholdHandler(d.GetHouseholdSvc))))
+	mux.Handle("PUT /api/v1/households/{household_id}", authn(adminGuard(UpdateHouseholdNameHandler(d.UpdateHouseholdNameSvc))))
+	mux.Handle("DELETE /api/v1/households/{household_id}", authn(adminGuard(DeactivateHouseholdHandler(d.DeactivateHouseholdSvc))))
+
+	// --- Members ---
+	mux.Handle("POST /api/v1/households/{household_id}/members", authn(adminGuard(AddMemberHandler(d.AddMemberSvc))))
+	mux.Handle("DELETE /api/v1/households/{household_id}/members/{user_id}", authn(adminGuard(RemoveMemberHandler(d.RemoveMemberSvc))))
+
+	// --- Accounts ---
+	mux.Handle("POST /api/v1/households/{household_id}/accounts", authn(guard(CreateAccountHandler(d.CreateAccountSvc))))
+	mux.Handle("GET /api/v1/households/{household_id}/accounts", authn(guard(ListAccountsHandler(d.ListAccountsSvc))))
+	mux.Handle("GET /api/v1/households/{household_id}/accounts/{id}", authn(guard(GetAccountHandler(d.GetAccountSvc))))
+	mux.Handle("PUT /api/v1/households/{household_id}/accounts/{id}/name", authn(guard(UpdateAccountNameHandler(d.UpdateAccountNameSvc))))
+	mux.Handle("PUT /api/v1/households/{household_id}/accounts/{id}/balance", authn(guard(UpdateAccountBalanceHandler(d.UpdateAccountBalanceSvc))))
+	mux.Handle("DELETE /api/v1/households/{household_id}/accounts/{id}", authn(guard(DeactivateAccountHandler(d.DeactivateAccountSvc))))
+
+	// --- Credit Card Settings ---
+	mux.Handle("POST /api/v1/households/{household_id}/accounts/{account_id}/credit-card-settings", authn(guard(CreateCreditCardSettingsHandler(d.CreateCCSettingsSvc))))
+	mux.Handle("GET /api/v1/households/{household_id}/accounts/{account_id}/credit-card-settings", authn(guard(GetCreditCardSettingsHandler(d.GetCCSettingsSvc))))
+	mux.Handle("PUT /api/v1/households/{household_id}/accounts/{account_id}/credit-card-settings/closing-day", authn(guard(UpdateClosingDayHandler(d.UpdateClosingDaySvc))))
+	mux.Handle("PUT /api/v1/households/{household_id}/accounts/{account_id}/credit-card-settings/due-day", authn(guard(UpdateDueDayHandler(d.UpdateDueDaySvc))))
+	mux.Handle("PUT /api/v1/households/{household_id}/accounts/{account_id}/credit-card-settings/limit", authn(guard(UpdateCreditLimitHandler(d.UpdateCreditLimitSvc))))
+	mux.Handle("DELETE /api/v1/households/{household_id}/accounts/{account_id}/credit-card-settings", authn(guard(DeleteCreditCardSettingsHandler(d.DeleteCCSettingsSvc))))
+
+	// --- Ledger ---
+	mux.Handle("POST /api/v1/households/{household_id}/transactions", authn(guard(PostTransactionHandler(d.PostTransactionSvc))))
+	mux.Handle("GET /api/v1/households/{household_id}/transactions", authn(guard(GetTransactionHistoryHandler(d.GetTransactionHistorySvc))))
+	mux.Handle("GET /api/v1/households/{household_id}/accounts/{account_id}/balance", authn(guard(GetBalanceHandler(d.GetBalanceSvc))))
+}
+
+// MembershipRoleFinder adapts a household membership lookup to the narrow FindRole
+// interface required by the authz middleware. It wraps FindMembership and extracts the role.
+type MembershipRoleFinder struct {
+	finder membershipLookup
+}
+
+// membershipLookup is the subset of HouseholdRepo required by MembershipRoleFinder.
+type membershipLookup interface {
+	FindMembership(ctx context.Context, householdID, userID uuid.UUID) (domainhouse.Membership, error)
+}
+
+// NewMembershipRoleFinder creates a MembershipRoleFinder. Panics if finder is nil.
+func NewMembershipRoleFinder(finder membershipLookup) *MembershipRoleFinder {
+	if finder == nil {
+		panic("http: NewMembershipRoleFinder requires non-nil membershipLookup")
+	}
+	return &MembershipRoleFinder{finder: finder}
+}
+
+// FindRole returns the role of a user within a household.
+func (m *MembershipRoleFinder) FindRole(ctx context.Context, householdID, userID uuid.UUID) (types.Role, error) {
+	membership, err := m.finder.FindMembership(ctx, householdID, userID)
+	if err != nil {
+		return "", err
+	}
+	return membership.Role, nil
+}
+
+// AccountTypeFinder adapts an account lookup to the narrow FindAccountType
+// interface required by the creditcard domain. It wraps FindByID and extracts the type.
+type AccountTypeFinder struct {
+	finder accountLookup
+}
+
+// accountLookup is the subset of AccountRepo required by AccountTypeFinder.
+type accountLookup interface {
+	FindByID(ctx context.Context, id uuid.UUID) (domainacct.Account, error)
+}
+
+// NewAccountTypeFinder creates an AccountTypeFinder. Panics if finder is nil.
+func NewAccountTypeFinder(finder accountLookup) *AccountTypeFinder {
+	if finder == nil {
+		panic("http: NewAccountTypeFinder requires non-nil accountLookup")
+	}
+	return &AccountTypeFinder{finder: finder}
+}
+
+// FindAccountType returns the account type for the given account ID.
+func (a *AccountTypeFinder) FindAccountType(ctx context.Context, accountID uuid.UUID) (types.AccountType, error) {
+	acct, err := a.finder.FindByID(ctx, accountID)
+	if err != nil {
+		return "", err
+	}
+	return acct.AccountType, nil
+}

--- a/internal/adapter/http/routes_test.go
+++ b/internal/adapter/http/routes_test.go
@@ -1,0 +1,335 @@
+package http_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pfmhttp "github.com/zambone/pfm-go/internal/adapter/http"
+	domainacct "github.com/zambone/pfm-go/internal/domain/account"
+	domaincc "github.com/zambone/pfm-go/internal/domain/creditcard"
+	domainhouse "github.com/zambone/pfm-go/internal/domain/household"
+	domainledger "github.com/zambone/pfm-go/internal/domain/ledger"
+	domainuser "github.com/zambone/pfm-go/internal/domain/user"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+// --- Stub that satisfies all handler service interfaces for route registration ---
+
+// allServicesStub implements every service interface used by every handler,
+// allowing RegisterRoutes to wire without real dependencies.
+type allServicesStub struct{}
+
+func (s *allServicesStub) Login(_ context.Context, _, _ string) (domainuser.LoginResult, error) {
+	return domainuser.LoginResult{}, nil
+}
+func (s *allServicesStub) Register(_ context.Context, _ domainuser.RegisterInput, _ uuid.UUID) (domainuser.User, error) {
+	return domainuser.User{}, nil
+}
+func (s *allServicesStub) FindByID(_ context.Context, _ uuid.UUID) (domainuser.User, error) {
+	return domainuser.User{}, nil
+}
+func (s *allServicesStub) UpdateProfile(_ context.Context, _ uuid.UUID, _ domainuser.UpdateProfileInput, _ int, _ uuid.UUID) (domainuser.User, error) {
+	return domainuser.User{}, nil
+}
+func (s *allServicesStub) ChangePassword(_ context.Context, _ uuid.UUID, _ domainuser.ChangePasswordInput, _ int, _ uuid.UUID) (domainuser.User, error) {
+	return domainuser.User{}, nil
+}
+func (s *allServicesStub) Deactivate(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+	return nil
+}
+
+// tokenValidatorStub satisfies the tokenValidator interface for authn middleware.
+type tokenValidatorStub struct{}
+
+func (s *tokenValidatorStub) Validate(_ context.Context, _ string) (uuid.UUID, error) {
+	return uuid.Nil, nil
+}
+
+// membershipFinderStub satisfies the membershipFinder interface for authz middleware.
+type membershipFinderStub struct{}
+
+func (s *membershipFinderStub) FindRole(_ context.Context, _, _ uuid.UUID) (types.Role, error) {
+	return types.RoleAdmin, nil
+}
+
+// householdServiceStub satisfies all household handler interfaces.
+type householdServiceStub struct{}
+
+func (s *householdServiceStub) Create(_ context.Context, _ domainhouse.CreateInput, _ uuid.UUID) (domainhouse.Household, error) {
+	return domainhouse.Household{}, nil
+}
+func (s *householdServiceStub) FindByID(_ context.Context, _ uuid.UUID) (domainhouse.Household, error) {
+	return domainhouse.Household{}, nil
+}
+func (s *householdServiceStub) ListForUser(_ context.Context, _ uuid.UUID) ([]domainhouse.Household, error) {
+	return []domainhouse.Household{}, nil
+}
+func (s *householdServiceStub) AddMember(_ context.Context, _ uuid.UUID, _ domainhouse.AddMemberInput, _ uuid.UUID) (domainhouse.Membership, error) {
+	return domainhouse.Membership{}, nil
+}
+func (s *householdServiceStub) RemoveMember(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ uuid.UUID) error {
+	return nil
+}
+func (s *householdServiceStub) UpdateName(_ context.Context, _ uuid.UUID, _ domainhouse.UpdateNameInput, _ int, _ uuid.UUID) (domainhouse.Household, error) {
+	return domainhouse.Household{}, nil
+}
+
+func (s *householdServiceStub) Deactivate(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+	return nil
+}
+
+// accountServiceStub satisfies all account handler interfaces.
+type accountServiceStub struct{}
+
+func (s *accountServiceStub) Create(_ context.Context, _ uuid.UUID, _ domainacct.CreateInput, _ uuid.UUID) (domainacct.Account, error) {
+	return domainacct.Account{}, nil
+}
+func (s *accountServiceStub) FindByID(_ context.Context, _ uuid.UUID) (domainacct.Account, error) {
+	return domainacct.Account{}, nil
+}
+func (s *accountServiceStub) ListForHousehold(_ context.Context, _ uuid.UUID) ([]domainacct.Account, error) {
+	return []domainacct.Account{}, nil
+}
+func (s *accountServiceStub) UpdateName(_ context.Context, _ uuid.UUID, _ domainacct.UpdateNameInput, _ int, _ uuid.UUID) (domainacct.Account, error) {
+	return domainacct.Account{}, nil
+}
+func (s *accountServiceStub) UpdateBalance(_ context.Context, _ uuid.UUID, _ domainacct.UpdateBalanceInput, _ int, _ uuid.UUID) (domainacct.Account, error) {
+	return domainacct.Account{}, nil
+}
+
+func (s *accountServiceStub) Deactivate(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+	return nil
+}
+
+// ccSettingsServiceStub satisfies all credit card settings handler interfaces.
+type ccSettingsServiceStub struct{}
+
+func (s *ccSettingsServiceStub) Create(_ context.Context, _ uuid.UUID, _ domaincc.CreateInput, _ uuid.UUID) (domaincc.Settings, error) {
+	return domaincc.Settings{}, nil
+}
+func (s *ccSettingsServiceStub) FindByAccountID(_ context.Context, _ uuid.UUID) (domaincc.Settings, error) {
+	return domaincc.Settings{}, nil
+}
+func (s *ccSettingsServiceStub) UpdateClosingDay(_ context.Context, _ uuid.UUID, _ domaincc.UpdateClosingDayInput, _ int, _ uuid.UUID) (domaincc.Settings, error) {
+	return domaincc.Settings{}, nil
+}
+func (s *ccSettingsServiceStub) UpdateDueDay(_ context.Context, _ uuid.UUID, _ domaincc.UpdateDueDayInput, _ int, _ uuid.UUID) (domaincc.Settings, error) {
+	return domaincc.Settings{}, nil
+}
+func (s *ccSettingsServiceStub) UpdateLimit(_ context.Context, _ uuid.UUID, _ domaincc.UpdateLimitInput, _ int, _ uuid.UUID) (domaincc.Settings, error) {
+	return domaincc.Settings{}, nil
+}
+func (s *ccSettingsServiceStub) Delete(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+	return nil
+}
+
+// ledgerServiceStub satisfies all ledger handler interfaces.
+type ledgerServiceStub struct{}
+
+func (s *ledgerServiceStub) PostTransaction(_ context.Context, _ uuid.UUID, _ domainledger.PostTransactionInput, _ uuid.UUID) (domainledger.Transaction, []domainledger.Entry, error) {
+	return domainledger.Transaction{}, nil, nil
+}
+func (s *ledgerServiceStub) GetBalance(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+func (s *ledgerServiceStub) GetTransactionHistory(_ context.Context, _ uuid.UUID, _ domainledger.HistoryQuery) ([]domainledger.TransactionWithEntries, error) {
+	return []domainledger.TransactionWithEntries{}, nil
+}
+
+// buildTestDeps creates a RouteDeps with all stubs for route registration testing.
+func buildTestDeps() pfmhttp.RouteDeps {
+	var shuttingDown atomic.Bool
+	userSvc := &allServicesStub{}
+	houseSvc := &householdServiceStub{}
+	acctSvc := &accountServiceStub{}
+	ccSvc := &ccSettingsServiceStub{}
+	ledgerSvc := &ledgerServiceStub{}
+
+	return pfmhttp.RouteDeps{
+		Version:        "test",
+		ShuttingDown:   &shuttingDown,
+		TokenValidator: &tokenValidatorStub{},
+		MembershipFinder: &membershipFinderStub{},
+		LoginSvc:       userSvc,
+		RegisterSvc:    userSvc,
+		GetUserSvc:     userSvc,
+		UpdateProfileSvc:    userSvc,
+		ChangePasswordSvc:   userSvc,
+		DeactivateUserSvc:   userSvc,
+		CreateHouseholdSvc:  houseSvc,
+		GetHouseholdSvc:     houseSvc,
+		ListHouseholdsSvc:   houseSvc,
+		AddMemberSvc:        houseSvc,
+		RemoveMemberSvc:     houseSvc,
+		UpdateHouseholdNameSvc:    houseSvc,
+		DeactivateHouseholdSvc:    houseSvc,
+		CreateAccountSvc:          acctSvc,
+		GetAccountSvc:             acctSvc,
+		ListAccountsSvc:           acctSvc,
+		UpdateAccountNameSvc:      acctSvc,
+		UpdateAccountBalanceSvc:   acctSvc,
+		DeactivateAccountSvc:      acctSvc,
+		CreateCCSettingsSvc:       ccSvc,
+		GetCCSettingsSvc:          ccSvc,
+		UpdateClosingDaySvc:       ccSvc,
+		UpdateDueDaySvc:           ccSvc,
+		UpdateCreditLimitSvc:      ccSvc,
+		DeleteCCSettingsSvc:       ccSvc,
+		PostTransactionSvc:        ledgerSvc,
+		GetBalanceSvc:             ledgerSvc,
+		GetTransactionHistorySvc:  ledgerSvc,
+	}
+}
+
+// TestRegisterRoutes_EndpointsReachable verifies AC1: all domain endpoints are
+// registered under /api/v1/ with appropriate HTTP methods.
+func TestRegisterRoutes_EndpointsReachable(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	pfmhttp.RegisterRoutes(mux, buildTestDeps())
+
+	hid := uuid.New().String()
+	aid := uuid.New().String()
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int // just check it's NOT 404/405
+	}{
+		// Health
+		{"healthz", http.MethodGet, "/healthz", http.StatusOK},
+		{"liveness", http.MethodGet, "/health/live", http.StatusOK},
+		{"readiness", http.MethodGet, "/health/ready", http.StatusOK},
+
+		// Auth (public)
+		{"login", http.MethodPost, "/auth/login", http.StatusBadRequest}, // no body → 400, but route matched
+
+		// Users (public registration)
+		{"register", http.MethodPost, "/api/v1/users", http.StatusBadRequest},
+
+		// Users (authn required → 401 without token)
+		{"get user", http.MethodGet, "/api/v1/users/" + uuid.New().String(), http.StatusUnauthorized},
+		{"update profile", http.MethodPut, "/api/v1/users/" + uuid.New().String(), http.StatusUnauthorized},
+		{"change password", http.MethodPut, "/api/v1/users/" + uuid.New().String() + "/password", http.StatusUnauthorized},
+		{"deactivate user", http.MethodDelete, "/api/v1/users/" + uuid.New().String(), http.StatusUnauthorized},
+
+		// Households (authn required)
+		{"create household", http.MethodPost, "/api/v1/households", http.StatusUnauthorized},
+		{"list households", http.MethodGet, "/api/v1/households", http.StatusUnauthorized},
+
+		// Household-scoped (authn + guard)
+		{"get household", http.MethodGet, "/api/v1/households/" + hid, http.StatusUnauthorized},
+		{"update household name", http.MethodPut, "/api/v1/households/" + hid, http.StatusUnauthorized},
+		{"deactivate household", http.MethodDelete, "/api/v1/households/" + hid, http.StatusUnauthorized},
+		{"add member", http.MethodPost, "/api/v1/households/" + hid + "/members", http.StatusUnauthorized},
+		{"remove member", http.MethodDelete, "/api/v1/households/" + hid + "/members/" + uuid.New().String(), http.StatusUnauthorized},
+
+		// Accounts
+		{"create account", http.MethodPost, "/api/v1/households/" + hid + "/accounts", http.StatusUnauthorized},
+		{"list accounts", http.MethodGet, "/api/v1/households/" + hid + "/accounts", http.StatusUnauthorized},
+		{"get account", http.MethodGet, "/api/v1/households/" + hid + "/accounts/" + aid, http.StatusUnauthorized},
+		{"update account name", http.MethodPut, "/api/v1/households/" + hid + "/accounts/" + aid + "/name", http.StatusUnauthorized},
+		{"update account balance", http.MethodPut, "/api/v1/households/" + hid + "/accounts/" + aid + "/balance", http.StatusUnauthorized},
+		{"deactivate account", http.MethodDelete, "/api/v1/households/" + hid + "/accounts/" + aid, http.StatusUnauthorized},
+
+		// Credit card settings
+		{"create cc settings", http.MethodPost, "/api/v1/households/" + hid + "/accounts/" + aid + "/credit-card-settings", http.StatusUnauthorized},
+		{"get cc settings", http.MethodGet, "/api/v1/households/" + hid + "/accounts/" + aid + "/credit-card-settings", http.StatusUnauthorized},
+		{"update closing day", http.MethodPut, "/api/v1/households/" + hid + "/accounts/" + aid + "/credit-card-settings/closing-day", http.StatusUnauthorized},
+		{"update due day", http.MethodPut, "/api/v1/households/" + hid + "/accounts/" + aid + "/credit-card-settings/due-day", http.StatusUnauthorized},
+		{"update credit limit", http.MethodPut, "/api/v1/households/" + hid + "/accounts/" + aid + "/credit-card-settings/limit", http.StatusUnauthorized},
+		{"delete cc settings", http.MethodDelete, "/api/v1/households/" + hid + "/accounts/" + aid + "/credit-card-settings", http.StatusUnauthorized},
+
+		// Ledger
+		{"post transaction", http.MethodPost, "/api/v1/households/" + hid + "/transactions", http.StatusUnauthorized},
+		{"get history", http.MethodGet, "/api/v1/households/" + hid + "/transactions", http.StatusUnauthorized},
+		{"get balance", http.MethodGet, "/api/v1/households/" + hid + "/accounts/" + aid + "/balance", http.StatusUnauthorized},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequest(tc.method, tc.path, nil)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, r)
+
+			// The route is reachable — NOT a 404 (unmatched route) or 405 (wrong method)
+			assert.Equal(t, tc.wantStatus, w.Code,
+				"route %s %s returned unexpected status", tc.method, tc.path)
+		})
+	}
+}
+
+// TestRegisterRoutes_UnauthenticatedProtectedEndpoint_Returns401 verifies AC2:
+// unauthenticated requests to protected endpoints get 401.
+func TestRegisterRoutes_UnauthenticatedProtectedEndpoint_Returns401(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	pfmhttp.RegisterRoutes(mux, buildTestDeps())
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/households", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestRegisterRoutes_NonExistentRoute_Returns404 verifies edge case.
+func TestRegisterRoutes_NonExistentRoute_Returns404(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	pfmhttp.RegisterRoutes(mux, buildTestDeps())
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/nonexistent", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestRegisterRoutes_WrongMethod_Returns405 verifies AC8.
+func TestRegisterRoutes_WrongMethod_Returns405(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	pfmhttp.RegisterRoutes(mux, buildTestDeps())
+
+	// GET on a POST-only endpoint
+	r := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+// TestRegisterRoutes_PublicRegistration_NoAuthRequired verifies that POST /api/v1/users
+// does not require authentication (it returns 400 for empty body, not 401).
+func TestRegisterRoutes_PublicRegistration_NoAuthRequired(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	pfmhttp.RegisterRoutes(mux, buildTestDeps())
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/users", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	// 400 (bad body), not 401 — proves no authn middleware on this route
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// placeholder to use time import (used in stubs)
+var _ = time.Now


### PR DESCRIPTION
## Summary
- Add `RegisterRoutes` function wiring 31 endpoints under `/api/v1/` with middleware chains (public, authn, household guard, admin guard)
- Add `RouteDeps` struct for clean dependency injection into route registration
- Add `MembershipRoleFinder` and `AccountTypeFinder` thin adapters for interface bridging
- Wire all domain logic (user, household, account, credit card, ledger), repos, and middleware in `main.go`
- Add 3 E2E integration tests against real PostgreSQL via testcontainers: full workflow (register→login→household→accounts→transaction→balance), unauthenticated access, non-member access
- Add 5 route unit tests verifying endpoint reachability, auth enforcement, 404, and 405

## Test plan
- [x] `make ci` passes (lint + unit tests + coverage + vuln + integration tests + build)
- [x] `/project:verify-issue` verdict: PASS (all 8 acceptance criteria)
- [x] `/project:review` verdict: PASS (all 9 applicable categories)
- [x] E2E integration tests pass with testcontainers against real PostgreSQL