### PR TITLE
fix(ci): fix concurrent template creation race and remove redundant workflow trigger

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -1,13 +1,12 @@
-# PR Quality Gate — runs on every PR against main and on every push to main.
+# PR Quality Gate — runs on every PR against main.
 # Steps: lint → unit tests (no integration) → build.
+# Post-merge checks (including integration tests) run in merge-quality-gate.yml.
 # All action versions are pinned; no `latest` references.
 
 name: PR Quality Gate
 
 on:
   pull_request:
-    branches: [main]
-  push:
     branches: [main]
 
 permissions:

--- a/internal/platform/database/testmain_test.go
+++ b/internal/platform/database/testmain_test.go
@@ -42,11 +42,28 @@ func setupAdminURL(ctx context.Context) func() {
 }
 
 // prepareTemplate creates pfm_template and applies all goose migrations to it.
+// Safe to call concurrently: uses a Postgres advisory lock so only the first
+// caller creates and migrates the template; others wait, see it exists, and return.
 func prepareTemplate(ctx context.Context) {
 	conn := dbAdminConn(ctx)
-	dbAdminExec(ctx, conn, fmt.Sprintf(`DROP DATABASE IF EXISTS %s`, dbTemplateDB))
+	defer conn.Close(ctx)
+
+	// Serialize concurrent prepareTemplate calls across packages sharing the
+	// same Postgres service container in CI.
+	dbAdminExec(ctx, conn, `SELECT pg_advisory_lock(7382910)`)
+
+	var exists bool
+	if err := conn.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)`, dbTemplateDB,
+	).Scan(&exists); err != nil {
+		panic(fmt.Sprintf("testmain: check template exists: %v", err))
+	}
+	if exists {
+		// Already created and migrated by another package's TestMain.
+		return
+	}
+
 	dbAdminExec(ctx, conn, fmt.Sprintf(`CREATE DATABASE %s`, dbTemplateDB))
-	conn.Close(ctx)
 
 	templateURL := dbReplaceDBName(dbAdminURL, dbTemplateDB)
 	sqlDB, err := Open(ctx, dbURLToConfig(templateURL))
@@ -63,6 +80,7 @@ func prepareTemplate(ctx context.Context) {
 	if err := sqlDB.Close(); err != nil {
 		panic(fmt.Sprintf("testmain: close template: %v", err))
 	}
+	// defer conn.Close(ctx) releases the advisory lock.
 }
 
 func startLocalContainer(ctx context.Context) func() {

--- a/internal/testutil/dbtest/dbtest.go
+++ b/internal/testutil/dbtest/dbtest.go
@@ -69,17 +69,38 @@ func Setup(ctx context.Context) (*SharedDB, func()) {
 // migrations to it. After this call, pfm_template has no active connections
 // and is ready to be cloned by NewPool.
 //
+// Safe to call concurrently from multiple packages sharing the same Postgres
+// server (e.g. the GitHub Actions service container). An advisory lock ensures
+// only the first caller creates and migrates the template; subsequent callers
+// block until the template is ready, then return immediately.
+//
 // Must be called once in TestMain, after Setup and before m.Run().
 func (s *SharedDB) PrepareTemplate(ctx context.Context) {
 	conn := s.adminConn(ctx)
+	defer conn.Close(ctx)
 
-	// Drop and recreate so TestMain is idempotent when a persistent service
-	// container is reused across workflow retries.
-	mustExec(ctx, conn, fmt.Sprintf(`DROP DATABASE IF EXISTS %s`, templateDB))
+	// Serialize concurrent PrepareTemplate calls across packages. In CI all
+	// packages share the same Postgres service container and their TestMain
+	// functions run in parallel. The advisory lock ensures only one caller
+	// creates and migrates pfm_template; the others wait, then see it exists
+	// and return without repeating the work.
+	mustExec(ctx, conn, `SELECT pg_advisory_lock(7382910)`)
+
+	var exists bool
+	if err := conn.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)`, templateDB,
+	).Scan(&exists); err != nil {
+		panic(fmt.Sprintf("dbtest: check template exists: %v", err))
+	}
+	if exists {
+		// Already created and migrated by another package's TestMain.
+		return
+	}
+
 	mustExec(ctx, conn, fmt.Sprintf(`CREATE DATABASE %s`, templateDB))
-	conn.Close(ctx)
 
-	// Apply all goose migrations via the database/sql adapter.
+	// Apply goose migrations while the advisory lock is held, so concurrent
+	// callers cannot use pfm_template before it is fully migrated.
 	templateURL := replaceDBName(s.adminURL, templateDB)
 	sqlDB, err := database.Open(ctx, urlToConfig(templateURL))
 	if err != nil {
@@ -98,6 +119,7 @@ func (s *SharedDB) PrepareTemplate(ctx context.Context) {
 	if err := sqlDB.Close(); err != nil {
 		panic(fmt.Sprintf("dbtest: close template db: %v", err))
 	}
+	// defer conn.Close(ctx) releases the advisory lock when PrepareTemplate returns.
 }
 
 // NewPool creates an isolated per-test database cloned from pfm_template and


### PR DESCRIPTION
## Summary
- Fixes panic in `adapter/http` TestMain: when multiple packages share the same Postgres service container in CI, their `PrepareTemplate` calls race on `CREATE DATABASE pfm_template`. Fix: `pg_advisory_lock(7382910)` serializes callers — first one creates+migrates the template, others wait then skip
- Removes `push: branches: [main]` from `pr-quality-gate.yml` — the PR gate only needs to run on PRs for branch protection; the merge gate already covers post-merge verification, so lint+unit+build was running twice redundantly after every squash-merge

## Test plan
- [x] `make ci` passes (lint + test -race + build)
- [x] Integration tests pass: all three packages green with shared testcontainer