### PR TITLE
test(ci): eliminate per-test containers with shared TestMain and template cloning

### DIFF
--- a/.github/workflows/merge-quality-gate.yml
+++ b/.github/workflows/merge-quality-gate.yml
@@ -1,6 +1,6 @@
 # Merge-to-main full quality gate — triggers on every push to main (PR merge,
 # rebase, or admin direct push). Runs the complete suite: lint, unit tests,
-# integration tests (testcontainers-go + real Postgres), and build.
+# integration tests (GitHub Actions Postgres service container + real SQL), and build.
 # Deployment workflows may only trigger after this gate passes.
 # All action versions are pinned; no `latest` references.
 
@@ -17,8 +17,21 @@ jobs:
   full-gate:
     name: full-gate
     runs-on: ubuntu-24.04
-    # Docker daemon is pre-installed on ubuntu-24.04 runners.
-    # testcontainers-go uses /var/run/docker.sock automatically.
+
+    services:
+      postgres:
+        image: postgres:18-alpine3.23
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpass
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U testuser"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - name: Checkout
@@ -39,11 +52,8 @@ jobs:
         run: go test -race -count=1 ./...
 
       - name: Test (integration)
-        # TESTCONTAINERS_RYUK_DISABLED prevents the Ryuk reaper container from
-        # starting. Ryuk can fail in GitHub Actions due to socket/permission
-        # restrictions; disabling it is the recommended workaround for CI.
         env:
-          TESTCONTAINERS_RYUK_DISABLED: "true"
+          TEST_DATABASE_URL: postgres://testuser:testpass@localhost:5432/postgres?sslmode=disable
         run: go test -tags integration -race -count=1 ./...
 
       - name: Build

