### PR TITLE
chore(ci): warm module cache before integration tests

### DIFF
--- a/.github/workflows/merge-quality-gate.yml
+++ b/.github/workflows/merge-quality-gate.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Test (unit)
         run: go test -race -count=1 ./...
 
+      - name: Download integration modules
+        # testcontainers-go and its transitive deps are only pulled by integration
+        # build tags. The unit-test step above does not download them, so they
+        # would be fetched during the test run itself (adding latency). This step
+        # warms the module cache before compilation and test execution begins.
+        run: go mod download
+
       - name: Test (integration)
         env:
           TEST_DATABASE_URL: postgres://testuser:testpass@localhost:5432/postgres?sslmode=disable


### PR DESCRIPTION
## Summary
- Adds a `go mod download` step between unit and integration tests in merge-quality-gate.yml
- testcontainers-go deps are not compiled during `go test ./...` (no integration tag), so the module cache is cold when the integration step starts — modules were being downloaded during the test run itself
- This step warms the cache before compilation begins, removing download latency from reported test times

## Test plan
- [x] No code changes — workflow only
- [x] `make ci` passes locally