### PR TITLE
fix(auth): add request body size limit, align token expiry, rename test factory

### DIFF
--- a/internal/adapter/auth/fake_token_service.go
+++ b/internal/adapter/auth/fake_token_service.go
@@ -43,16 +43,16 @@ func NewFakeTokenService(clk clock.Clock) *FakeTokenService {
 	}
 }
 
-// Issue creates an opaque token for userID that expires after expiresIn.
+// Issue creates an opaque token for userID that expires at expiresAt.
 // Panics if called outside a test binary.
-func (f *FakeTokenService) Issue(_ context.Context, userID uuid.UUID, expiresIn time.Duration) (string, error) {
+func (f *FakeTokenService) Issue(_ context.Context, userID uuid.UUID, expiresAt time.Time) (string, error) {
 	if !testing.Testing() {
 		panic("FakeTokenService: not for production use — wire PasetoTokenService instead")
 	}
 	token := "fake-" + uuid.New().String()
 	entry := fakeTokenEntry{
 		userID:    userID,
-		expiresAt: f.clk.Now().Add(expiresIn),
+		expiresAt: expiresAt,
 	}
 	f.mu.Lock()
 	f.tokens[token] = entry

--- a/internal/adapter/auth/fake_token_service_test.go
+++ b/internal/adapter/auth/fake_token_service_test.go
@@ -31,7 +31,7 @@ func TestFakeTokenService_Issue_ThenValidate_ReturnsUserID(t *testing.T) {
 	svc := authadapter.NewFakeTokenService(clk)
 	ctx := context.Background()
 
-	token, err := svc.Issue(ctx, testUserID, time.Hour)
+	token, err := svc.Issue(ctx, testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 
@@ -47,7 +47,7 @@ func TestFakeTokenService_Validate_ExpiredToken_ReturnsErrTokenExpired(t *testin
 	svc := authadapter.NewFakeTokenService(clk)
 	ctx := context.Background()
 
-	token, err := svc.Issue(ctx, testUserID, time.Hour)
+	token, err := svc.Issue(ctx, testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 
 	// Advance clock past expiry.
@@ -78,10 +78,10 @@ func TestFakeTokenService_Issue_DifferentUsersProduceDifferentTokens(t *testing.
 	userA := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 	userB := uuid.MustParse("00000000-0000-0000-0000-000000000002")
 
-	tokenA, err := svc.Issue(ctx, userA, time.Hour)
+	tokenA, err := svc.Issue(ctx, userA, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 
-	tokenB, err := svc.Issue(ctx, userB, time.Hour)
+	tokenB, err := svc.Issue(ctx, userB, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 
 	assert.NotEqual(t, tokenA, tokenB)
@@ -102,10 +102,10 @@ func TestFakeTokenService_Issue_SameUserProducesUniqueTokens(t *testing.T) {
 	svc := authadapter.NewFakeTokenService(clk)
 	ctx := context.Background()
 
-	t1, err := svc.Issue(ctx, testUserID, time.Hour)
+	t1, err := svc.Issue(ctx, testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 
-	t2, err := svc.Issue(ctx, testUserID, time.Hour)
+	t2, err := svc.Issue(ctx, testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 
 	assert.NotEqual(t, t1, t2, "each Issue call must produce a unique token")
@@ -126,13 +126,13 @@ func TestFakeTokenService_Validate_TokenNotRenewable(t *testing.T) {
 	svc := authadapter.NewFakeTokenService(clk)
 	ctx := context.Background()
 
-	oldToken, err := svc.Issue(ctx, testUserID, time.Hour)
+	oldToken, err := svc.Issue(ctx, testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 
 	clk.Advance(2 * time.Hour)
 
 	// Issue a new token (which is valid); old token must still be expired.
-	_, err = svc.Issue(ctx, testUserID, time.Hour)
+	_, err = svc.Issue(ctx, testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 
 	_, err = svc.Validate(ctx, oldToken)

--- a/internal/adapter/auth/paseto_token_service.go
+++ b/internal/adapter/auth/paseto_token_service.go
@@ -51,7 +51,7 @@ func NewPasetoTokenService(keyHex string, clk clock.Clock) (*PasetoTokenService,
 
 // Issue encrypts a new PASETO v4.local token containing the userID, iat, nbf,
 // and exp claims. Each call uses a fresh random nonce so tokens are unique.
-func (s *PasetoTokenService) Issue(ctx context.Context, userID uuid.UUID, expiresIn time.Duration) (string, error) {
+func (s *PasetoTokenService) Issue(ctx context.Context, userID uuid.UUID, expiresAt time.Time) (string, error) {
 	_, span := otel.Tracer("auth").Start(ctx, "PasetoTokenService.Issue")
 	defer span.End()
 
@@ -60,7 +60,7 @@ func (s *PasetoTokenService) Issue(ctx context.Context, userID uuid.UUID, expire
 	token.SetSubject(userID.String())
 	token.SetIssuedAt(now)
 	token.SetNotBefore(now)
-	token.SetExpiration(now.Add(expiresIn))
+	token.SetExpiration(expiresAt)
 
 	encrypted := token.V4Encrypt(s.key, nil)
 	span.SetStatus(codes.Ok, "")

--- a/internal/adapter/auth/paseto_token_service_test.go
+++ b/internal/adapter/auth/paseto_token_service_test.go
@@ -30,7 +30,7 @@ func TestPasetoTokenService_Issue_ThenValidate_ReturnsUserID(t *testing.T) {
 	require.NoError(t, err)
 	ctx := context.Background()
 
-	token, err := svc.Issue(ctx, testUserID, time.Hour)
+	token, err := svc.Issue(ctx, testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 
@@ -47,10 +47,10 @@ func TestPasetoTokenService_Issue_DifferentSaltsEachCall(t *testing.T) {
 	require.NoError(t, err)
 	ctx := context.Background()
 
-	t1, err := svc.Issue(ctx, testUserID, time.Hour)
+	t1, err := svc.Issue(ctx, testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 
-	t2, err := svc.Issue(ctx, testUserID, time.Hour)
+	t2, err := svc.Issue(ctx, testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 
 	assert.NotEqual(t, t1, t2, "each Issue must produce a unique token due to random nonce")
@@ -63,7 +63,7 @@ func TestPasetoTokenService_Validate_ExpiredToken_ReturnsErrTokenExpired(t *test
 	require.NoError(t, err)
 	ctx := context.Background()
 
-	token, err := svc.Issue(ctx, testUserID, time.Hour)
+	token, err := svc.Issue(ctx, testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 
 	// Advance clock past expiry.
@@ -130,7 +130,7 @@ func TestPasetoTokenService_Validate_WrongKey_ReturnsErrTokenInvalid(t *testing.
 	svc2, err := authadapter.NewPasetoTokenService(otherKey, clk)
 	require.NoError(t, err)
 
-	token, err := svc1.Issue(context.Background(), testUserID, time.Hour)
+	token, err := svc1.Issue(context.Background(), testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 
 	_, err = svc2.Validate(context.Background(), token)
@@ -146,7 +146,7 @@ func BenchmarkPasetoTokenService_Validate(b *testing.B) {
 		b.Fatal(err)
 	}
 	ctx := context.Background()
-	token, err := svc.Issue(ctx, testUserID, time.Hour)
+	token, err := svc.Issue(ctx, testUserID, fixedTime.Add(time.Hour))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/adapter/http/response.go
+++ b/internal/adapter/http/response.go
@@ -34,9 +34,16 @@ func WriteNoContent(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// maxRequestBodyBytes is the maximum allowed size for JSON request bodies (1 MB).
+// Requests exceeding this limit are rejected before the full body is read into memory,
+// preventing denial-of-service via oversized payloads.
+const maxRequestBodyBytes = 1024 * 1024
+
 // DecodeBody reads the request body and decodes it as JSON into dst.
-// Returns an error if the body is empty or contains malformed JSON.
+// The body is limited to maxRequestBodyBytes to prevent oversized payloads.
+// Returns an error if the body is empty, exceeds the limit, or contains malformed JSON.
 func DecodeBody(r *http.Request, dst any) error {
+	r.Body = http.MaxBytesReader(nil, r.Body, maxRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
 		return fmt.Errorf("decode request body: %w", err)
 	}

--- a/internal/adapter/http/response_test.go
+++ b/internal/adapter/http/response_test.go
@@ -162,6 +162,41 @@ func TestDecodeBody_EmptyBody(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestDecodeBody_OversizedBody verifies that a request body exceeding the max
+// allowed size is rejected with an error before being fully read into memory.
+func TestDecodeBody_OversizedBody(t *testing.T) {
+	t.Parallel()
+
+	type input struct {
+		Name string `json:"name"`
+	}
+
+	// Create a body larger than the max allowed size (1 MB + 1 byte).
+	oversized := strings.Repeat("x", 1024*1024+1)
+	body := `{"name":"` + oversized + `"}`
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	var got input
+	err := pfmhttp.DecodeBody(r, &got)
+
+	require.Error(t, err)
+}
+
+// TestDecodeBody_NormalSizedBody verifies that a body within the limit is decoded normally.
+func TestDecodeBody_NormalSizedBody(t *testing.T) {
+	t.Parallel()
+
+	type input struct {
+		Name string `json:"name"`
+	}
+
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"Alice"}`))
+	var got input
+	err := pfmhttp.DecodeBody(r, &got)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", got.Name)
+}
+
 // --- MapError tests ---
 
 // TestMapError_DomainErrors verifies AC2–AC4 and AC8: each domain error sentinel

--- a/internal/domain/user/login_logic.go
+++ b/internal/domain/user/login_logic.go
@@ -80,13 +80,14 @@ func (l *LoginLogic) Login(ctx context.Context, email, password string) (LoginRe
 		return LoginResult{}, fmt.Errorf(message.ErrLoginVerifyPassword, message.ErrLoginInvalidCredentials)
 	}
 
-	token, err := l.tokens.Issue(ctx, u.ID, l.tokenTTL)
+	expiresAt := l.clk.Now().Add(l.tokenTTL)
+	token, err := l.tokens.Issue(ctx, u.ID, expiresAt)
 	if err != nil {
 		return LoginResult{}, fmt.Errorf(message.ErrLoginIssueToken, err)
 	}
 
 	return LoginResult{
 		Token:     token,
-		ExpiresAt: l.clk.Now().Add(l.tokenTTL),
+		ExpiresAt: expiresAt,
 	}, nil
 }

--- a/internal/domain/user/login_logic_test.go
+++ b/internal/domain/user/login_logic_test.go
@@ -27,9 +27,9 @@ const (
 	testPassword = "correct-horse-battery-staple"
 )
 
-// newLogic builds a LoginLogic pre-seeded with one active user.
+// loginLogicFactory builds a LoginLogic pre-seeded with one active user.
 // Returns the logic and the fake repo so individual tests can manipulate state.
-func newLogic(t *testing.T) (*domainuser.LoginLogic, *postgres.FakeUserRepository) {
+func loginLogicFactory(t *testing.T) (*domainuser.LoginLogic, *postgres.FakeUserRepository) {
 	t.Helper()
 	clk := clock.NewFakeClock(fixedTime)
 	repo := postgres.NewFakeUserRepository()
@@ -53,7 +53,7 @@ func newLogic(t *testing.T) (*domainuser.LoginLogic, *postgres.FakeUserRepositor
 // TestLoginLogic_ValidCredentials_ReturnsTokenAndExpiry verifies AC1:
 // valid credentials produce a non-empty token and a future expiry time.
 func TestLoginLogic_ValidCredentials_ReturnsTokenAndExpiry(t *testing.T) {
-	logic, _ := newLogic(t)
+	logic, _ := loginLogicFactory(t)
 
 	result, err := logic.Login(context.Background(), testEmail, testPassword)
 
@@ -65,7 +65,7 @@ func TestLoginLogic_ValidCredentials_ReturnsTokenAndExpiry(t *testing.T) {
 // TestLoginLogic_ValidCredentials_IsCaseInsensitive verifies that email lookup
 // is case-insensitive: "USER@EXAMPLE.COM" finds the "user@example.com" record.
 func TestLoginLogic_ValidCredentials_IsCaseInsensitive(t *testing.T) {
-	logic, _ := newLogic(t)
+	logic, _ := loginLogicFactory(t)
 
 	result, err := logic.Login(context.Background(), "USER@EXAMPLE.COM", testPassword)
 
@@ -76,7 +76,7 @@ func TestLoginLogic_ValidCredentials_IsCaseInsensitive(t *testing.T) {
 // TestLoginLogic_UserNotFound_ReturnsInvalidCredentials verifies AC3:
 // a non-existent email produces the same generic error as a wrong password.
 func TestLoginLogic_UserNotFound_ReturnsInvalidCredentials(t *testing.T) {
-	logic, _ := newLogic(t)
+	logic, _ := loginLogicFactory(t)
 
 	_, err := logic.Login(context.Background(), "nobody@example.com", testPassword)
 
@@ -88,7 +88,7 @@ func TestLoginLogic_UserNotFound_ReturnsInvalidCredentials(t *testing.T) {
 // TestLoginLogic_WrongPassword_ReturnsInvalidCredentials verifies AC2 and AC5:
 // wrong password produces the same generic error as a missing user.
 func TestLoginLogic_WrongPassword_ReturnsInvalidCredentials(t *testing.T) {
-	logic, _ := newLogic(t)
+	logic, _ := loginLogicFactory(t)
 
 	_, err := logic.Login(context.Background(), testEmail, "wrong-password")
 
@@ -100,7 +100,7 @@ func TestLoginLogic_WrongPassword_ReturnsInvalidCredentials(t *testing.T) {
 // TestLoginLogic_RepoInfraError_PropagatesError verifies that a non-auth repository
 // error (e.g., DB down) is propagated to the caller, not swallowed.
 func TestLoginLogic_RepoInfraError_PropagatesError(t *testing.T) {
-	logic, repo := newLogic(t)
+	logic, repo := loginLogicFactory(t)
 	infraErr := errors.New("connection refused")
 	repo.SetError(infraErr)
 
@@ -122,7 +122,7 @@ func (s *stubHasher) Verify(_ context.Context, _, _ string) (bool, error) {
 
 type stubTokenIssuer struct{ err error }
 
-func (s *stubTokenIssuer) Issue(_ context.Context, _ uuid.UUID, _ time.Duration) (string, error) {
+func (s *stubTokenIssuer) Issue(_ context.Context, _ uuid.UUID, _ time.Time) (string, error) {
 	return "", s.err
 }
 

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -89,7 +89,7 @@ type passwordVerifier interface {
 // tokenIssuer abstracts token creation.
 // Structurally satisfied by port/auth.TokenService.
 type tokenIssuer interface {
-	Issue(ctx context.Context, userID uuid.UUID, expiresIn time.Duration) (string, error)
+	Issue(ctx context.Context, userID uuid.UUID, expiresAt time.Time) (string, error)
 }
 
 // clocker abstracts the current time.

--- a/internal/middleware/authn_test.go
+++ b/internal/middleware/authn_test.go
@@ -53,7 +53,7 @@ func newSvc(t *testing.T) (*auth.FakeTokenService, string) {
 	t.Helper()
 	clk := clock.NewFakeClock(fixedTime)
 	svc := auth.NewFakeTokenService(clk)
-	token, err := svc.Issue(context.Background(), testUserID, time.Hour)
+	token, err := svc.Issue(context.Background(), testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 	return svc, token
 }
@@ -111,7 +111,7 @@ func TestAuthnMiddleware_InvalidToken_Returns401(t *testing.T) {
 func TestAuthnMiddleware_ExpiredToken_Returns401(t *testing.T) {
 	clk := clock.NewFakeClock(fixedTime)
 	svc := auth.NewFakeTokenService(clk)
-	token, err := svc.Issue(context.Background(), testUserID, time.Hour)
+	token, err := svc.Issue(context.Background(), testUserID, fixedTime.Add(time.Hour))
 	require.NoError(t, err)
 
 	// Advance clock past expiry.
@@ -192,7 +192,7 @@ func BenchmarkAuthnMiddleware_ValidRequest(b *testing.B) {
 	svc, token := func() (*auth.FakeTokenService, string) {
 		clk := clock.NewFakeClock(fixedTime)
 		svc := auth.NewFakeTokenService(clk)
-		tok, err := svc.Issue(context.Background(), testUserID, time.Hour)
+		tok, err := svc.Issue(context.Background(), testUserID, fixedTime.Add(time.Hour))
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/port/auth/token_service.go
+++ b/internal/port/auth/token_service.go
@@ -11,9 +11,11 @@ import (
 // Tokens are self-contained: they carry the user ID and expiration so no
 // server-side session storage is required.
 type TokenService interface {
-	// Issue creates a signed token for userID that expires after expiresIn.
+	// Issue creates a signed token for userID that expires at expiresAt.
 	// The token includes issued-at, not-before, and expiration claims.
-	Issue(ctx context.Context, userID uuid.UUID, expiresIn time.Duration) (string, error)
+	// The caller computes the absolute expiry so the token and the returned
+	// LoginResult.ExpiresAt are guaranteed to be consistent.
+	Issue(ctx context.Context, userID uuid.UUID, expiresAt time.Time) (string, error)
 
 	// Validate verifies the token signature and expiration, returning the
 	// embedded userID on success. Returns ErrTokenExpired or ErrTokenInvalid


### PR DESCRIPTION
## Summary
- Add `http.MaxBytesReader` (1 MB limit) to `DecodeBody`, protecting all 16 JSON-consuming handlers against oversized request body DoS
- Change `tokenIssuer.Issue` interface from `time.Duration` to `time.Time` so expiry is computed once and consistent between PASETO claim and `LoginResult.ExpiresAt`
- Rename `newLogic` → `loginLogicFactory` in login_logic_test.go per project naming convention
- Update all implementations (`PasetoTokenService`, `FakeTokenService`) and test callers

## Test plan
- [x] `make ci` passes (lint + unit tests + coverage + vuln + integration tests + build)
- [x] All existing tests pass without behavior changes
- [x] New tests for oversized body rejection
- [x] Integration tests pass with testcontainers