--- a/internal/adapter/http/e2e_account_test.go
+++ b/internal/adapter/http/e2e_account_test.go
@@ -33,6 +33,7 @@ func createAccountHelper(t *testing.T, env *e2eEnv, email, householdName, accoun
 // TestE2E_Account_Create_Success verifies AC1: valid input returns 201 with
 // server-assigned ID and zero balance.
 func TestE2E_Account_Create_Success(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "a1@example.com", "House A1")
@@ -56,6 +57,7 @@ func TestE2E_Account_Create_Success(t *testing.T) {
 // TestE2E_Account_Create_DuplicateName verifies AC2: duplicate name in the same
 // household returns 409.
 func TestE2E_Account_Create_DuplicateName(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "a2@example.com", "House A2")
@@ -79,6 +81,7 @@ func TestE2E_Account_Create_DuplicateName(t *testing.T) {
 
 // TestE2E_Account_Create_ValidationError_EmptyName verifies AC3: empty name returns 400.
 func TestE2E_Account_Create_ValidationError_EmptyName(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "a3a@example.com", "House A3a")
@@ -94,6 +97,7 @@ func TestE2E_Account_Create_ValidationError_EmptyName(t *testing.T) {
 // TestE2E_Account_Create_ValidationError_InvalidType verifies AC3: invalid account
 // type returns 400.
 func TestE2E_Account_Create_ValidationError_InvalidType(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "a3b@example.com", "House A3b")
@@ -109,6 +113,7 @@ func TestE2E_Account_Create_ValidationError_InvalidType(t *testing.T) {
 // TestE2E_Account_Create_ValidationError_InvalidCurrency verifies AC3: invalid
 // currency code returns 400.
 func TestE2E_Account_Create_ValidationError_InvalidCurrency(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "a3c@example.com", "House A3c")
@@ -124,6 +129,7 @@ func TestE2E_Account_Create_ValidationError_InvalidCurrency(t *testing.T) {
 // TestE2E_Account_GetByID verifies AC4: member retrieves an account by ID and
 // receives correct data.
 func TestE2E_Account_GetByID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createAccountHelper(t, env, "a4@example.com", "House A4", "Checking")
@@ -139,6 +145,7 @@ func TestE2E_Account_GetByID(t *testing.T) {
 
 // TestE2E_Account_GetByID_NotFound verifies AC5: non-existent account ID returns 404.
 func TestE2E_Account_GetByID_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "a5@example.com", "House A5")
@@ -150,6 +157,7 @@ func TestE2E_Account_GetByID_NotFound(t *testing.T) {
 // TestE2E_Account_List verifies AC6: listing accounts returns all active accounts
 // for the household.
 func TestE2E_Account_List(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "a6@example.com", "House A6")
@@ -170,6 +178,7 @@ func TestE2E_Account_List(t *testing.T) {
 
 // TestE2E_Account_List_Empty verifies AC7: a household with no accounts returns [].
 func TestE2E_Account_List_Empty(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "a7@example.com", "House A7")
@@ -183,6 +192,7 @@ func TestE2E_Account_List_Empty(t *testing.T) {
 // TestE2E_Account_UpdateName verifies AC8: updating an account name with the
 // correct version returns 200 with the updated name and incremented version.
 func TestE2E_Account_UpdateName(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createAccountHelper(t, env, "a8@example.com", "House A8", "Old Name")
@@ -200,6 +210,7 @@ func TestE2E_Account_UpdateName(t *testing.T) {
 // TestE2E_Account_UpdateName_StaleVersion verifies AC9: a stale version on name
 // update returns 409.
 func TestE2E_Account_UpdateName_StaleVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createAccountHelper(t, env, "a9@example.com", "House A9", "Acct")
@@ -219,6 +230,7 @@ func TestE2E_Account_UpdateName_StaleVersion(t *testing.T) {
 // TestE2E_Account_UpdateBalance verifies AC10: updating an account balance with
 // the correct version returns 200 with the new balance.
 func TestE2E_Account_UpdateBalance(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createAccountHelper(t, env, "a10@example.com", "House A10", "Checking")
@@ -236,6 +248,7 @@ func TestE2E_Account_UpdateBalance(t *testing.T) {
 // TestE2E_Account_Deactivate verifies AC11: deactivating an account with zero
 // balance returns 204 and subsequent GET returns 404.
 func TestE2E_Account_Deactivate(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createAccountHelper(t, env, "a11@example.com", "House A11", "Checking")
@@ -250,6 +263,7 @@ func TestE2E_Account_Deactivate(t *testing.T) {
 // TestE2E_Account_Deactivate_BalanceNotZero verifies AC12: deactivating an account
 // with a non-zero balance returns 409.
 func TestE2E_Account_Deactivate_BalanceNotZero(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createAccountHelper(t, env, "a12@example.com", "House A12", "Checking")
@@ -275,6 +289,7 @@ func TestE2E_Account_Deactivate_BalanceNotZero(t *testing.T) {
 // TestE2E_Account_Create_DifferentTypes verifies edge case: all four account types
 // are accepted.
 func TestE2E_Account_Create_DifferentTypes(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "a-types@example.com", "TypesHouse")
@@ -295,6 +310,7 @@ func TestE2E_Account_Create_DifferentTypes(t *testing.T) {
 // TestE2E_Account_Create_DifferentCurrencies verifies edge case: USD, BRL, and EUR
 // are all accepted.
 func TestE2E_Account_Create_DifferentCurrencies(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "a-currencies@example.com", "CurrenciesHouse")
@@ -315,6 +331,7 @@ func TestE2E_Account_Create_DifferentCurrencies(t *testing.T) {
 // TestE2E_Account_List_AfterDeactivate verifies edge case: listing accounts after
 // deactivating one returns only the active accounts.
 func TestE2E_Account_List_AfterDeactivate(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "a-listdeact@example.com", "ListDeactHouse")
@@ -346,6 +363,7 @@ func TestE2E_Account_List_AfterDeactivate(t *testing.T) {
 // TestE2E_Account_UpdateBalance_Negative verifies edge case: the domain accepts a
 // negative balance (representing an overdraft or owed amount).
 func TestE2E_Account_UpdateBalance_Negative(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createAccountHelper(t, env, "a-neg@example.com", "NegHouse", "Checking")

--- a/internal/adapter/http/e2e_creditcard_test.go
+++ b/internal/adapter/http/e2e_creditcard_test.go
@@ -51,6 +51,7 @@ func ccSettingsURL(householdID, accountID string) string {
 // TestE2E_CCSettings_Create_Success verifies AC1: creating settings for a
 // CREDIT_CARD account returns 201 with the settings.
 func TestE2E_CCSettings_Create_Success(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc1@example.com", "CC House 1", "Visa")
@@ -74,6 +75,7 @@ func TestE2E_CCSettings_Create_Success(t *testing.T) {
 // TestE2E_CCSettings_Create_NotCreditCard verifies AC2: creating settings for a
 // non-CREDIT_CARD account returns the appropriate conflict error (409).
 func TestE2E_CCSettings_Create_NotCreditCard(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	// Use a CHECKING account — not a credit card.
@@ -91,6 +93,7 @@ func TestE2E_CCSettings_Create_NotCreditCard(t *testing.T) {
 // TestE2E_CCSettings_Create_Duplicate verifies AC3: creating settings for an
 // account that already has settings returns 409.
 func TestE2E_CCSettings_Create_Duplicate(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc3@example.com", "CC House 3", "Visa")
@@ -108,6 +111,7 @@ func TestE2E_CCSettings_Create_Duplicate(t *testing.T) {
 // TestE2E_CCSettings_GetByAccountID verifies AC4: retrieving settings by account
 // ID returns 200 with the correct data.
 func TestE2E_CCSettings_GetByAccountID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc4@example.com", "CC House 4", "Visa")
@@ -126,6 +130,7 @@ func TestE2E_CCSettings_GetByAccountID(t *testing.T) {
 // TestE2E_CCSettings_GetByAccountID_NotFound verifies AC5: retrieving settings
 // for an account with no settings returns 404.
 func TestE2E_CCSettings_GetByAccountID_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc5@example.com", "CC House 5", "Visa")
@@ -137,6 +142,7 @@ func TestE2E_CCSettings_GetByAccountID_NotFound(t *testing.T) {
 // TestE2E_CCSettings_UpdateClosingDay verifies AC6: updating the closing day with
 // the correct version returns 200 with the updated value and incremented version.
 func TestE2E_CCSettings_UpdateClosingDay(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc6@example.com", "CC House 6", "Visa")
@@ -156,6 +162,7 @@ func TestE2E_CCSettings_UpdateClosingDay(t *testing.T) {
 // TestE2E_CCSettings_UpdateDueDay verifies AC7: updating the due day with the
 // correct version returns 200 with the updated value.
 func TestE2E_CCSettings_UpdateDueDay(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc7@example.com", "CC House 7", "Visa")
@@ -175,6 +182,7 @@ func TestE2E_CCSettings_UpdateDueDay(t *testing.T) {
 // TestE2E_CCSettings_UpdateLimit verifies AC8: updating the credit limit with the
 // correct version returns 200 with the updated value.
 func TestE2E_CCSettings_UpdateLimit(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc8@example.com", "CC House 8", "Visa")
@@ -194,6 +202,7 @@ func TestE2E_CCSettings_UpdateLimit(t *testing.T) {
 // TestE2E_CCSettings_UpdateClosingDay_StaleVersion verifies AC9: any settings
 // update with a stale version returns 409.
 func TestE2E_CCSettings_UpdateClosingDay_StaleVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc9@example.com", "CC House 9", "Visa")
@@ -216,6 +225,7 @@ func TestE2E_CCSettings_UpdateClosingDay_StaleVersion(t *testing.T) {
 // TestE2E_CCSettings_Delete verifies AC10: deleting settings returns 204 and
 // subsequent GET returns 404.
 func TestE2E_CCSettings_Delete(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc10@example.com", "CC House 10", "Visa")
@@ -232,6 +242,7 @@ func TestE2E_CCSettings_Delete(t *testing.T) {
 // deleting them, then creating new settings for the same account succeeds because
 // the uniqueness constraint is partial (WHERE deleted_at IS NULL).
 func TestE2E_CCSettings_RecreateAfterDelete(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc-recreate@example.com", "RecreateHouse", "Visa")
@@ -257,6 +268,7 @@ func TestE2E_CCSettings_RecreateAfterDelete(t *testing.T) {
 // TestE2E_CCSettings_ClosingDay_BoundaryValues verifies edge case: closing day
 // values of 1 and 31 are both accepted.
 func TestE2E_CCSettings_ClosingDay_BoundaryValues(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc-close-bound@example.com", "CloseBoundHouse", "Visa")
@@ -281,6 +293,7 @@ func TestE2E_CCSettings_ClosingDay_BoundaryValues(t *testing.T) {
 // TestE2E_CCSettings_DueDay_BoundaryValues verifies edge case: due day values of
 // 1 and 31 are both accepted.
 func TestE2E_CCSettings_DueDay_BoundaryValues(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc-due-bound@example.com", "DueBoundHouse", "Visa")
@@ -305,6 +318,7 @@ func TestE2E_CCSettings_DueDay_BoundaryValues(t *testing.T) {
 // TestE2E_CCSettings_UpdateLimit_LargeValue verifies edge case: a credit limit
 // near the int64 maximum is accepted (stored as BIGINT minor units).
 func TestE2E_CCSettings_UpdateLimit_LargeValue(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, householdID, accountID := createCCAccountHelper(t, env, "cc-large@example.com", "LargeHouse", "Visa")

--- a/internal/adapter/http/e2e_household_test.go
+++ b/internal/adapter/http/e2e_household_test.go
@@ -31,6 +31,7 @@ func createHouseholdHelper(t *testing.T, env *e2eEnv, email, householdName strin
 // TestE2E_Household_Create_Success verifies AC1: creating a household returns 201
 // and the creator can access it (proving they're an ADMIN member).
 func TestE2E_Household_Create_Success(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "h1@example.com", "My House")
@@ -44,6 +45,7 @@ func TestE2E_Household_Create_Success(t *testing.T) {
 
 // TestE2E_Household_Create_ValidationError verifies AC2: empty name returns 400.
 func TestE2E_Household_Create_ValidationError(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _ := registerAndLogin(t, env, "h2@example.com", "User", "secret1234")
@@ -56,6 +58,7 @@ func TestE2E_Household_Create_ValidationError(t *testing.T) {
 
 // TestE2E_Household_GetByID verifies AC3: member retrieves household by ID.
 func TestE2E_Household_GetByID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "h3@example.com", "Get House")
@@ -69,6 +72,7 @@ func TestE2E_Household_GetByID(t *testing.T) {
 
 // TestE2E_Household_List verifies AC4: list returns all households the user belongs to.
 func TestE2E_Household_List(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _ := registerAndLogin(t, env, "h4@example.com", "Lister", "secret1234")
@@ -85,6 +89,7 @@ func TestE2E_Household_List(t *testing.T) {
 
 // TestE2E_Household_List_Empty verifies AC5: user with no households gets [].
 func TestE2E_Household_List_Empty(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _ := registerAndLogin(t, env, "h5@example.com", "NoHouse", "secret1234")
@@ -97,6 +102,7 @@ func TestE2E_Household_List_Empty(t *testing.T) {
 
 // TestE2E_Household_UpdateName verifies AC6: admin renames with correct version.
 func TestE2E_Household_UpdateName(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "h6@example.com", "Old Name")
@@ -112,6 +118,7 @@ func TestE2E_Household_UpdateName(t *testing.T) {
 
 // TestE2E_Household_UpdateName_StaleVersion verifies AC7: stale version returns 409.
 func TestE2E_Household_UpdateName_StaleVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "h7@example.com", "Stale")
@@ -131,6 +138,7 @@ func TestE2E_Household_UpdateName_StaleVersion(t *testing.T) {
 // TestE2E_Household_AddMember verifies AC8: admin adds a member who can then
 // access the household.
 func TestE2E_Household_AddMember(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	tokenA, _, householdID := createHouseholdHelper(t, env, "admin@example.com", "Shared House")
@@ -151,6 +159,7 @@ func TestE2E_Household_AddMember(t *testing.T) {
 
 // TestE2E_Household_AddMember_Duplicate verifies AC9: adding existing member → 409.
 func TestE2E_Household_AddMember_Duplicate(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	tokenA, _, householdID := createHouseholdHelper(t, env, "dup-admin@example.com", "DupHouse")
@@ -172,6 +181,7 @@ func TestE2E_Household_AddMember_Duplicate(t *testing.T) {
 // TestE2E_Household_RemoveMember verifies AC10: admin removes a member who then
 // cannot access the household.
 func TestE2E_Household_RemoveMember(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	tokenA, _, householdID := createHouseholdHelper(t, env, "rm-admin@example.com", "RmHouse")
@@ -191,6 +201,7 @@ func TestE2E_Household_RemoveMember(t *testing.T) {
 
 // TestE2E_Household_RemoveMember_LastAdmin verifies AC11: last admin removal rejected.
 func TestE2E_Household_RemoveMember_LastAdmin(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, userID, householdID := createHouseholdHelper(t, env, "last-admin@example.com", "LastAdmin")
@@ -202,6 +213,7 @@ func TestE2E_Household_RemoveMember_LastAdmin(t *testing.T) {
 // TestE2E_Household_Deactivate verifies AC12: deactivation returns 204 and
 // subsequent access returns 404.
 func TestE2E_Household_Deactivate(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "deact@example.com", "DeactHouse")
@@ -216,6 +228,7 @@ func TestE2E_Household_Deactivate(t *testing.T) {
 // TestE2E_Household_NonAdminRejected verifies AC13: MEMBER cannot perform admin
 // operations (rename, deactivate, add/remove member).
 func TestE2E_Household_NonAdminRejected(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	tokenA, _, householdID := createHouseholdHelper(t, env, "admin-guard@example.com", "GuardHouse")
@@ -254,6 +267,7 @@ func TestE2E_Household_NonAdminRejected(t *testing.T) {
 // TestE2E_Household_AddSecondAdmin verifies edge case: admin adds another admin,
 // both can perform admin operations.
 func TestE2E_Household_AddSecondAdmin(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	tokenA, _, householdID := createHouseholdHelper(t, env, "admin1@example.com", "DualAdmin")
@@ -275,6 +289,7 @@ func TestE2E_Household_AddSecondAdmin(t *testing.T) {
 // TestE2E_Household_RemoveMember_NonExistent verifies edge case: removing a user
 // who is not a member is idempotent — returns 204 (domain treats it as a no-op).
 func TestE2E_Household_RemoveMember_NonExistent(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _, householdID := createHouseholdHelper(t, env, "rm-noop@example.com", "RmNoop")

--- a/internal/adapter/http/e2e_integration_test.go
+++ b/internal/adapter/http/e2e_integration_test.go
@@ -6,21 +6,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 
-	pfmdb "github.com/zambone/pfm-go/db"
 	pfmhttp "github.com/zambone/pfm-go/internal/adapter/http"
 	authadapter "github.com/zambone/pfm-go/internal/adapter/auth"
 	pgadapter "github.com/zambone/pfm-go/internal/adapter/postgres"
@@ -30,7 +24,6 @@ import (
 	domainledger "github.com/zambone/pfm-go/internal/domain/ledger"
 	domainuser "github.com/zambone/pfm-go/internal/domain/user"
 	"github.com/zambone/pfm-go/internal/platform/clock"
-	"github.com/zambone/pfm-go/internal/platform/config"
 	"github.com/zambone/pfm-go/internal/platform/database"
 )
 
@@ -44,7 +37,7 @@ type e2eEnv struct {
 func newE2EEnv(t *testing.T, ctx context.Context) *e2eEnv {
 	t.Helper()
 
-	pool := newE2EPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	realClock := clock.NewRealClock()
 	hasher := authadapter.NewArgon2idHasher(authadapter.DefaultArgon2idParams())
 	// 32-byte hex-encoded key for PASETO token service (decodes to 32 bytes).
@@ -123,58 +116,6 @@ func newE2EEnv(t *testing.T, ctx context.Context) *e2eEnv {
 	return &e2eEnv{mux: mux}
 }
 
-// newE2EPool creates a testcontainers PostgreSQL instance with migrations applied.
-func newE2EPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
-	t.Helper()
-
-	ctr, err := tcpostgres.Run(ctx,
-		"postgres:18-alpine3.23",
-		tcpostgres.WithDatabase("testdb"),
-		tcpostgres.WithUsername("testuser"),
-		tcpostgres.WithPassword("testpass"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2),
-		),
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = ctr.Terminate(ctx) })
-
-	host, err := ctr.Host(ctx)
-	require.NoError(t, err)
-	mappedPort, err := ctr.MappedPort(ctx, "5432")
-	require.NoError(t, err)
-
-	cfg := &config.Config{
-		DatabaseHost:           host,
-		DatabasePort:           mappedPort.Int(),
-		DatabaseName:           "testdb",
-		DatabaseUser:           "testuser",
-		DatabasePassword:       "testpass",
-		DatabaseSSLMode:        "disable",
-		DBConnectTimeoutSec:    5,
-		DBStartupRetries:       3,
-		DBStartupRetryDelaySec: 1,
-		DBMaxOpenConns:         5,
-		DBMaxIdleConns:         2,
-		DBConnMaxLifetimeSec:   60,
-		DBConnMaxIdleTimeSec:   30,
-	}
-
-	sqlDB, err := database.Open(ctx, cfg)
-	require.NoError(t, err)
-	sub, err := fs.Sub(pfmdb.Migrations, "migrations")
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(ctx, sqlDB, sub))
-	require.NoError(t, sqlDB.Close())
-
-	pool, err := database.NewPool(ctx, cfg)
-	require.NoError(t, err)
-	t.Cleanup(pool.Close)
-
-	return pool
-}
-
 // do sends an HTTP request to the mux and returns the recorder.
 func (e *e2eEnv) do(t *testing.T, method, path string, body any, token string) *httptest.ResponseRecorder {
 	t.Helper()
@@ -208,6 +149,7 @@ func decodeJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
 // TestE2E_FullWorkflow verifies AC5 and AC6: a full register → login → create
 // household → create account → post transaction workflow against a real database.
 func TestE2E_FullWorkflow(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -299,6 +241,7 @@ func TestE2E_FullWorkflow(t *testing.T) {
 
 // TestE2E_UnauthenticatedRequest_Returns401 verifies AC2 against the full stack.
 func TestE2E_UnauthenticatedRequest_Returns401(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -309,6 +252,7 @@ func TestE2E_UnauthenticatedRequest_Returns401(t *testing.T) {
 // TestE2E_NonMemberAccess_Returns403 verifies AC3: a user who is not a member
 // of the household gets 403 Forbidden.
 func TestE2E_NonMemberAccess_Returns403(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 

--- a/internal/adapter/http/e2e_ledger_test.go
+++ b/internal/adapter/http/e2e_ledger_test.go
@@ -81,6 +81,7 @@ func balanceURL(householdID, accountID string) string {
 // TestE2E_Ledger_PostTransaction_Success verifies AC1: a balanced transaction
 // returns 201 with the transaction and all its entries.
 func TestE2E_Ledger_PostTransaction_Success(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger1@example.com", "Ledger House 1")
@@ -107,6 +108,7 @@ func TestE2E_Ledger_PostTransaction_Success(t *testing.T) {
 // TestE2E_Ledger_PostTransaction_Unbalanced verifies AC2: a transaction where
 // total debits ≠ total credits returns 422.
 func TestE2E_Ledger_PostTransaction_Unbalanced(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger2@example.com", "Ledger House 2")
@@ -126,6 +128,7 @@ func TestE2E_Ledger_PostTransaction_Unbalanced(t *testing.T) {
 // TestE2E_Ledger_PostTransaction_ValidationError verifies AC3: a transaction with
 // an empty description returns 400.
 func TestE2E_Ledger_PostTransaction_ValidationError_EmptyDescription(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger3a@example.com", "Ledger House 3a")
@@ -145,6 +148,7 @@ func TestE2E_Ledger_PostTransaction_ValidationError_EmptyDescription(t *testing.
 // TestE2E_Ledger_PostTransaction_ValidationError_NoEntries verifies AC3: a transaction
 // with no entries returns 400.
 func TestE2E_Ledger_PostTransaction_ValidationError_NoEntries(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger3b@example.com", "Ledger House 3b")
@@ -161,6 +165,7 @@ func TestE2E_Ledger_PostTransaction_ValidationError_NoEntries(t *testing.T) {
 // TestE2E_Ledger_GetBalance_AfterMultipleTransactions verifies AC4: the balance
 // reflects the cumulative net of all debits and credits.
 func TestE2E_Ledger_GetBalance_AfterMultipleTransactions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger4@example.com", "Ledger House 4")
@@ -183,6 +188,7 @@ func TestE2E_Ledger_GetBalance_AfterMultipleTransactions(t *testing.T) {
 // TestE2E_Ledger_GetBalance_NoEntries_ReturnsZero verifies AC5: querying the balance
 // for an account with no entries returns zero (not an error).
 func TestE2E_Ledger_GetBalance_NoEntries_ReturnsZero(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger5@example.com", "Ledger House 5")
@@ -197,6 +203,7 @@ func TestE2E_Ledger_GetBalance_NoEntries_ReturnsZero(t *testing.T) {
 // TestE2E_Ledger_GetHistory_ReturnsAllTransactions verifies AC6: history returns all
 // transactions with their entries for the household.
 func TestE2E_Ledger_GetHistory_ReturnsAllTransactions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger6@example.com", "Ledger House 6")
@@ -220,6 +227,7 @@ func TestE2E_Ledger_GetHistory_ReturnsAllTransactions(t *testing.T) {
 // TestE2E_Ledger_GetHistory_FilterByAccountID verifies AC7: the account_id query
 // parameter filters the history to transactions involving that account only.
 func TestE2E_Ledger_GetHistory_FilterByAccountID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger7@example.com", "Ledger House 7")
@@ -250,6 +258,7 @@ func TestE2E_Ledger_GetHistory_FilterByAccountID(t *testing.T) {
 // TestE2E_Ledger_GetHistory_Pagination verifies AC8: limit and offset query
 // parameters are respected.
 func TestE2E_Ledger_GetHistory_Pagination(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger8@example.com", "Ledger House 8")
@@ -277,6 +286,7 @@ func TestE2E_Ledger_GetHistory_Pagination(t *testing.T) {
 // TestE2E_Ledger_GetHistory_Empty verifies AC9: a household with no transactions
 // returns an empty array (not null, not 404).
 func TestE2E_Ledger_GetHistory_Empty(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger9@example.com", "Ledger House 9")
@@ -293,6 +303,7 @@ func TestE2E_Ledger_GetHistory_Empty(t *testing.T) {
 // TestE2E_Ledger_SplitTransaction_ThreeEntries verifies the edge case: a transaction
 // with 3 entries (split expense across 3 accounts) balances correctly.
 func TestE2E_Ledger_SplitTransaction_ThreeEntries(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger-split@example.com", "Split House")
@@ -340,6 +351,7 @@ func TestE2E_Ledger_SplitTransaction_ThreeEntries(t *testing.T) {
 // TestE2E_Ledger_RunningBalance_Cumulative verifies the edge case: balance is
 // cumulative across multiple transactions on the same accounts.
 func TestE2E_Ledger_RunningBalance_Cumulative(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger-cumul@example.com", "Cumul House")
@@ -362,6 +374,7 @@ func TestE2E_Ledger_RunningBalance_Cumulative(t *testing.T) {
 // TestE2E_Ledger_Balance_DebitOnly_IsNegative verifies the edge case: an account
 // that only has debit entries has a negative balance.
 func TestE2E_Ledger_Balance_DebitOnly_IsNegative(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger-debit@example.com", "Debit House")
@@ -379,6 +392,7 @@ func TestE2E_Ledger_Balance_DebitOnly_IsNegative(t *testing.T) {
 // TestE2E_Ledger_TransactionDate_Format verifies the edge case: transaction_date
 // is stored and returned in YYYY-MM-DD format.
 func TestE2E_Ledger_TransactionDate_Format(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	setup := createLedgerSetupHelper(t, env, "ledger-date@example.com", "Date House")

--- a/internal/adapter/http/e2e_user_test.go
+++ b/internal/adapter/http/e2e_user_test.go
@@ -41,6 +41,7 @@ func registerAndLogin(t *testing.T, env *e2eEnv, email, displayName, password st
 // TestE2E_User_Register_Success verifies AC1: registration returns the new user
 // with a server-assigned ID and the user can subsequently log in.
 func TestE2E_User_Register_Success(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -66,6 +67,7 @@ func TestE2E_User_Register_Success(t *testing.T) {
 
 // TestE2E_User_Register_DuplicateEmail verifies AC2: duplicate email returns 409.
 func TestE2E_User_Register_DuplicateEmail(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -83,6 +85,7 @@ func TestE2E_User_Register_DuplicateEmail(t *testing.T) {
 // TestE2E_User_Register_ValidationErrors verifies AC3: invalid fields return 400
 // with per-field violations.
 func TestE2E_User_Register_ValidationErrors(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -99,6 +102,7 @@ func TestE2E_User_Register_ValidationErrors(t *testing.T) {
 
 // TestE2E_User_Register_EmptyBody verifies edge case: empty body returns 400.
 func TestE2E_User_Register_EmptyBody(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -108,6 +112,7 @@ func TestE2E_User_Register_EmptyBody(t *testing.T) {
 
 // TestE2E_User_GetProfile verifies AC4: authenticated user retrieves profile by ID.
 func TestE2E_User_GetProfile(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, userID := registerAndLogin(t, env, "bob@example.com", "Bob", "secret1234")
@@ -123,6 +128,7 @@ func TestE2E_User_GetProfile(t *testing.T) {
 
 // TestE2E_User_GetProfile_NotFound verifies AC5: non-existent user returns 404.
 func TestE2E_User_GetProfile_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _ := registerAndLogin(t, env, "x@example.com", "XX", "secret1234")
@@ -133,6 +139,7 @@ func TestE2E_User_GetProfile_NotFound(t *testing.T) {
 
 // TestE2E_User_GetProfile_InvalidUUID verifies edge case: bad UUID returns 400.
 func TestE2E_User_GetProfile_InvalidUUID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, _ := registerAndLogin(t, env, "x@example.com", "XX", "secret1234")
@@ -144,6 +151,7 @@ func TestE2E_User_GetProfile_InvalidUUID(t *testing.T) {
 // TestE2E_User_UpdateProfile verifies AC6: update profile with correct version
 // returns updated user with incremented version.
 func TestE2E_User_UpdateProfile(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, userID := registerAndLogin(t, env, "carol@example.com", "Carol", "secret1234")
@@ -160,6 +168,7 @@ func TestE2E_User_UpdateProfile(t *testing.T) {
 
 // TestE2E_User_UpdateProfile_StaleVersion verifies AC7: stale version returns 409.
 func TestE2E_User_UpdateProfile_StaleVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, userID := registerAndLogin(t, env, "dave@example.com", "Dave", "secret1234")
@@ -180,6 +189,7 @@ func TestE2E_User_UpdateProfile_StaleVersion(t *testing.T) {
 // TestE2E_User_ChangePassword verifies AC8: password change with correct old
 // password succeeds, and subsequent login uses new password.
 func TestE2E_User_ChangePassword(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, userID := registerAndLogin(t, env, "eve@example.com", "Eve", "oldpass1234")
@@ -204,6 +214,7 @@ func TestE2E_User_ChangePassword(t *testing.T) {
 
 // TestE2E_User_ChangePassword_WrongOldPassword verifies AC9: wrong old password returns 401.
 func TestE2E_User_ChangePassword_WrongOldPassword(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, userID := registerAndLogin(t, env, "frank@example.com", "Frank", "secret1234")
@@ -217,6 +228,7 @@ func TestE2E_User_ChangePassword_WrongOldPassword(t *testing.T) {
 // TestE2E_User_Deactivate verifies AC10: deactivation returns 204 and subsequent
 // requests for that user return 404.
 func TestE2E_User_Deactivate(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, userID := registerAndLogin(t, env, "gone@example.com", "Gone", "secret1234")
@@ -231,6 +243,7 @@ func TestE2E_User_Deactivate(t *testing.T) {
 
 // TestE2E_User_Deactivate_CannotLogin verifies edge case: deactivated user cannot log in.
 func TestE2E_User_Deactivate_CannotLogin(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 	token, userID := registerAndLogin(t, env, "byebye@example.com", "ByeBye", "secret1234")
@@ -248,6 +261,7 @@ func TestE2E_User_Deactivate_CannotLogin(t *testing.T) {
 // TestE2E_User_GetProfile_Unauthenticated verifies that accessing a user
 // profile without a token returns 401.
 func TestE2E_User_GetProfile_Unauthenticated(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 

--- a/internal/adapter/http/e2e_workflow_test.go
+++ b/internal/adapter/http/e2e_workflow_test.go
@@ -18,6 +18,7 @@ import (
 // registration through account deactivation and household deactivation, exercising
 // every domain in a single cohesive flow.
 func TestE2E_Workflow_FullFinancialLifecycle(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -110,6 +111,7 @@ func TestE2E_Workflow_FullFinancialLifecycle(t *testing.T) {
 // TestE2E_Workflow_MultiUserCollaboration verifies AC2: two users in a household
 // can both create accounts and post transactions, and both appear in history.
 func TestE2E_Workflow_MultiUserCollaboration(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -174,6 +176,7 @@ func TestE2E_Workflow_MultiUserCollaboration(t *testing.T) {
 // TestE2E_Workflow_MemberRoleEnforcement verifies AC3: MEMBER is blocked from
 // admin-only household operations (403) but can freely read and create resources.
 func TestE2E_Workflow_MemberRoleEnforcement(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -236,6 +239,7 @@ func TestE2E_Workflow_MemberRoleEnforcement(t *testing.T) {
 // TestE2E_Workflow_DualAdminOperations verifies AC4: after a second admin is added,
 // both admins can independently perform admin-only operations.
 func TestE2E_Workflow_DualAdminOperations(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -279,6 +283,7 @@ func TestE2E_Workflow_DualAdminOperations(t *testing.T) {
 // TestE2E_Workflow_MultiCurrencyAccounts verifies AC5: accounts created in different
 // currencies within the same household maintain independent balances.
 func TestE2E_Workflow_MultiCurrencyAccounts(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -355,6 +360,7 @@ func TestE2E_Workflow_MultiCurrencyAccounts(t *testing.T) {
 // a user does not affect the household's transaction history. A second household
 // member (B) can still retrieve history created by A after A deactivates.
 func TestE2E_Workflow_UserDeactivation_HistoryPreserved(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -409,6 +415,7 @@ func TestE2E_Workflow_UserDeactivation_HistoryPreserved(t *testing.T) {
 // The guard checks membership (not household state), so sub-resources remain
 // accessible to existing members — this is the current designed behaviour.
 func TestE2E_Workflow_HouseholdDeactivation_AccountsInaccessible(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
@@ -439,6 +446,7 @@ func TestE2E_Workflow_HouseholdDeactivation_AccountsInaccessible(t *testing.T) {
 // TestE2E_Workflow_MemberRemoval_AccessRevoked verifies EDGE-3: a removed member
 // can no longer access any household-scoped resources.
 func TestE2E_Workflow_MemberRemoval_AccessRevoked(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 

--- a/internal/adapter/http/testmain_test.go
+++ b/internal/adapter/http/testmain_test.go
@@ -1,0 +1,22 @@
+//go:build integration
+
+package http_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/zambone/pfm-go/internal/testutil/dbtest"
+)
+
+var sharedDB *dbtest.SharedDB
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	var cleanup func()
+	sharedDB, cleanup = dbtest.Setup(ctx)
+	defer cleanup()
+	sharedDB.PrepareTemplate(ctx)
+	os.Exit(m.Run())
+}

--- a/internal/adapter/postgres/account_repo_integration_test.go
+++ b/internal/adapter/postgres/account_repo_integration_test.go
@@ -48,8 +48,9 @@ func defaultAccountInput() account.CreateInput {
 // ---------------------------------------------------------------------------
 
 func TestAccountRepo_Create_StoresAndReturns(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -68,8 +69,9 @@ func TestAccountRepo_Create_StoresAndReturns(t *testing.T) {
 }
 
 func TestAccountRepo_Create_DuplicateName_ReturnsNameTaken(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -83,8 +85,9 @@ func TestAccountRepo_Create_DuplicateName_ReturnsNameTaken(t *testing.T) {
 }
 
 func TestAccountRepo_Create_CaseInsensitiveDuplicateName(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -106,8 +109,9 @@ func TestAccountRepo_Create_CaseInsensitiveDuplicateName(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAccountRepo_FindByID_ReturnsAccount(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -122,8 +126,9 @@ func TestAccountRepo_FindByID_ReturnsAccount(t *testing.T) {
 }
 
 func TestAccountRepo_FindByID_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 
 	_, err := repo.FindByID(ctx, uuid.MustParse("00000000-0000-0000-0000-000000000099"))
@@ -133,8 +138,9 @@ func TestAccountRepo_FindByID_NotFound(t *testing.T) {
 }
 
 func TestAccountRepo_FindByID_SoftDeleted_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -155,8 +161,9 @@ func TestAccountRepo_FindByID_SoftDeleted_NotFound(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAccountRepo_ListForHousehold_ReturnsHouseholdAccounts(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -176,8 +183,9 @@ func TestAccountRepo_ListForHousehold_ReturnsHouseholdAccounts(t *testing.T) {
 }
 
 func TestAccountRepo_ListForHousehold_EmptyForOtherHousehold(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 	otherHousehold := insertTestHousehold(t, pool)
@@ -196,8 +204,9 @@ func TestAccountRepo_ListForHousehold_EmptyForOtherHousehold(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAccountRepo_UpdateName_ChangesNameAndVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -213,8 +222,9 @@ func TestAccountRepo_UpdateName_ChangesNameAndVersion(t *testing.T) {
 }
 
 func TestAccountRepo_UpdateName_VersionConflict(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -233,8 +243,9 @@ func TestAccountRepo_UpdateName_VersionConflict(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAccountRepo_UpdateBalance_ChangesBalanceAndVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -250,8 +261,9 @@ func TestAccountRepo_UpdateBalance_ChangesBalanceAndVersion(t *testing.T) {
 }
 
 func TestAccountRepo_UpdateBalance_VersionConflict(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -270,8 +282,9 @@ func TestAccountRepo_UpdateBalance_VersionConflict(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAccountRepo_Deactivate_SoftDeletes(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -286,8 +299,9 @@ func TestAccountRepo_Deactivate_SoftDeletes(t *testing.T) {
 }
 
 func TestAccountRepo_Deactivate_IsIdempotent(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -305,8 +319,9 @@ func TestAccountRepo_Deactivate_IsIdempotent(t *testing.T) {
 // TestAccountRepo_Workflow_DeactivateHidesFromList verifies that a deactivated
 // account no longer appears in ListForHousehold results.
 func TestAccountRepo_Workflow_DeactivateHidesFromList(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -333,8 +348,9 @@ func TestAccountRepo_Workflow_DeactivateHidesFromList(t *testing.T) {
 // two sequential updates with correct version chain succeed (v1→v2→v3),
 // but reusing the first version fails.
 func TestAccountRepo_Workflow_VersionChain(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 
@@ -363,8 +379,9 @@ func TestAccountRepo_Workflow_VersionChain(t *testing.T) {
 // AccountLogic layer rejects deactivation when balance is non-zero, using
 // the real postgres adapter.
 func TestAccountRepo_Workflow_NonZeroBalanceDeactivateRejected(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	clk := clock.NewFakeClock(fixedAccountTime)
 	logic := account.NewAccountLogic(repo, clk)
@@ -395,8 +412,9 @@ func TestAccountRepo_Workflow_NonZeroBalanceDeactivateRejected(t *testing.T) {
 // is soft-deleted, its name can be reused by a new account in the same household
 // (the partial unique index only covers non-deleted rows).
 func TestAccountRepo_Workflow_DeactivatedNameReusable(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewAccountRepo(pool)
 	householdID := insertTestHousehold(t, pool)
 

--- a/internal/adapter/postgres/creditcard_settings_repo_integration_test.go
+++ b/internal/adapter/postgres/creditcard_settings_repo_integration_test.go
@@ -40,8 +40,9 @@ func defaultCCInput() creditcard.CreateInput {
 // ---------------------------------------------------------------------------
 
 func TestCCSettingsRepo_Create_StoresAndReturns(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewCreditCardSettingsRepo(pool)
 	accountID := insertTestAccount(t, pool)
 
@@ -58,8 +59,9 @@ func TestCCSettingsRepo_Create_StoresAndReturns(t *testing.T) {
 }
 
 func TestCCSettingsRepo_Create_Duplicate_ReturnsExists(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewCreditCardSettingsRepo(pool)
 	accountID := insertTestAccount(t, pool)
 
@@ -77,8 +79,9 @@ func TestCCSettingsRepo_Create_Duplicate_ReturnsExists(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCCSettingsRepo_FindByAccountID_ReturnsSettings(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewCreditCardSettingsRepo(pool)
 	accountID := insertTestAccount(t, pool)
 
@@ -93,8 +96,9 @@ func TestCCSettingsRepo_FindByAccountID_ReturnsSettings(t *testing.T) {
 }
 
 func TestCCSettingsRepo_FindByAccountID_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewCreditCardSettingsRepo(pool)
 
 	_, err := repo.FindByAccountID(ctx, uuid.MustParse("00000000-0000-0000-0000-000000000099"))
@@ -104,8 +108,9 @@ func TestCCSettingsRepo_FindByAccountID_NotFound(t *testing.T) {
 }
 
 func TestCCSettingsRepo_FindByAccountID_SoftDeleted_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewCreditCardSettingsRepo(pool)
 	accountID := insertTestAccount(t, pool)
 
@@ -124,8 +129,9 @@ func TestCCSettingsRepo_FindByAccountID_SoftDeleted_NotFound(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCCSettingsRepo_UpdateClosingDay_ChangesAndVersions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewCreditCardSettingsRepo(pool)
 	accountID := insertTestAccount(t, pool)
 
@@ -141,8 +147,9 @@ func TestCCSettingsRepo_UpdateClosingDay_ChangesAndVersions(t *testing.T) {
 }
 
 func TestCCSettingsRepo_UpdateClosingDay_VersionConflict(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewCreditCardSettingsRepo(pool)
 	accountID := insertTestAccount(t, pool)
 
@@ -161,8 +168,9 @@ func TestCCSettingsRepo_UpdateClosingDay_VersionConflict(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCCSettingsRepo_UpdateDueDay_ChangesAndVersions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewCreditCardSettingsRepo(pool)
 	accountID := insertTestAccount(t, pool)
 
@@ -182,8 +190,9 @@ func TestCCSettingsRepo_UpdateDueDay_ChangesAndVersions(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCCSettingsRepo_UpdateLimit_ChangesAndVersions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewCreditCardSettingsRepo(pool)
 	accountID := insertTestAccount(t, pool)
 
@@ -203,8 +212,9 @@ func TestCCSettingsRepo_UpdateLimit_ChangesAndVersions(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCCSettingsRepo_Delete_SoftDeletes(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewCreditCardSettingsRepo(pool)
 	accountID := insertTestAccount(t, pool)
 
@@ -219,8 +229,9 @@ func TestCCSettingsRepo_Delete_SoftDeletes(t *testing.T) {
 }
 
 func TestCCSettingsRepo_Delete_IsIdempotent(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewCreditCardSettingsRepo(pool)
 	accountID := insertTestAccount(t, pool)
 

--- a/internal/adapter/postgres/household_repo_integration_test.go
+++ b/internal/adapter/postgres/household_repo_integration_test.go
@@ -37,8 +37,9 @@ func insertTestUser(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
 // ---------------------------------------------------------------------------
 
 func TestHouseholdRepo_Create_StoresHouseholdAndMembership(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -62,8 +63,9 @@ func TestHouseholdRepo_Create_StoresHouseholdAndMembership(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHouseholdRepo_FindByID_ReturnsHousehold(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -78,8 +80,9 @@ func TestHouseholdRepo_FindByID_ReturnsHousehold(t *testing.T) {
 }
 
 func TestHouseholdRepo_FindByID_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 
 	_, err := repo.FindByID(ctx, uuid.MustParse("00000000-0000-0000-0000-000000000099"))
@@ -89,8 +92,9 @@ func TestHouseholdRepo_FindByID_NotFound(t *testing.T) {
 }
 
 func TestHouseholdRepo_FindByID_SoftDeleted_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -111,8 +115,9 @@ func TestHouseholdRepo_FindByID_SoftDeleted_NotFound(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHouseholdRepo_ListForUser_ReturnsUserHouseholds(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -128,8 +133,9 @@ func TestHouseholdRepo_ListForUser_ReturnsUserHouseholds(t *testing.T) {
 }
 
 func TestHouseholdRepo_ListForUser_EmptyForUnknownUser(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -148,8 +154,9 @@ func TestHouseholdRepo_ListForUser_EmptyForUnknownUser(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHouseholdRepo_FindMembership_ReturnsAdminMembership(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -164,8 +171,9 @@ func TestHouseholdRepo_FindMembership_ReturnsAdminMembership(t *testing.T) {
 }
 
 func TestHouseholdRepo_FindMembership_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -184,8 +192,9 @@ func TestHouseholdRepo_FindMembership_NotFound(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHouseholdRepo_ListMembers_ReturnsAllActive(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -210,8 +219,9 @@ func TestHouseholdRepo_ListMembers_ReturnsAllActive(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHouseholdRepo_AddMember_StoresAndReturns(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -231,8 +241,9 @@ func TestHouseholdRepo_AddMember_StoresAndReturns(t *testing.T) {
 }
 
 func TestHouseholdRepo_AddMember_DuplicateReturnsMemberExists(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -260,8 +271,9 @@ func TestHouseholdRepo_AddMember_DuplicateReturnsMemberExists(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHouseholdRepo_RemoveMember_SoftDeletes(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -283,8 +295,9 @@ func TestHouseholdRepo_RemoveMember_SoftDeletes(t *testing.T) {
 }
 
 func TestHouseholdRepo_RemoveMember_IsIdempotent(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -301,8 +314,9 @@ func TestHouseholdRepo_RemoveMember_IsIdempotent(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHouseholdRepo_UpdateName_ChangesNameAndVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -318,8 +332,9 @@ func TestHouseholdRepo_UpdateName_ChangesNameAndVersion(t *testing.T) {
 }
 
 func TestHouseholdRepo_UpdateName_VersionConflict(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -338,8 +353,9 @@ func TestHouseholdRepo_UpdateName_VersionConflict(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHouseholdRepo_Deactivate_SoftDeletes(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -354,8 +370,9 @@ func TestHouseholdRepo_Deactivate_SoftDeletes(t *testing.T) {
 }
 
 func TestHouseholdRepo_Deactivate_IsIdempotent(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 
@@ -374,8 +391,9 @@ func TestHouseholdRepo_Deactivate_IsIdempotent(t *testing.T) {
 // a committed transaction, both the household and its admin membership are
 // visible in subsequent queries.
 func TestHouseholdRepo_Txn_CreateCommits(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	tx := database.NewPostgresTransactor(pool)
 	callerID := insertTestUser(t, pool)
@@ -405,8 +423,9 @@ func TestHouseholdRepo_Txn_CreateCommits(t *testing.T) {
 // TestHouseholdRepo_Txn_CreateRollsBack verifies that when a transaction
 // fails after Create, neither the household nor the membership is committed.
 func TestHouseholdRepo_Txn_CreateRollsBack(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	tx := database.NewPostgresTransactor(pool)
 	callerID := insertTestUser(t, pool)
@@ -438,8 +457,9 @@ func TestHouseholdRepo_Txn_CreateRollsBack(t *testing.T) {
 // TestHouseholdRepo_Workflow_DeactivateHidesFromAllMembers verifies that
 // deactivating a household removes it from ListForUser for every member.
 func TestHouseholdRepo_Workflow_DeactivateHidesFromAllMembers(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	admin := insertTestUser(t, pool)
 	member := insertTestUser(t, pool)
@@ -480,8 +500,9 @@ func TestHouseholdRepo_Workflow_DeactivateHidesFromAllMembers(t *testing.T) {
 // makes the household visible in their list, and removing them hides it —
 // while other members remain unaffected.
 func TestHouseholdRepo_Workflow_AddRemoveMember(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	admin := insertTestUser(t, pool)
 	member := insertTestUser(t, pool)
@@ -519,8 +540,9 @@ func TestHouseholdRepo_Workflow_AddRemoveMember(t *testing.T) {
 // two sequential updates with correct version chain succeed (v1→v2→v3),
 // but reusing the first version fails.
 func TestHouseholdRepo_Workflow_VersionChain(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewHouseholdRepo(pool)
 	callerID := insertTestUser(t, pool)
 

--- a/internal/adapter/postgres/ledger_repo_integration_test.go
+++ b/internal/adapter/postgres/ledger_repo_integration_test.go
@@ -68,8 +68,9 @@ func balancedLedgerInput(debitAcct, creditAcct uuid.UUID) ledger.PostTransaction
 // ---------------------------------------------------------------------------
 
 func TestLedgerRepo_PostTransaction_StoresTransactionAndEntries(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewLedgerRepo(pool)
 	householdID, acct1, acct2 := insertTwoAccountsSameHousehold(t, pool)
 
@@ -83,8 +84,9 @@ func TestLedgerRepo_PostTransaction_StoresTransactionAndEntries(t *testing.T) {
 }
 
 func TestLedgerRepo_PostTransaction_UpdatesAccountBalances(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewLedgerRepo(pool)
 	householdID, acct1, acct2 := insertTwoAccountsSameHousehold(t, pool)
 
@@ -101,8 +103,9 @@ func TestLedgerRepo_PostTransaction_UpdatesAccountBalances(t *testing.T) {
 }
 
 func TestLedgerRepo_PostTransaction_Atomic_RollbackOnFailure(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewLedgerRepo(pool)
 	tx := database.NewPostgresTransactor(pool)
 	householdID, acct1, acct2 := insertTwoAccountsSameHousehold(t, pool)
@@ -125,8 +128,9 @@ func TestLedgerRepo_PostTransaction_Atomic_RollbackOnFailure(t *testing.T) {
 }
 
 func TestLedgerRepo_PostTransaction_UnbalancedFails(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewLedgerRepo(pool)
 	householdID, acct1, acct2 := insertTwoAccountsSameHousehold(t, pool)
 
@@ -150,8 +154,9 @@ func TestLedgerRepo_PostTransaction_UnbalancedFails(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLedgerRepo_GetBalance_ZeroForNewAccount(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewLedgerRepo(pool)
 	acctID := insertTestAccountForLedger(t, pool)
 
@@ -162,8 +167,9 @@ func TestLedgerRepo_GetBalance_ZeroForNewAccount(t *testing.T) {
 }
 
 func TestLedgerRepo_GetBalance_AccumulatesMultipleTransactions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewLedgerRepo(pool)
 	householdID, acct1, acct2 := insertTwoAccountsSameHousehold(t, pool)
 
@@ -182,8 +188,9 @@ func TestLedgerRepo_GetBalance_AccumulatesMultipleTransactions(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLedgerRepo_GetTransactionHistory_ReturnsTransactionsForAccount(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewLedgerRepo(pool)
 	householdID, acct1, acct2 := insertTwoAccountsSameHousehold(t, pool)
 
@@ -200,8 +207,9 @@ func TestLedgerRepo_GetTransactionHistory_ReturnsTransactionsForAccount(t *testi
 }
 
 func TestLedgerRepo_GetTransactionHistory_Pagination(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewLedgerRepo(pool)
 	householdID, acct1, acct2 := insertTwoAccountsSameHousehold(t, pool)
 
@@ -218,8 +226,9 @@ func TestLedgerRepo_GetTransactionHistory_Pagination(t *testing.T) {
 }
 
 func TestLedgerRepo_GetTransactionHistory_NoFilter_AllHouseholdTransactions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewLedgerRepo(pool)
 	householdID, acct1, acct2 := insertTwoAccountsSameHousehold(t, pool)
 

--- a/internal/adapter/postgres/testmain_test.go
+++ b/internal/adapter/postgres/testmain_test.go
@@ -1,0 +1,22 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/zambone/pfm-go/internal/testutil/dbtest"
+)
+
+var sharedDB *dbtest.SharedDB
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	var cleanup func()
+	sharedDB, cleanup = dbtest.Setup(ctx)
+	defer cleanup()
+	sharedDB.PrepareTemplate(ctx)
+	os.Exit(m.Run())
+}

--- a/internal/adapter/postgres/user_repo_integration_test.go
+++ b/internal/adapter/postgres/user_repo_integration_test.go
@@ -5,7 +5,6 @@ package postgres_test
 import (
 	"context"
 	"errors"
-	"io/fs"
 	"strings"
 	"testing"
 
@@ -13,75 +12,14 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 
-	pfmdb "github.com/zambone/pfm-go/db"
 	"github.com/zambone/pfm-go/internal/adapter/postgres"
 	domainuser "github.com/zambone/pfm-go/internal/domain/user"
 	"github.com/zambone/pfm-go/internal/message"
-	"github.com/zambone/pfm-go/internal/platform/config"
-	"github.com/zambone/pfm-go/internal/platform/database"
 )
 
-// testPasswordHash is a valid-length placeholder hash used for insertion fixtures.
+// integTestPasswordHash is a valid-length placeholder hash used for insertion fixtures.
 var integTestPasswordHash = strings.Repeat("x", 128)
-
-// newTestPool spins up a Postgres container, runs all migrations, and returns
-// a *pgxpool.Pool. Each call creates an isolated container — tests never share state.
-func newTestPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
-	t.Helper()
-
-	ctr, err := tcpostgres.Run(ctx,
-		"postgres:18-alpine3.23",
-		tcpostgres.WithDatabase("testdb"),
-		tcpostgres.WithUsername("testuser"),
-		tcpostgres.WithPassword("testpass"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2),
-		),
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = ctr.Terminate(ctx) })
-
-	host, err := ctr.Host(ctx)
-	require.NoError(t, err)
-	mappedPort, err := ctr.MappedPort(ctx, "5432")
-	require.NoError(t, err)
-
-	cfg := &config.Config{
-		DatabaseHost:           host,
-		DatabasePort:           mappedPort.Int(),
-		DatabaseName:           "testdb",
-		DatabaseUser:           "testuser",
-		DatabasePassword:       "testpass",
-		DatabaseSSLMode:        "disable",
-		DBConnectTimeoutSec:    5,
-		DBStartupRetries:       3,
-		DBStartupRetryDelaySec: 1,
-		DBMaxOpenConns:         5,
-		DBMaxIdleConns:         2,
-		DBConnMaxLifetimeSec:   60,
-		DBConnMaxIdleTimeSec:   30,
-	}
-
-	// Run migrations via database/sql (goose requirement).
-	sqlDB, err := database.Open(ctx, cfg)
-	require.NoError(t, err)
-	sub, err := fs.Sub(pfmdb.Migrations, "migrations")
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(ctx, sqlDB, sub))
-	require.NoError(t, sqlDB.Close())
-
-	// Re-connect with the pgx-native pool for application queries.
-	pool, err := database.NewPool(ctx, cfg)
-	require.NoError(t, err)
-	t.Cleanup(func() { pool.Close() })
-
-	return pool
-}
 
 // insertUser is a test helper that inserts a user row directly via SQL.
 func insertUser(t *testing.T, pool *pgxpool.Pool, email, passwordHash string) {
@@ -96,8 +34,9 @@ func insertUser(t *testing.T, pool *pgxpool.Pool, email, passwordHash string) {
 // TestUserRepo_FindByEmail_ReturnsUser verifies the happy path:
 // an existing active user is found and all fields are populated.
 func TestUserRepo_FindByEmail_ReturnsUser(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	insertUser(t, pool, "alice@example.com", integTestPasswordHash)
@@ -113,8 +52,9 @@ func TestUserRepo_FindByEmail_ReturnsUser(t *testing.T) {
 // TestUserRepo_FindByEmail_CaseInsensitive verifies that email lookup ignores case:
 // "ALICE@EXAMPLE.COM" matches the record stored as "alice@example.com".
 func TestUserRepo_FindByEmail_CaseInsensitive(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	insertUser(t, pool, "alice@example.com", integTestPasswordHash)
@@ -128,8 +68,9 @@ func TestUserRepo_FindByEmail_CaseInsensitive(t *testing.T) {
 // TestUserRepo_FindByEmail_NotFound_ReturnsInvalidCredentials verifies that
 // a missing email returns an error wrapping ErrLoginInvalidCredentials.
 func TestUserRepo_FindByEmail_NotFound_ReturnsInvalidCredentials(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	_, err := repo.FindByEmail(ctx, "nobody@example.com")
@@ -142,8 +83,9 @@ func TestUserRepo_FindByEmail_NotFound_ReturnsInvalidCredentials(t *testing.T) {
 // TestUserRepo_FindByEmail_SoftDeleted_ReturnsInvalidCredentials verifies AC4:
 // a soft-deleted user is invisible to FindByEmail (deleted_at IS NULL in SQL).
 func TestUserRepo_FindByEmail_SoftDeleted_ReturnsInvalidCredentials(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	insertUser(t, pool, "deleted@example.com", integTestPasswordHash)
@@ -180,8 +122,9 @@ func integRegisterInput(email string) domainuser.RegisterInput {
 // TestUserRepo_Create_StoresAndReturnsUser verifies the happy path:
 // the created user has a server-assigned ID, correct fields, and Version = 1.
 func TestUserRepo_Create_StoresAndReturnsUser(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	u, err := repo.Create(ctx, integRegisterInput("create@example.com"), integTestPasswordHash, integCallerID)
@@ -199,8 +142,9 @@ func TestUserRepo_Create_StoresAndReturnsUser(t *testing.T) {
 // TestUserRepo_Create_EmailAlreadyTaken verifies that inserting a duplicate email
 // returns an error wrapping ErrUserEmailTaken.
 func TestUserRepo_Create_EmailAlreadyTaken(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	insertUser(t, pool, "taken@example.com", integTestPasswordHash)
@@ -216,8 +160,9 @@ func TestUserRepo_Create_EmailAlreadyTaken(t *testing.T) {
 // is case-insensitive: inserting "ALICE@example.com" when "alice@example.com" already
 // exists returns ErrUserEmailTaken.
 func TestUserRepo_Create_EmailCaseInsensitiveDuplicate(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	_, err := repo.Create(ctx, integRegisterInput("alice@example.com"), integTestPasswordHash, integCallerID)
@@ -236,8 +181,9 @@ func TestUserRepo_Create_EmailCaseInsensitiveDuplicate(t *testing.T) {
 
 // TestUserRepo_FindByID_ReturnsUser verifies that an inserted user is returned by ID.
 func TestUserRepo_FindByID_ReturnsUser(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	created, err := repo.Create(ctx, integRegisterInput("findbyid@example.com"), integTestPasswordHash, integCallerID)
@@ -253,8 +199,9 @@ func TestUserRepo_FindByID_ReturnsUser(t *testing.T) {
 
 // TestUserRepo_FindByID_NotFound verifies that a missing ID returns ErrUserNotFound.
 func TestUserRepo_FindByID_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	_, err := repo.FindByID(ctx, uuid.MustParse("00000000-0000-0000-0000-000000000099"))
@@ -267,8 +214,9 @@ func TestUserRepo_FindByID_NotFound(t *testing.T) {
 // TestUserRepo_FindByID_SoftDeleted_NotFound verifies that a deactivated user
 // is invisible to FindByID.
 func TestUserRepo_FindByID_SoftDeleted_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	created, err := repo.Create(ctx, integRegisterInput("deleted2@example.com"), integTestPasswordHash, integCallerID)
@@ -291,8 +239,9 @@ func TestUserRepo_FindByID_SoftDeleted_NotFound(t *testing.T) {
 // TestUserRepo_UpdateProfile_UpdatesDisplayName verifies the happy path:
 // display name is updated and version increments.
 func TestUserRepo_UpdateProfile_UpdatesDisplayName(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	created, err := repo.Create(ctx, integRegisterInput("profile@example.com"), integTestPasswordHash, integCallerID)
@@ -310,8 +259,9 @@ func TestUserRepo_UpdateProfile_UpdatesDisplayName(t *testing.T) {
 // TestUserRepo_UpdateProfile_VersionConflict verifies that a stale version
 // returns ErrUserVersionConflict.
 func TestUserRepo_UpdateProfile_VersionConflict(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	created, err := repo.Create(ctx, integRegisterInput("conflict@example.com"), integTestPasswordHash, integCallerID)
@@ -333,8 +283,9 @@ func TestUserRepo_UpdateProfile_VersionConflict(t *testing.T) {
 // TestUserRepo_ChangePassword_UpdatesHash verifies the happy path:
 // the password hash is replaced and version increments.
 func TestUserRepo_ChangePassword_UpdatesHash(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	created, err := repo.Create(ctx, integRegisterInput("pwd@example.com"), integTestPasswordHash, integCallerID)
@@ -351,8 +302,9 @@ func TestUserRepo_ChangePassword_UpdatesHash(t *testing.T) {
 // TestUserRepo_ChangePassword_VersionConflict verifies that a stale version
 // returns ErrUserVersionConflict.
 func TestUserRepo_ChangePassword_VersionConflict(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	created, err := repo.Create(ctx, integRegisterInput("pwdconflict@example.com"), integTestPasswordHash, integCallerID)
@@ -372,8 +324,9 @@ func TestUserRepo_ChangePassword_VersionConflict(t *testing.T) {
 // TestUserRepo_Deactivate_SoftDeletesUser verifies that a deactivated user
 // is no longer findable by ID or email.
 func TestUserRepo_Deactivate_SoftDeletesUser(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	created, err := repo.Create(ctx, integRegisterInput("deactivate@example.com"), integTestPasswordHash, integCallerID)
@@ -394,8 +347,9 @@ func TestUserRepo_Deactivate_SoftDeletesUser(t *testing.T) {
 // TestUserRepo_Deactivate_IsIdempotent verifies that deactivating an already-
 // deactivated user does not return an error.
 func TestUserRepo_Deactivate_IsIdempotent(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	pool := newTestPool(t, ctx)
+	pool := sharedDB.NewPool(t, ctx)
 	repo := postgres.NewUserRepo(pool)
 
 	created, err := repo.Create(ctx, integRegisterInput("idemp@example.com"), integTestPasswordHash, integCallerID)

--- a/internal/platform/database/accounts_migration_integration_test.go
+++ b/internal/platform/database/accounts_migration_integration_test.go
@@ -14,6 +14,7 @@ import (
 // TestAccountsMigration_DefaultsOnCreate verifies AC1: a new account has name, type,
 // currency, zero balance, version=1, and status='ACTIVE'.
 func TestAccountsMigration_DefaultsOnCreate(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -57,6 +58,7 @@ func TestAccountsMigration_DefaultsOnCreate(t *testing.T) {
 // TestAccountsMigration_NameUniqueWithinHousehold verifies AC2: two accounts in the same
 // household cannot share the same name.
 func TestAccountsMigration_NameUniqueWithinHousehold(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -91,6 +93,7 @@ func TestAccountsMigration_NameUniqueWithinHousehold(t *testing.T) {
 // TestAccountsMigration_NameAllowedAcrossHouseholds verifies AC3: two accounts in different
 // households may share the same name.
 func TestAccountsMigration_NameAllowedAcrossHouseholds(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -137,6 +140,7 @@ func TestAccountsMigration_NameAllowedAcrossHouseholds(t *testing.T) {
 // TestAccountsMigration_SoftDeleteReleasesName verifies AC4: after an account is soft-deleted,
 // its name becomes available for reuse within the same household.
 func TestAccountsMigration_SoftDeleteReleasesName(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -177,6 +181,7 @@ func TestAccountsMigration_SoftDeleteReleasesName(t *testing.T) {
 // TestAccountsMigration_AccountTypeEnforced verifies AC5: only valid account_type values
 // are accepted; any other value is rejected by the CHECK constraint.
 func TestAccountsMigration_AccountTypeEnforced(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -204,6 +209,7 @@ func TestAccountsMigration_AccountTypeEnforced(t *testing.T) {
 // TestAccountsMigration_CurrencyCodeEnforced verifies AC6: only USD, BRL, and EUR are
 // valid currency codes; any other value is rejected by the CHECK constraint.
 func TestAccountsMigration_CurrencyCodeEnforced(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -231,6 +237,7 @@ func TestAccountsMigration_CurrencyCodeEnforced(t *testing.T) {
 // TestAccountsMigration_RollbackRemovesTable verifies AC7: rolling back the accounts
 // migration drops the table and all constraints cleanly.
 func TestAccountsMigration_RollbackRemovesTable(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	sub := usersMigrationsFS(t)

--- a/internal/platform/database/credit_card_settings_migration_integration_test.go
+++ b/internal/platform/database/credit_card_settings_migration_integration_test.go
@@ -14,6 +14,7 @@ import (
 // TestCreditCardSettingsMigration_ReferencesOneAccount verifies AC1: credit card settings
 // reference exactly one account via account_id FK.
 func TestCreditCardSettingsMigration_ReferencesOneAccount(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -51,6 +52,7 @@ func TestCreditCardSettingsMigration_ReferencesOneAccount(t *testing.T) {
 // TestCreditCardSettingsMigration_UniquePerAccount verifies AC2: a second set of settings
 // for the same account is rejected by the unique constraint on account_id.
 func TestCreditCardSettingsMigration_UniquePerAccount(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -90,6 +92,7 @@ func TestCreditCardSettingsMigration_UniquePerAccount(t *testing.T) {
 // TestCreditCardSettingsMigration_ClosingDayRange verifies AC3 + EC1: closing_day must be
 // between 1 and 31 inclusive. Tests boundary violations at 0 and 32.
 func TestCreditCardSettingsMigration_ClosingDayRange(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -138,6 +141,7 @@ func TestCreditCardSettingsMigration_ClosingDayRange(t *testing.T) {
 // TestCreditCardSettingsMigration_DueDayRange verifies AC4 + EC2: due_day must be
 // between 1 and 31 inclusive.
 func TestCreditCardSettingsMigration_DueDayRange(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -186,6 +190,7 @@ func TestCreditCardSettingsMigration_DueDayRange(t *testing.T) {
 // TestCreditCardSettingsMigration_LimitAmountIsBigint verifies AC5 + EC4: limit_amount
 // is stored as BIGINT (minor units) and accepts large values without precision loss.
 func TestCreditCardSettingsMigration_LimitAmountIsBigint(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -225,6 +230,7 @@ func TestCreditCardSettingsMigration_LimitAmountIsBigint(t *testing.T) {
 // TestCreditCardSettingsMigration_RollbackRemovesTable verifies AC6: rolling back the
 // credit_card_settings migration drops the table cleanly.
 func TestCreditCardSettingsMigration_RollbackRemovesTable(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	sub := usersMigrationsFS(t)

--- a/internal/platform/database/database_integration_test.go
+++ b/internal/platform/database/database_integration_test.go
@@ -8,52 +8,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"github.com/zambone/pfm-go/internal/platform/config"
 )
 
 func TestOpen_WhenDatabaseAvailable_ReturnsConfiguredPool(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
-	ctr, err := postgres.Run(ctx,
-		"postgres:18-alpine3.23",
-		postgres.WithDatabase("testdb"),
-		postgres.WithUsername("testuser"),
-		postgres.WithPassword("testpass"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2),
-		),
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = ctr.Terminate(ctx) }) // best-effort
+	// newTestDB creates an isolated per-test database and opens it via Open().
+	// A successful open proves the database is available and Open is configured correctly.
+	db := newTestDB(t, ctx)
 
-	host, err := ctr.Host(ctx)
-	require.NoError(t, err)
-	mappedPort, err := ctr.MappedPort(ctx, "5432")
-	require.NoError(t, err)
-
-	cfg := &config.Config{
-		DatabaseHost:           host,
-		DatabasePort:           mappedPort.Int(),
-		DatabaseUser:           "testuser",
-		DatabasePassword:       "testpass",
-		DatabaseName:           "testdb",
-		DatabaseSSLMode:        "disable",
-		DBConnectTimeoutSec:    5,
-		DBStartupRetries:       3,
-		DBStartupRetryDelaySec: 1,
-		DBMaxOpenConns:         5,
-		DBMaxIdleConns:         2,
-		DBConnMaxLifetimeSec:   60,
-		DBConnMaxIdleTimeSec:   30,
-	}
-
-	db, err := Open(ctx, cfg)
-
-	require.NoError(t, err)
-	assert.NotNil(t, db)
-	t.Cleanup(func() { _ = db.Close() }) // best-effort
+	require.NotNil(t, db)
+	assert.NoError(t, db.Ping())
 }

--- a/internal/platform/database/households_migration_integration_test.go
+++ b/internal/platform/database/households_migration_integration_test.go
@@ -14,6 +14,7 @@ import (
 // TestHouseholdsMigration_DefaultsOnCreate verifies AC1: a newly created household has
 // status = 'ACTIVE', version = 1, and non-null audit timestamps.
 func TestHouseholdsMigration_DefaultsOnCreate(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -48,6 +49,7 @@ func TestHouseholdsMigration_DefaultsOnCreate(t *testing.T) {
 // TestHouseholdsMigration_MembershipRecordsFields verifies AC2: a membership row captures
 // household_id, user_id, role, and invited_by correctly.
 func TestHouseholdsMigration_MembershipRecordsFields(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -106,6 +108,7 @@ func TestHouseholdsMigration_MembershipRecordsFields(t *testing.T) {
 // TestHouseholdsMigration_RoleEnforcedByCheck verifies AC3: only 'ADMIN' and 'MEMBER'
 // are valid role values — any other value must be rejected by the CHECK constraint.
 func TestHouseholdsMigration_RoleEnforcedByCheck(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -133,6 +136,7 @@ func TestHouseholdsMigration_RoleEnforcedByCheck(t *testing.T) {
 // TestHouseholdsMigration_SoftDeletedHouseholdExcluded verifies AC4: a soft-deleted
 // household must not appear in queries that filter WHERE deleted_at IS NULL.
 func TestHouseholdsMigration_SoftDeletedHouseholdExcluded(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -168,6 +172,7 @@ func TestHouseholdsMigration_SoftDeletedHouseholdExcluded(t *testing.T) {
 // TestHouseholdsMigration_SoftDeletedMemberRetained verifies AC5: soft-deleting a
 // membership record sets deleted_at but retains the row for audit purposes.
 func TestHouseholdsMigration_SoftDeletedMemberRetained(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -212,6 +217,7 @@ func TestHouseholdsMigration_SoftDeletedMemberRetained(t *testing.T) {
 // TestHouseholdsMigration_RollbackRemovesBothTables verifies AC6: rolling back the
 // household migration drops both tables and all associated constraints cleanly.
 func TestHouseholdsMigration_RollbackRemovesBothTables(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	sub := usersMigrationsFS(t)

--- a/internal/platform/database/migrate_integration_test.go
+++ b/internal/platform/database/migrate_integration_test.go
@@ -22,6 +22,7 @@ func validMigrationFS() fstest.MapFS {
 }
 
 func TestMigrate_WhenNoMigrations_Succeeds(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 
@@ -31,6 +32,7 @@ func TestMigrate_WhenNoMigrations_Succeeds(t *testing.T) {
 }
 
 func TestMigrate_WhenMigrationsApplied_IsIdempotent(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	fs := validMigrationFS()
@@ -42,6 +44,7 @@ func TestMigrate_WhenMigrationsApplied_IsIdempotent(t *testing.T) {
 }
 
 func TestMigrate_WhenSingleMigrationApplied_TableExists(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 
@@ -56,6 +59,7 @@ func TestMigrate_WhenSingleMigrationApplied_TableExists(t *testing.T) {
 }
 
 func TestMigrate_WhenMigrationFails_ReturnsError(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	badFS := fstest.MapFS{

--- a/internal/platform/database/testhelper_test.go
+++ b/internal/platform/database/testhelper_test.go
@@ -5,116 +5,71 @@ package database
 import (
 	"context"
 	"database/sql"
-	"io/fs"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
-	pfmdb "github.com/zambone/pfm-go/db"
-	"github.com/zambone/pfm-go/internal/platform/config"
 )
 
-// newTestDb spins up a real Postgres container and returns an open *sql.DB.
-// Each call creates an isolated container - tests never share state.
+// newTestDB creates an isolated per-test database (no migrations) cloned from
+// the admin connection. The caller is expected to run migrations inside the test.
+// The database is dropped in t.Cleanup.
 func newTestDB(t *testing.T, ctx context.Context) *sql.DB {
 	t.Helper()
 
-	ctr, err := postgres.Run(ctx,
-		"postgres:18-alpine3.23",
-		postgres.WithDatabase("testdb"),
-		postgres.WithUsername("testuser"),
-		postgres.WithPassword("testpass"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2),
-		),
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = ctr.Terminate(ctx) })
+	dbName := "test_" + strings.ReplaceAll(uuid.New().String(), "-", "")
+	conn := dbAdminConn(ctx)
+	dbAdminExec(ctx, conn, fmt.Sprintf(`CREATE DATABASE %s`, dbName))
+	conn.Close(ctx)
 
-	host, err := ctr.Host(ctx)
-	require.NoError(t, err)
-	mappedPort, err := ctr.MappedPort(ctx, "5432")
-	require.NoError(t, err)
+	t.Cleanup(func() {
+		dropCtx := context.Background()
+		dropConn := dbAdminConn(dropCtx)
+		defer dropConn.Close(dropCtx)
+		_, _ = dropConn.Exec(dropCtx, // best-effort
+			`SELECT pg_terminate_backend(pid) FROM pg_stat_activity `+
+				`WHERE datname = $1 AND pid <> pg_backend_pid()`,
+			dbName,
+		)
+		_, _ = dropConn.Exec(dropCtx, fmt.Sprintf(`DROP DATABASE IF EXISTS %s`, dbName)) // best-effort
+	})
 
-	cfg := &config.Config{
-		DatabaseHost:           host,
-		DatabasePort:           mappedPort.Int(),
-		DatabaseName:           "testdb",
-		DatabaseUser:           "testuser",
-		DatabasePassword:       "testpass",
-		DatabaseSSLMode:        "disable",
-		DBConnectTimeoutSec:    5,
-		DBStartupRetries:       3,
-		DBStartupRetryDelaySec: 1,
-		DBMaxOpenConns:         5,
-		DBMaxIdleConns:         2,
-		DBConnMaxLifetimeSec:   60,
-		DBConnMaxIdleTimeSec:   30,
-	}
-
-	db, err := Open(ctx, cfg)
+	db, err := Open(ctx, dbURLToConfig(dbReplaceDBName(dbAdminURL, dbName)))
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() { _ = db.Close() }) // best-effort
 
 	return db
 }
 
-// newTestPool spins up a real Postgres container, runs all migrations, and returns
-// a *pgxpool.Pool connected to it. Used by transactor integration tests.
-// Each call creates an isolated container — tests never share state.
+// newTestPool creates an isolated per-test database cloned from pfm_template
+// (which has all migrations applied) and returns a *pgxpool.Pool connected to it.
+// The database is dropped in t.Cleanup.
 func newTestPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
 
-	ctr, err := postgres.Run(ctx,
-		"postgres:18-alpine3.23",
-		postgres.WithDatabase("testdb"),
-		postgres.WithUsername("testuser"),
-		postgres.WithPassword("testpass"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2),
-		),
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = ctr.Terminate(ctx) })
+	dbName := "test_" + strings.ReplaceAll(uuid.New().String(), "-", "")
+	conn := dbAdminConn(ctx)
+	dbAdminExec(ctx, conn, fmt.Sprintf(`CREATE DATABASE %s TEMPLATE %s`, dbName, dbTemplateDB))
+	conn.Close(ctx)
 
-	host, err := ctr.Host(ctx)
-	require.NoError(t, err)
-	mappedPort, err := ctr.MappedPort(ctx, "5432")
-	require.NoError(t, err)
+	t.Cleanup(func() {
+		dropCtx := context.Background()
+		dropConn := dbAdminConn(dropCtx)
+		defer dropConn.Close(dropCtx)
+		_, _ = dropConn.Exec(dropCtx, // best-effort
+			`SELECT pg_terminate_backend(pid) FROM pg_stat_activity `+
+				`WHERE datname = $1 AND pid <> pg_backend_pid()`,
+			dbName,
+		)
+		_, _ = dropConn.Exec(dropCtx, fmt.Sprintf(`DROP DATABASE IF EXISTS %s`, dbName)) // best-effort
+	})
 
-	cfg := &config.Config{
-		DatabaseHost:           host,
-		DatabasePort:           mappedPort.Int(),
-		DatabaseName:           "testdb",
-		DatabaseUser:           "testuser",
-		DatabasePassword:       "testpass",
-		DatabaseSSLMode:        "disable",
-		DBConnectTimeoutSec:    5,
-		DBStartupRetries:       3,
-		DBStartupRetryDelaySec: 1,
-		DBMaxOpenConns:         5,
-		DBMaxIdleConns:         2,
-		DBConnMaxLifetimeSec:   60,
-		DBConnMaxIdleTimeSec:   30,
-	}
-
-	// Run migrations using the database/sql adapter (required by goose).
-	sqlDB, err := Open(ctx, cfg)
+	pool, err := NewPool(ctx, dbURLToConfig(dbReplaceDBName(dbAdminURL, dbName)))
 	require.NoError(t, err)
-	sub, err := fs.Sub(pfmdb.Migrations, "migrations")
-	require.NoError(t, err)
-	require.NoError(t, Migrate(ctx, sqlDB, sub))
-	require.NoError(t, sqlDB.Close())
-
-	// Open the pgx-native pool for application use.
-	pool, err := NewPool(ctx, cfg)
-	require.NoError(t, err)
-	t.Cleanup(func() { pool.Close() })
+	t.Cleanup(pool.Close)
 
 	return pool
 }

--- a/internal/platform/database/testmain_test.go
+++ b/internal/platform/database/testmain_test.go
@@ -1,0 +1,135 @@
+//go:build integration
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	pfmdb "github.com/zambone/pfm-go/db"
+	"github.com/zambone/pfm-go/internal/platform/config"
+)
+
+// dbAdminURL points to the "postgres" admin database used for DDL (CREATE/DROP DATABASE).
+var dbAdminURL string
+
+const dbTemplateDB = "pfm_template"
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	cleanup := setupAdminURL(ctx)
+	defer cleanup()
+	prepareTemplate(ctx)
+	os.Exit(m.Run())
+}
+
+// setupAdminURL sets dbAdminURL from TEST_DATABASE_URL or starts a testcontainer.
+func setupAdminURL(ctx context.Context) func() {
+	if url := os.Getenv("TEST_DATABASE_URL"); url != "" {
+		dbAdminURL = url
+		return func() {}
+	}
+	return startLocalContainer(ctx)
+}
+
+// prepareTemplate creates pfm_template and applies all goose migrations to it.
+func prepareTemplate(ctx context.Context) {
+	conn := dbAdminConn(ctx)
+	dbAdminExec(ctx, conn, fmt.Sprintf(`DROP DATABASE IF EXISTS %s`, dbTemplateDB))
+	dbAdminExec(ctx, conn, fmt.Sprintf(`CREATE DATABASE %s`, dbTemplateDB))
+	conn.Close(ctx)
+
+	templateURL := dbReplaceDBName(dbAdminURL, dbTemplateDB)
+	sqlDB, err := Open(ctx, dbURLToConfig(templateURL))
+	if err != nil {
+		panic(fmt.Sprintf("testmain: open template: %v", err))
+	}
+	sub, err := fs.Sub(pfmdb.Migrations, "migrations")
+	if err != nil {
+		panic(fmt.Sprintf("testmain: sub migrations: %v", err))
+	}
+	if err := Migrate(ctx, sqlDB, sub); err != nil {
+		panic(fmt.Sprintf("testmain: migrate template: %v", err))
+	}
+	if err := sqlDB.Close(); err != nil {
+		panic(fmt.Sprintf("testmain: close template: %v", err))
+	}
+}
+
+func startLocalContainer(ctx context.Context) func() {
+	ctr, err := tcpostgres.Run(ctx,
+		"postgres:18-alpine3.23",
+		tcpostgres.WithDatabase("postgres"),
+		tcpostgres.WithUsername("testuser"),
+		tcpostgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2),
+		),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("testmain: start container: %v", err))
+	}
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("testmain: container host: %v", err))
+	}
+	port, err := ctr.MappedPort(ctx, "5432")
+	if err != nil {
+		panic(fmt.Sprintf("testmain: container port: %v", err))
+	}
+	dbAdminURL = fmt.Sprintf(
+		"postgres://testuser:testpass@%s:%s/postgres?sslmode=disable",
+		host, port.Port(),
+	)
+	return func() { _ = ctr.Terminate(ctx) } // best-effort
+}
+
+func dbAdminConn(ctx context.Context) *pgx.Conn {
+	conn, err := pgx.Connect(ctx, dbAdminURL)
+	if err != nil {
+		panic(fmt.Sprintf("testmain: admin connect: %v", err))
+	}
+	return conn
+}
+
+func dbAdminExec(ctx context.Context, conn *pgx.Conn, sql string) {
+	if _, err := conn.Exec(ctx, sql); err != nil {
+		panic(fmt.Sprintf("testmain: exec %q: %v", sql, err))
+	}
+}
+
+func dbReplaceDBName(adminURL, newDB string) string {
+	idx := strings.LastIndex(adminURL, "/")
+	if idx < 0 {
+		panic(fmt.Sprintf("testmain: malformed URL: %s", adminURL))
+	}
+	base := adminURL[:idx+1]
+	rest := adminURL[idx+1:]
+	if q := strings.Index(rest, "?"); q >= 0 {
+		return base + newDB + rest[q:]
+	}
+	return base + newDB
+}
+
+func dbURLToConfig(url string) *config.Config {
+	return &config.Config{
+		DatabaseURL:            url,
+		DBConnectTimeoutSec:    5,
+		DBStartupRetries:       3,
+		DBStartupRetryDelaySec: 1,
+		DBMaxOpenConns:         10,
+		DBMaxIdleConns:         5,
+		DBConnMaxLifetimeSec:   60,
+		DBConnMaxIdleTimeSec:   30,
+	}
+}

--- a/internal/platform/database/transactor_integration_test.go
+++ b/internal/platform/database/transactor_integration_test.go
@@ -14,6 +14,7 @@ import (
 // TestPostgresTransactor_CommitsOnSuccess verifies AC1+AC2: when fn returns nil,
 // all changes made inside the atomic block are visible after the call.
 func TestPostgresTransactor_CommitsOnSuccess(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pool := newTestPool(t, ctx)
 	tr := NewPostgresTransactor(pool)
@@ -41,6 +42,7 @@ func TestPostgresTransactor_CommitsOnSuccess(t *testing.T) {
 // TestPostgresTransactor_RollsBackOnError verifies AC3: when fn returns an error,
 // all changes made inside the atomic block are not visible after the call.
 func TestPostgresTransactor_RollsBackOnError(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pool := newTestPool(t, ctx)
 	tr := NewPostgresTransactor(pool)
@@ -73,6 +75,7 @@ func TestPostgresTransactor_RollsBackOnError(t *testing.T) {
 // TestPostgresTransactor_RollsBackOnPanic verifies the panic edge case: when fn
 // panics, the transaction is rolled back and the panic is re-raised.
 func TestPostgresTransactor_RollsBackOnPanic(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pool := newTestPool(t, ctx)
 	tr := NewPostgresTransactor(pool)
@@ -100,6 +103,7 @@ func TestPostgresTransactor_RollsBackOnPanic(t *testing.T) {
 // TestPostgresTransactor_RollsBackOnPanic_PreservesValue verifies that the panic
 // value is re-raised unchanged after rollback.
 func TestPostgresTransactor_RollsBackOnPanic_PreservesValue(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pool := newTestPool(t, ctx)
 	tr := NewPostgresTransactor(pool)
@@ -123,6 +127,7 @@ func TestPostgresTransactor_RollsBackOnPanic_PreservesValue(t *testing.T) {
 // the outer transaction rather than starting a new one. Both inserts commit or roll back
 // together.
 func TestPostgresTransactor_NestedCallUsesOuterTransaction(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pool := newTestPool(t, ctx)
 	tr := NewPostgresTransactor(pool)
@@ -163,6 +168,7 @@ func TestPostgresTransactor_NestedCallUsesOuterTransaction(t *testing.T) {
 // is rolled back (outer fn returns error), both outer and inner inserts are undone
 // even though the inner RunAtomic succeeded.
 func TestPostgresTransactor_NestedRollback(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pool := newTestPool(t, ctx)
 	tr := NewPostgresTransactor(pool)
@@ -206,6 +212,7 @@ func TestPostgresTransactor_NestedRollback(t *testing.T) {
 // TestPostgresTransactor_DBTXFromContext_NoTx_UsesPool verifies AC4: outside an
 // atomic block, DBTXFromContext returns the pool (regular connection).
 func TestPostgresTransactor_DBTXFromContext_NoTx_UsesPool(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pool := newTestPool(t, ctx)
 
@@ -221,6 +228,7 @@ func TestPostgresTransactor_DBTXFromContext_NoTx_UsesPool(t *testing.T) {
 // TestPostgresTransactor_DBTXFromContext_WithTx_UsesTx verifies AC5: inside an
 // atomic block, DBTXFromContext returns the transaction executor.
 func TestPostgresTransactor_DBTXFromContext_WithTx_UsesTx(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pool := newTestPool(t, ctx)
 	tr := NewPostgresTransactor(pool)

--- a/internal/platform/database/users_migration_integration_test.go
+++ b/internal/platform/database/users_migration_integration_test.go
@@ -29,6 +29,7 @@ var testPasswordHash = strings.Repeat("x", 128)
 // TestUsersMigration_UUIDGeneratedByDB verifies AC1: the database generates a UUIDv7
 // when a user is inserted without an explicit id.
 func TestUsersMigration_UUIDGeneratedByDB(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -47,6 +48,7 @@ func TestUsersMigration_UUIDGeneratedByDB(t *testing.T) {
 // TestUsersMigration_EmailUniquenessEnforced verifies AC2: inserting two active users
 // with the same email (case-insensitive) is rejected by the database.
 func TestUsersMigration_EmailUniquenessEnforced(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -68,6 +70,7 @@ func TestUsersMigration_EmailUniquenessEnforced(t *testing.T) {
 // TestUsersMigration_SoftDeleteAllowsEmailReuse verifies AC3: after a user is soft-deleted,
 // the same email can be registered again.
 func TestUsersMigration_SoftDeleteAllowsEmailReuse(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -96,6 +99,7 @@ func TestUsersMigration_SoftDeleteAllowsEmailReuse(t *testing.T) {
 // TestUsersMigration_TimestampsSetOnCreate verifies AC4: created_at and updated_at are
 // populated automatically when a row is inserted.
 func TestUsersMigration_TimestampsSetOnCreate(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -119,6 +123,7 @@ func TestUsersMigration_TimestampsSetOnCreate(t *testing.T) {
 // TestUsersMigration_CreatedAtImmutableOnUpdate verifies AC5: updating a row must not
 // change created_at — only updated_at is allowed to change.
 func TestUsersMigration_CreatedAtImmutableOnUpdate(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -154,6 +159,7 @@ func TestUsersMigration_CreatedAtImmutableOnUpdate(t *testing.T) {
 
 // TestUsersMigration_VersionStartsAtOne verifies AC6: every new row has version = 1.
 func TestUsersMigration_VersionStartsAtOne(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	require.NoError(t, Migrate(ctx, db, usersMigrationsFS(t)))
@@ -176,6 +182,7 @@ func TestUsersMigration_VersionStartsAtOne(t *testing.T) {
 // TestUsersMigration_RollbackRemovesTable verifies AC7: running the Down migration
 // drops the users table and all its indexes cleanly.
 func TestUsersMigration_RollbackRemovesTable(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db := newTestDB(t, ctx)
 	sub := usersMigrationsFS(t)

--- a/internal/testutil/dbtest/dbtest.go
+++ b/internal/testutil/dbtest/dbtest.go
@@ -1,0 +1,229 @@
+//go:build integration
+
+// Package dbtest provides shared PostgreSQL infrastructure for integration tests
+// in external test packages (package xxx_test). It manages a single Postgres
+// connection per test binary — either a GitHub Actions service container (when
+// TEST_DATABASE_URL is set) or a testcontainer for local development — and
+// creates per-test isolated databases cloned from a migrated template.
+//
+// Import cycle note: internal/platform/database tests (package database, internal)
+// cannot import this package without creating an import cycle. Those packages
+// replicate the same pattern inline.
+package dbtest
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	pfmdb "github.com/zambone/pfm-go/db"
+	"github.com/zambone/pfm-go/internal/platform/config"
+	"github.com/zambone/pfm-go/internal/platform/database"
+)
+
+const templateDB = "pfm_template"
+
+// SharedDB holds the admin connection URL (pointing to the postgres system
+// database) used to issue CREATE DATABASE / DROP DATABASE DDL commands.
+// NewPool is safe to call concurrently from parallel tests.
+type SharedDB struct {
+	// adminURL connects to the "postgres" system database as a superuser,
+	// used exclusively for DDL (CREATE DATABASE, DROP DATABASE).
+	adminURL string
+}
+
+// Setup returns a SharedDB ready for per-test database creation and a cleanup
+// function that terminates any testcontainer started for local development.
+//
+// If TEST_DATABASE_URL is set (e.g. by the GitHub Actions merge-quality-gate
+// workflow), the value is used directly and no container is started.
+// Otherwise, a postgres:18-alpine3.23 testcontainer is started.
+//
+// Call PrepareTemplate after Setup and before m.Run():
+//
+//	func TestMain(m *testing.M) {
+//	    ctx := context.Background()
+//	    db, cleanup := dbtest.Setup(ctx)
+//	    defer cleanup()
+//	    db.PrepareTemplate(ctx)
+//	    os.Exit(m.Run())
+//	}
+func Setup(ctx context.Context) (*SharedDB, func()) {
+	if url := os.Getenv("TEST_DATABASE_URL"); url != "" {
+		return &SharedDB{adminURL: url}, func() {}
+	}
+	return startContainer(ctx)
+}
+
+// PrepareTemplate creates the pfm_template database and applies all goose
+// migrations to it. After this call, pfm_template has no active connections
+// and is ready to be cloned by NewPool.
+//
+// Must be called once in TestMain, after Setup and before m.Run().
+func (s *SharedDB) PrepareTemplate(ctx context.Context) {
+	conn := s.adminConn(ctx)
+
+	// Drop and recreate so TestMain is idempotent when a persistent service
+	// container is reused across workflow retries.
+	mustExec(ctx, conn, fmt.Sprintf(`DROP DATABASE IF EXISTS %s`, templateDB))
+	mustExec(ctx, conn, fmt.Sprintf(`CREATE DATABASE %s`, templateDB))
+	conn.Close(ctx)
+
+	// Apply all goose migrations via the database/sql adapter.
+	templateURL := replaceDBName(s.adminURL, templateDB)
+	sqlDB, err := database.Open(ctx, urlToConfig(templateURL))
+	if err != nil {
+		panic(fmt.Sprintf("dbtest: open template db: %v", err))
+	}
+	sub, err := fs.Sub(pfmdb.Migrations, "migrations")
+	if err != nil {
+		panic(fmt.Sprintf("dbtest: sub migrations fs: %v", err))
+	}
+	if err := database.Migrate(ctx, sqlDB, sub); err != nil {
+		panic(fmt.Sprintf("dbtest: migrate template db: %v", err))
+	}
+	// Close ALL connections to pfm_template. Postgres requires no active
+	// sessions on the template database when CREATE DATABASE ... TEMPLATE
+	// is executed. This satisfies that requirement before m.Run().
+	if err := sqlDB.Close(); err != nil {
+		panic(fmt.Sprintf("dbtest: close template db: %v", err))
+	}
+}
+
+// NewPool creates an isolated per-test database cloned from pfm_template and
+// returns a *pgxpool.Pool connected to it. The database is dropped in
+// t.Cleanup so each test starts and ends with clean state.
+//
+// Call t.Parallel() in the test before or after NewPool — both work correctly.
+func (s *SharedDB) NewPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+
+	dbName := "test_" + strings.ReplaceAll(uuid.New().String(), "-", "")
+
+	// CREATE DATABASE runs against the admin (postgres) database, never against
+	// pfm_template itself, so no session is connected to the template during cloning.
+	conn := s.adminConn(ctx)
+	mustExec(ctx, conn,
+		fmt.Sprintf(`CREATE DATABASE %s TEMPLATE %s`, dbName, templateDB),
+	)
+	conn.Close(ctx)
+
+	t.Cleanup(func() {
+		dropCtx := context.Background()
+		dropConn := s.adminConn(dropCtx)
+		defer dropConn.Close(dropCtx)
+		// Terminate lingering connections before dropping — prevents
+		// "database is being accessed by other users" errors.
+		_, _ = dropConn.Exec(dropCtx, // best-effort
+			`SELECT pg_terminate_backend(pid) FROM pg_stat_activity `+
+				`WHERE datname = $1 AND pid <> pg_backend_pid()`,
+			dbName,
+		)
+		_, _ = dropConn.Exec(dropCtx, // best-effort
+			fmt.Sprintf(`DROP DATABASE IF EXISTS %s`, dbName),
+		)
+	})
+
+	pool, err := database.NewPool(ctx, urlToConfig(replaceDBName(s.adminURL, dbName)))
+	if err != nil {
+		t.Fatalf("dbtest: open pool for %s: %v", dbName, err)
+	}
+	t.Cleanup(pool.Close)
+
+	return pool
+}
+
+// ── internal helpers ──────────────────────────────────────────────────────────
+
+func startContainer(ctx context.Context) (*SharedDB, func()) {
+	ctr, err := tcpostgres.Run(ctx,
+		"postgres:18-alpine3.23",
+		// Use "postgres" as the default database so the admin URL is predictable.
+		tcpostgres.WithDatabase("postgres"),
+		tcpostgres.WithUsername("testuser"),
+		tcpostgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2),
+		),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("dbtest: start container: %v", err))
+	}
+
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("dbtest: container host: %v", err))
+	}
+	port, err := ctr.MappedPort(ctx, "5432")
+	if err != nil {
+		panic(fmt.Sprintf("dbtest: container port: %v", err))
+	}
+
+	adminURL := fmt.Sprintf(
+		"postgres://testuser:testpass@%s:%s/postgres?sslmode=disable",
+		host, port.Port(),
+	)
+	return &SharedDB{adminURL: adminURL}, func() {
+		_ = ctr.Terminate(ctx) // best-effort
+	}
+}
+
+// adminConn returns a single *pgx.Conn to the admin (postgres) database.
+// The caller is responsible for closing it.
+func (s *SharedDB) adminConn(ctx context.Context) *pgx.Conn {
+	conn, err := pgx.Connect(ctx, s.adminURL)
+	if err != nil {
+		panic(fmt.Sprintf("dbtest: admin connect %s: %v", s.adminURL, err))
+	}
+	return conn
+}
+
+// mustExec executes a SQL statement on conn and panics on error.
+func mustExec(ctx context.Context, conn *pgx.Conn, sql string) {
+	if _, err := conn.Exec(ctx, sql); err != nil {
+		panic(fmt.Sprintf("dbtest: exec %q: %v", sql, err))
+	}
+}
+
+// replaceDBName replaces the database name segment in a postgres URL.
+//
+//	postgres://u:p@h:5432/postgres?sslmode=disable
+//	→ postgres://u:p@h:5432/new_name?sslmode=disable
+func replaceDBName(adminURL, newDB string) string {
+	idx := strings.LastIndex(adminURL, "/")
+	if idx < 0 {
+		panic(fmt.Sprintf("dbtest: malformed URL (no slash): %s", adminURL))
+	}
+	base := adminURL[:idx+1]
+	rest := adminURL[idx+1:] // everything after the last slash (db + optional query)
+	if q := strings.Index(rest, "?"); q >= 0 {
+		return base + newDB + rest[q:] // preserve ?sslmode=disable etc.
+	}
+	return base + newDB
+}
+
+// urlToConfig builds a *config.Config from a full postgres URL.
+// database.Open and database.NewPool both honour cfg.DatabaseURL when set.
+func urlToConfig(url string) *config.Config {
+	return &config.Config{
+		DatabaseURL:            url,
+		DBConnectTimeoutSec:    5,
+		DBStartupRetries:       3,
+		DBStartupRetryDelaySec: 1,
+		DBMaxOpenConns:         10,
+		DBMaxIdleConns:         5,
+		DBConnMaxLifetimeSec:   60,
+		DBConnMaxIdleTimeSec:   30,
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/testutil/dbtest` package with `Setup`, `PrepareTemplate`, and `NewPool` — one testcontainer per package binary (or zero in CI), then `CREATE DATABASE test_<uuid> TEMPLATE pfm_template` per test (< 100ms each)
- Adds `TestMain` to `adapter/postgres`, `adapter/http`, and `platform/database` — shared infrastructure, no per-test container startup
- Replaces all `newTestPool`/`newE2EPool` calls with `sharedDB.NewPool` across 25 test files
- Adds `t.Parallel()` to every integration test function (201 total) for full in-package concurrency
- Updates `merge-quality-gate.yml` to declare a `postgres:18-alpine3.23` service container and pass `TEST_DATABASE_URL` — eliminates container startup cost in CI entirely
- `platform/database` uses an inline `TestMain` to avoid an import cycle (`database_test → dbtest → database`)

Expected result: integration test wall-clock drops from ~3.5 minutes to ~2–5 seconds in CI.

## Test plan
- [x] `make ci` passes (lint + test -race + build)
- [x] `/project:verify-issue` verdict: PASS
- [x] `/project:review` verdict: PASS (all categories)
- [x] Integration tests pass with testcontainers locally: postgres=9.2s, http=14.9s, database=13.6s