### PR TITLE
chore(ci): rename unit test step and add binary smoke test to merge gate

### DIFF
--- a/.github/workflows/merge-quality-gate.yml
+++ b/.github/workflows/merge-quality-gate.yml
@@ -58,3 +58,26 @@ jobs:
 
       - name: Build
         run: make build
+
+      - name: Smoke test
+        # Start the compiled binary against the service container Postgres and
+        # verify it reaches a healthy state. This is the only test that exercises
+        # the full main.go startup path — repos, logic, middleware, and HTTP server
+        # wired together as they are in production.
+        # TOKEN_SECRET_KEY is a throwaway 32-byte hex key (64 hex chars), safe for CI.
+        env:
+          DATABASE_URL: postgres://testuser:testpass@localhost:5432/postgres?sslmode=disable
+          TOKEN_SECRET_KEY: "0000000000000000000000000000000000000000000000000000000000000001"
+          HTTP_PORT: "9090"
+        run: |
+          ./bin/pfm &
+          PFM_PID=$!
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:9090/health/live > /dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+          curl -sf http://localhost:9090/health/live
+          curl -sf http://localhost:9090/health/ready
+          kill $PFM_PID

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -35,9 +35,8 @@ jobs:
           # dev machines and CI. golangci-lint v2 requires action v7+.
           version: v2.10.1
 
-      - name: Test
-        # Run unit tests only — integration tests require Docker and run in the
-        # merge-to-main gate (issue #156). No -tags integration here.
+      - name: Test (unit)
+        # Unit tests only — integration tests run in merge-quality-gate.yml.
         run: go test -race -count=1 ./...
 
       - name: Build


### PR DESCRIPTION
## Summary
- Renames the \`Test\` step in pr-quality-gate.yml to \`Test (unit)\` to make it explicit that integration tests are not included
- Adds a \`Smoke test\` step to merge-quality-gate.yml that starts the compiled \`bin/pfm\` binary against the service container Postgres and asserts \`/health/live\` and \`/health/ready\` return 200 — this is the only test that exercises the full \`main.go\` startup path (DB connect, goose migrations, all wiring) rather than the httptest-based integration tests

## What the smoke test covers
- \`main.go\` wires up without panicking
- DB connection pool reaches the server
- Goose migrations apply cleanly against the service container
- HTTP server binds and responds within 15s
- Both health endpoints return 200 (process alive, not shutting down)