### PR TITLE
feat(household): replace public user registration with household-scoped atomic creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Binaries
 bin/
-pfm
+/pfm
 *.exe
 
 # Test artifacts

--- a/cmd/pfm/main.go
+++ b/cmd/pfm/main.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
+
 	pfmhttp "github.com/zambone/pfm-go/internal/adapter/http"
 	authadapter "github.com/zambone/pfm-go/internal/adapter/auth"
 	pgadapter "github.com/zambone/pfm-go/internal/adapter/postgres"
@@ -125,6 +127,12 @@ func run() error {
 		time.Duration(cfg.TokenExpirationSec)*time.Second,
 	)
 	householdLogic := domainhousehold.NewHouseholdLogic(householdRepo, transactor, realClock)
+	householdMemberLogic := domainhousehold.NewHouseholdMemberLogic(
+		householdRepo,
+		newHouseholdUserCreator(userLogic),
+		transactor,
+		realClock,
+	)
 	accountLogic := domainaccount.NewAccountLogic(accountRepo, realClock)
 	ccSettingsLogic := domaincreditcard.NewSettingsLogic(
 		ccSettingsRepo,
@@ -147,7 +155,6 @@ func run() error {
 
 		// User
 		LoginSvc:          loginLogic,
-		RegisterSvc:       userLogic,
 		GetUserSvc:        userLogic,
 		UpdateProfileSvc:  userLogic,
 		ChangePasswordSvc: userLogic,
@@ -155,6 +162,7 @@ func run() error {
 
 		// Household
 		CreateHouseholdSvc:     householdLogic,
+		CreateHouseholdUserSvc: householdMemberLogic,
 		GetHouseholdSvc:        householdLogic,
 		ListHouseholdsSvc:      householdLogic,
 		AddMemberSvc:           householdLogic,
@@ -222,4 +230,35 @@ func run() error {
 	}
 
 	return nil
+}
+
+// householdUserCreator adapts UserLogic to the household.userCreator interface.
+// It lives here — in the composition root — because it bridges two domain packages
+// that must not import each other.
+type householdUserCreator struct {
+	logic *domainuser.UserLogic
+}
+
+// newHouseholdUserCreator returns a householdUserCreator wrapping the given UserLogic.
+func newHouseholdUserCreator(logic *domainuser.UserLogic) *householdUserCreator {
+	return &householdUserCreator{logic: logic}
+}
+
+// Create implements the household.userCreator interface. It delegates to UserLogic.Register,
+// which handles validation and password hashing, then maps the result to the household
+// domain's minimal CreatedUser type.
+func (a *householdUserCreator) Create(ctx context.Context, input domainhousehold.NewUserInput, callerID uuid.UUID) (domainhousehold.CreatedUser, error) {
+	u, err := a.logic.Register(ctx, domainuser.RegisterInput{
+		Email:       input.Email,
+		DisplayName: input.DisplayName,
+		Password:    input.Password,
+	}, callerID)
+	if err != nil {
+		return domainhousehold.CreatedUser{}, err
+	}
+	return domainhousehold.CreatedUser{
+		ID:          u.ID,
+		Email:       u.Email,
+		DisplayName: u.DisplayName,
+	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/zambone/pfm-go
 
-go 1.26.1
+go 1.26.2
 
 require (
+	aidanwoods.dev/go-paseto v1.6.0
+	github.com/alexedwards/argon2id v1.0.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/pressly/goose/v3 v3.27.0
@@ -16,12 +18,10 @@ require (
 )
 
 require (
-	aidanwoods.dev/go-paseto v1.6.0 // indirect
 	aidanwoods.dev/go-result v0.3.1 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/alexedwards/argon2id v1.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/internal/adapter/http/e2e_integration_test.go
+++ b/internal/adapter/http/e2e_integration_test.go
@@ -6,12 +6,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -29,7 +32,9 @@ import (
 
 // e2eEnv holds the fully wired test environment for E2E tests.
 type e2eEnv struct {
-	mux *http.ServeMux
+	mux    *http.ServeMux
+	pool   *pgxpool.Pool // direct DB access for bootstrapAdmin
+	hasher *authadapter.Argon2idHasher
 }
 
 // newE2EEnv spins up a Postgres testcontainer, runs migrations, and wires the
@@ -60,6 +65,12 @@ func newE2EEnv(t *testing.T, ctx context.Context) *e2eEnv {
 		15*time.Minute,
 	)
 	householdLogic := domainhousehold.NewHouseholdLogic(householdRepo, transactor, realClock)
+	householdMemberLogic := domainhousehold.NewHouseholdMemberLogic(
+		householdRepo,
+		newE2EHouseholdUserCreator(userLogic),
+		transactor,
+		realClock,
+	)
 	accountLogic := domainaccount.NewAccountLogic(accountRepo, realClock)
 	ccSettingsLogic := domaincreditcard.NewSettingsLogic(
 		ccSettingsRepo,
@@ -80,13 +91,13 @@ func newE2EEnv(t *testing.T, ctx context.Context) *e2eEnv {
 		MembershipFinder: membershipFinder,
 
 		LoginSvc:          loginLogic,
-		RegisterSvc:       userLogic,
 		GetUserSvc:        userLogic,
 		UpdateProfileSvc:  userLogic,
 		ChangePasswordSvc: userLogic,
 		DeactivateUserSvc: userLogic,
 
 		CreateHouseholdSvc:     householdLogic,
+		CreateHouseholdUserSvc: householdMemberLogic,
 		GetHouseholdSvc:        householdLogic,
 		ListHouseholdsSvc:      householdLogic,
 		AddMemberSvc:           householdLogic,
@@ -113,7 +124,79 @@ func newE2EEnv(t *testing.T, ctx context.Context) *e2eEnv {
 		GetTransactionHistorySvc: ledgerLogic,
 	})
 
-	return &e2eEnv{mux: mux}
+	return &e2eEnv{mux: mux, pool: pool, hasher: hasher}
+}
+
+// e2eHouseholdUserCreator adapts UserLogic to the household.userCreator interface
+// for E2E tests. This mirrors the production adapter in cmd/pfm/main.go.
+type e2eHouseholdUserCreator struct {
+	logic *domainuser.UserLogic
+}
+
+func newE2EHouseholdUserCreator(logic *domainuser.UserLogic) *e2eHouseholdUserCreator {
+	return &e2eHouseholdUserCreator{logic: logic}
+}
+
+func (a *e2eHouseholdUserCreator) Create(ctx context.Context, input domainhousehold.NewUserInput, callerID uuid.UUID) (domainhousehold.CreatedUser, error) {
+	u, err := a.logic.Register(ctx, domainuser.RegisterInput{
+		Email:       input.Email,
+		DisplayName: input.DisplayName,
+		Password:    input.Password,
+	}, callerID)
+	if err != nil {
+		return domainhousehold.CreatedUser{}, err
+	}
+	return domainhousehold.CreatedUser{ID: u.ID, Email: u.Email, DisplayName: u.DisplayName}, nil
+}
+
+// bootstrapAdmin inserts the first user + household + membership directly via SQL
+// (bypassing the HTTP layer, which requires auth for user creation), then logs in
+// via HTTP to obtain a real PASETO token.
+//
+// This is the only way to create the "seed" admin user for E2E tests, mirroring
+// what the cmd/pfm-seed binary will do in production (#182).
+func (e *e2eEnv) bootstrapAdmin(t *testing.T, ctx context.Context, email, displayName, password string) (token, userID, householdID string) {
+	t.Helper()
+
+	// Hash the password using the same hasher as the application.
+	hash, err := e.hasher.Hash(ctx, password)
+	require.NoError(t, err, "bootstrap: hash password")
+
+	// Insert admin user directly into the DB.
+	var uid string
+	err = e.pool.QueryRow(ctx, `
+		INSERT INTO users (email, display_name, password_hash, created_by, updated_by)
+		VALUES ($1, $2, $3, gen_random_uuid(), gen_random_uuid())
+		RETURNING id::text
+	`, email, displayName, hash).Scan(&uid)
+	require.NoError(t, err, "bootstrap: insert user")
+
+	// Insert household.
+	var hid string
+	err = e.pool.QueryRow(ctx, `
+		INSERT INTO households (name, created_by, updated_by)
+		VALUES ('Bootstrap Household', $1::uuid, $1::uuid)
+		RETURNING id::text
+	`, uid).Scan(&hid)
+	require.NoError(t, err, "bootstrap: insert household")
+
+	// Insert admin membership.
+	_, err = e.pool.Exec(ctx, `
+		INSERT INTO household_members (household_id, user_id, role, invited_by)
+		VALUES ($1::uuid, $2::uuid, 'ADMIN', $2::uuid)
+	`, hid, uid)
+	require.NoError(t, err, "bootstrap: insert membership")
+
+	// Login via HTTP to get a real PASETO token.
+	w := e.do(t, http.MethodPost, "/auth/login", map[string]string{
+		"email": email, "password": password,
+	}, "")
+	require.Equal(t, http.StatusOK, w.Code, "bootstrap: login failed: %s", w.Body.String())
+	login := decodeJSON(t, w)
+	token = login["token"].(string)
+	require.NotEmpty(t, token, "bootstrap: empty token")
+
+	return token, uid, hid
 }
 
 // do sends an HTTP request to the mux and returns the recorder.
@@ -146,65 +229,48 @@ func decodeJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
 	return m
 }
 
-// TestE2E_FullWorkflow verifies AC5 and AC6: a full register → login → create
-// household → create account → post transaction workflow against a real database.
+// TestE2E_FullWorkflow verifies AC5 and AC6: a full bootstrap → login → create
+// household user → create account → post transaction workflow against a real database.
 func TestE2E_FullWorkflow(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
-	// Step 1: Register a user.
-	w := env.do(t, http.MethodPost, "/api/v1/users", map[string]string{
-		"email":        "alice@example.com",
-		"display_name": "Alice",
+	// Step 1: Bootstrap an admin user (direct DB insert + login).
+	adminToken, _, householdID := env.bootstrapAdmin(t, ctx, "alice@example.com", "Alice", "secret1234")
+
+	// Step 2: Create a second user via the new household-scoped endpoint.
+	w := env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/users", map[string]string{
+		"email":        "bob@example.com",
+		"display_name": "Bob",
 		"password":     "secret1234",
-	}, "")
-	require.Equal(t, http.StatusCreated, w.Code, "register failed: %s", w.Body.String())
-	user := decodeJSON(t, w)
-	userID := user["id"].(string)
-	assert.NotEmpty(t, userID)
+	}, adminToken)
+	require.Equal(t, http.StatusCreated, w.Code, "create household user failed: %s", w.Body.String())
+	newUser := decodeJSON(t, w)
+	assert.NotEmpty(t, newUser["id"])
 
-	// Step 2: Login.
-	w = env.do(t, http.MethodPost, "/auth/login", map[string]string{
-		"email":    "alice@example.com",
-		"password": "secret1234",
-	}, "")
-	require.Equal(t, http.StatusOK, w.Code, "login failed: %s", w.Body.String())
-	loginResp := decodeJSON(t, w)
-	token := loginResp["token"].(string)
-	assert.NotEmpty(t, token)
-
-	// Step 3: Create a household.
-	w = env.do(t, http.MethodPost, "/api/v1/households", map[string]string{
-		"name": "Alice's Home",
-	}, token)
-	require.Equal(t, http.StatusCreated, w.Code, "create household failed: %s", w.Body.String())
-	household := decodeJSON(t, w)
-	householdID := household["id"].(string)
-	assert.Equal(t, "Alice's Home", household["name"])
-
-	// Step 4: Create a checking account.
+	// Step 3: Create a checking account.
 	w = env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/accounts", map[string]string{
 		"name":          "Checking",
 		"account_type":  "CHECKING",
 		"currency_code": "BRL",
-	}, token)
+	}, adminToken)
 	require.Equal(t, http.StatusCreated, w.Code, "create account failed: %s", w.Body.String())
 	account1 := decodeJSON(t, w)
 	account1ID := account1["id"].(string)
 	assert.Equal(t, "Checking", account1["name"])
 
-	// Step 5: Create a savings account (for balanced transaction).
+	// Step 4: Create a savings account (for balanced transaction).
 	w = env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/accounts", map[string]string{
 		"name":          "Savings",
 		"account_type":  "SAVINGS",
 		"currency_code": "BRL",
-	}, token)
+	}, adminToken)
 	require.Equal(t, http.StatusCreated, w.Code, "create savings failed: %s", w.Body.String())
 	account2 := decodeJSON(t, w)
 	account2ID := account2["id"].(string)
 
-	// Step 6: Post a balanced transaction.
+	// Step 5: Post a balanced transaction.
 	w = env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/transactions", map[string]any{
 		"description":      "Transfer to savings",
 		"transaction_date": "2026-03-15",
@@ -212,7 +278,7 @@ func TestE2E_FullWorkflow(t *testing.T) {
 			{"account_id": account1ID, "entry_type": "DEBIT", "amount": 10000},
 			{"account_id": account2ID, "entry_type": "CREDIT", "amount": 10000},
 		},
-	}, token)
+	}, adminToken)
 	require.Equal(t, http.StatusCreated, w.Code, "post transaction failed: %s", w.Body.String())
 	txn := decodeJSON(t, w)
 	assert.Equal(t, "Transfer to savings", txn["description"])
@@ -220,19 +286,19 @@ func TestE2E_FullWorkflow(t *testing.T) {
 	require.True(t, ok)
 	assert.Len(t, entries, 2)
 
-	// Step 7: Verify account balances.
-	w = env.do(t, http.MethodGet, "/api/v1/households/"+householdID+"/accounts/"+account1ID+"/balance", nil, token)
+	// Step 6: Verify account balances.
+	w = env.do(t, http.MethodGet, "/api/v1/households/"+householdID+"/accounts/"+account1ID+"/balance", nil, adminToken)
 	require.Equal(t, http.StatusOK, w.Code)
 	bal1 := decodeJSON(t, w)
-	assert.Equal(t, float64(-10000), bal1["balance"]) // debit reduces balance
+	assert.Equal(t, float64(-10000), bal1["balance"])
 
-	w = env.do(t, http.MethodGet, "/api/v1/households/"+householdID+"/accounts/"+account2ID+"/balance", nil, token)
+	w = env.do(t, http.MethodGet, "/api/v1/households/"+householdID+"/accounts/"+account2ID+"/balance", nil, adminToken)
 	require.Equal(t, http.StatusOK, w.Code)
 	bal2 := decodeJSON(t, w)
-	assert.Equal(t, float64(10000), bal2["balance"]) // credit increases balance
+	assert.Equal(t, float64(10000), bal2["balance"])
 
-	// Step 8: Get transaction history.
-	w = env.do(t, http.MethodGet, "/api/v1/households/"+householdID+"/transactions", nil, token)
+	// Step 7: Get transaction history.
+	w = env.do(t, http.MethodGet, "/api/v1/households/"+householdID+"/transactions", nil, adminToken)
 	require.Equal(t, http.StatusOK, w.Code)
 	var history []map[string]any
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&history))
@@ -256,44 +322,15 @@ func TestE2E_NonMemberAccess_Returns403(t *testing.T) {
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
-	// Register user A and get token.
-	w := env.do(t, http.MethodPost, "/api/v1/users", map[string]string{
-		"email": "a@example.com", "display_name": "Alice", "password": "secret1234",
-	}, "")
-	require.Equal(t, http.StatusCreated, w.Code, "register A: %s", w.Body.String())
+	// Bootstrap admin user A with their own household.
+	tokenA, _, householdID := env.bootstrapAdmin(t, ctx, fmt.Sprintf("a-%d@example.com", time.Now().UnixNano()), "User A", "secret1234")
 
-	w = env.do(t, http.MethodPost, "/auth/login", map[string]string{
-		"email": "a@example.com", "password": "secret1234",
-	}, "")
-	require.Equal(t, http.StatusOK, w.Code, "login A: %s", w.Body.String())
-	loginA := decodeJSON(t, w)
-	tokenA, ok := loginA["token"].(string)
-	require.True(t, ok, "login A response missing token: %v", loginA)
+	// Bootstrap a second independent admin user B (different household).
+	tokenB, _, _ := env.bootstrapAdmin(t, ctx, fmt.Sprintf("b-%d@example.com", time.Now().UnixNano()), "User B", "secret1234")
 
-	// User A creates a household.
-	w = env.do(t, http.MethodPost, "/api/v1/households", map[string]string{
-		"name": "A's House",
-	}, tokenA)
-	require.Equal(t, http.StatusCreated, w.Code, "create household: %s", w.Body.String())
-	houseResp := decodeJSON(t, w)
-	householdID, ok := houseResp["id"].(string)
-	require.True(t, ok, "household response missing id: %v", houseResp)
-
-	// Register user B and get token.
-	w = env.do(t, http.MethodPost, "/api/v1/users", map[string]string{
-		"email": "b@example.com", "display_name": "Bob", "password": "secret1234",
-	}, "")
-	require.Equal(t, http.StatusCreated, w.Code, "register B: %s", w.Body.String())
-
-	w = env.do(t, http.MethodPost, "/auth/login", map[string]string{
-		"email": "b@example.com", "password": "secret1234",
-	}, "")
-	require.Equal(t, http.StatusOK, w.Code, "login B: %s", w.Body.String())
-	loginB := decodeJSON(t, w)
-	tokenB, ok := loginB["token"].(string)
-	require.True(t, ok, "login B response missing token: %v", loginB)
-
-	// User B tries to access A's household → 403.
-	w = env.do(t, http.MethodGet, "/api/v1/households/"+householdID, nil, tokenB)
+	// User B tries to access A's household — 403.
+	w := env.do(t, http.MethodGet, "/api/v1/households/"+householdID, nil, tokenB)
 	require.Equal(t, http.StatusForbidden, w.Code)
+
+	_ = tokenA
 }

--- a/internal/adapter/http/e2e_user_test.go
+++ b/internal/adapter/http/e2e_user_test.go
@@ -5,94 +5,215 @@ package http_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// registerAndLogin is a test helper that registers a user and logs in,
-// returning the auth token and user ID. Fails the test if either step fails.
+// registerAndLogin bootstraps a user directly via SQL and logs in via HTTP,
+// returning the auth token and user ID. Used by tests that need an authenticated
+// user to set up preconditions — not for testing the registration endpoint itself.
 func registerAndLogin(t *testing.T, env *e2eEnv, email, displayName, password string) (token string, userID string) {
 	t.Helper()
-
-	w := env.do(t, http.MethodPost, "/api/v1/users", map[string]string{
-		"email": email, "display_name": displayName, "password": password,
-	}, "")
-	require.Equal(t, http.StatusCreated, w.Code, "register failed: %s", w.Body.String())
-	user := decodeJSON(t, w)
-	userID = user["id"].(string)
-
-	w = env.do(t, http.MethodPost, "/auth/login", map[string]string{
-		"email": email, "password": password,
-	}, "")
-	require.Equal(t, http.StatusOK, w.Code, "login failed: %s", w.Body.String())
-	login := decodeJSON(t, w)
-	token = login["token"].(string)
-
+	ctx := context.Background()
+	token, userID, _ = env.bootstrapAdmin(t, ctx, email, displayName, password)
 	return token, userID
 }
 
-// --- User Domain E2E Tests ---
+// --- Household-scoped user creation E2E tests ---
 
-// TestE2E_User_Register_Success verifies AC1: registration returns the new user
-// with a server-assigned ID and the user can subsequently log in.
-func TestE2E_User_Register_Success(t *testing.T) {
+// TestE2E_HouseholdUser_Create_Success verifies that a household admin can create
+// a new user within their household. The new user is returned with ID, email, and
+// display_name; they can subsequently log in.
+func TestE2E_HouseholdUser_Create_Success(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
-	w := env.do(t, http.MethodPost, "/api/v1/users", map[string]string{
-		"email": "alice@example.com", "display_name": "Alice", "password": "secret1234",
-	}, "")
+	adminToken, _, householdID := env.bootstrapAdmin(t, ctx, "admin-hcu@example.com", "Admin", "secret1234")
 
-	require.Equal(t, http.StatusCreated, w.Code)
+	w := env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/users", map[string]string{
+		"email": "newuser@example.com", "display_name": "New User", "password": "secret1234",
+	}, adminToken)
+
+	require.Equal(t, http.StatusCreated, w.Code, "create household user: %s", w.Body.String())
 	resp := decodeJSON(t, w)
 	assert.NotEmpty(t, resp["id"])
-	assert.Equal(t, "alice@example.com", resp["email"])
-	assert.Equal(t, "Alice", resp["display_name"])
+	assert.Equal(t, "newuser@example.com", resp["email"])
+	assert.Equal(t, "New User", resp["display_name"])
 	assert.NotEmpty(t, w.Header().Get("Location"))
+	// PasswordHash must never appear in the response.
+	assert.NotContains(t, w.Body.String(), "password")
 
-	// Verify can log in with the registered credentials.
+	// The new user can log in.
 	w = env.do(t, http.MethodPost, "/auth/login", map[string]string{
-		"email": "alice@example.com", "password": "secret1234",
+		"email": "newuser@example.com", "password": "secret1234",
 	}, "")
-	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, http.StatusOK, w.Code, "login new user: %s", w.Body.String())
 	login := decodeJSON(t, w)
 	assert.NotEmpty(t, login["token"])
 }
 
-// TestE2E_User_Register_DuplicateEmail verifies AC2: duplicate email returns 409.
-func TestE2E_User_Register_DuplicateEmail(t *testing.T) {
+// TestE2E_HouseholdUser_Create_NoToken_Returns401 verifies that an unauthenticated
+// request to POST /api/v1/households/{id}/users returns 401.
+func TestE2E_HouseholdUser_Create_NoToken_Returns401(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
-	body := map[string]string{
+	adminToken, _, householdID := env.bootstrapAdmin(t, ctx, "admin-ntoken@example.com", "Admin", "secret1234")
+	_ = adminToken
+
+	w := env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/users", map[string]string{
+		"email": "x@example.com", "display_name": "X", "password": "secret1234",
+	}, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestE2E_HouseholdUser_Create_CallerIsMember_Returns403 verifies that a MEMBER
+// (non-admin) of a household cannot create new users.
+func TestE2E_HouseholdUser_Create_CallerIsMember_Returns403(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := newE2EEnv(t, ctx)
+
+	adminToken, _, householdID := env.bootstrapAdmin(t, ctx, "admin-member@example.com", "Admin", "secret1234")
+
+	// Admin creates a second user — that user becomes a MEMBER.
+	w := env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/users", map[string]string{
+		"email": "member@example.com", "display_name": "Member", "password": "secret1234",
+	}, adminToken)
+	require.Equal(t, http.StatusCreated, w.Code, "create member: %s", w.Body.String())
+
+	// Member logs in.
+	w = env.do(t, http.MethodPost, "/auth/login", map[string]string{
+		"email": "member@example.com", "password": "secret1234",
+	}, "")
+	require.Equal(t, http.StatusOK, w.Code)
+	memberToken := decodeJSON(t, w)["token"].(string)
+
+	// Member tries to create another user — 403.
+	w = env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/users", map[string]string{
+		"email": "another@example.com", "display_name": "Another", "password": "secret1234",
+	}, memberToken)
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// TestE2E_HouseholdUser_Create_DifferentHousehold_Returns403 verifies that an admin
+// of household A cannot create users in household B (cross-household injection is blocked).
+func TestE2E_HouseholdUser_Create_DifferentHousehold_Returns403(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := newE2EEnv(t, ctx)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	// Admin A and admin B each have their own household.
+	tokenA, _, _ := env.bootstrapAdmin(t, ctx, "adminA-"+suffix+"@example.com", "Admin A", "secret1234")
+	_, _, householdB := env.bootstrapAdmin(t, ctx, "adminB-"+suffix+"@example.com", "Admin B", "secret1234")
+
+	// Admin A tries to POST to household B's user endpoint → 403.
+	w := env.do(t, http.MethodPost, "/api/v1/households/"+householdB+"/users", map[string]string{
+		"email": "injected@example.com", "display_name": "Injected", "password": "secret1234",
+	}, tokenA)
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// TestE2E_HouseholdUser_Create_NonExistentHousehold_Returns403 verifies the edge
+// case where the household_id in the URL refers to a household that does not exist.
+// The adminGuard calls FindRole for the caller against the given household; since no
+// membership exists for a non-existent household, it returns 403 — the same as any
+// other unauthorized access. The API intentionally does not reveal whether a household
+// ID exists (prevents enumeration).
+func TestE2E_HouseholdUser_Create_NonExistentHousehold_Returns403(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := newE2EEnv(t, ctx)
+
+	adminToken, _, _ := env.bootstrapAdmin(t, ctx, "admin-nohouse@example.com", "Admin", "secret1234")
+	nonExistentID := uuid.New().String()
+
+	w := env.do(t, http.MethodPost, "/api/v1/households/"+nonExistentID+"/users", map[string]string{
+		"email": "x@example.com", "display_name": "X", "password": "secret1234",
+	}, adminToken)
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// TestE2E_HouseholdUser_Create_PasswordExactlyMinimum_Succeeds verifies the boundary
+// value: a password of exactly 8 characters (the minimum) is accepted.
+func TestE2E_HouseholdUser_Create_PasswordExactlyMinimum_Succeeds(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := newE2EEnv(t, ctx)
+
+	adminToken, _, householdID := env.bootstrapAdmin(t, ctx, "admin-pwmin@example.com", "Admin", "secret1234")
+
+	w := env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/users", map[string]string{
+		"email": "minpass@example.com", "display_name": "Min Pass", "password": "8charPwd",
+	}, adminToken)
+	require.Equal(t, http.StatusCreated, w.Code, "8-char password must be accepted: %s", w.Body.String())
+}
+
+// TestE2E_HouseholdUser_Create_PasswordBelowMinimum_Returns400 verifies the boundary
+// value: a password of 7 characters (one below the minimum of 8) is rejected with 400.
+func TestE2E_HouseholdUser_Create_PasswordBelowMinimum_Returns400(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := newE2EEnv(t, ctx)
+
+	adminToken, _, householdID := env.bootstrapAdmin(t, ctx, "admin-pwbelow@example.com", "Admin", "secret1234")
+
+	w := env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/users", map[string]string{
+		"email": "shortpw@example.com", "display_name": "Short PW", "password": "7charPw",
+	}, adminToken)
+	require.Equal(t, http.StatusBadRequest, w.Code, "7-char password must be rejected: %s", w.Body.String())
+	resp := decodeJSON(t, w)
+	fields, ok := resp["fields"].(map[string]any)
+	require.True(t, ok, "expected fields in response: %v", resp)
+	assert.Contains(t, fields, "password")
+}
+
+// TestE2E_HouseholdUser_Create_DuplicateEmail_Returns409 verifies 409 when the
+// email is already registered globally (even in another household).
+func TestE2E_HouseholdUser_Create_DuplicateEmail_Returns409(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := newE2EEnv(t, ctx)
+
+	adminToken, _, householdID := env.bootstrapAdmin(t, ctx, "admin-dup@example.com", "Admin", "secret1234")
+
+	// Create the user once.
+	w := env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/users", map[string]string{
 		"email": "dup@example.com", "display_name": "First", "password": "secret1234",
-	}
-	w := env.do(t, http.MethodPost, "/api/v1/users", body, "")
+	}, adminToken)
 	require.Equal(t, http.StatusCreated, w.Code)
 
-	// Second registration with same email.
-	w = env.do(t, http.MethodPost, "/api/v1/users", body, "")
+	// Create again with the same email → 409.
+	w = env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/users", map[string]string{
+		"email": "dup@example.com", "display_name": "Second", "password": "secret1234",
+	}, adminToken)
 	require.Equal(t, http.StatusConflict, w.Code)
 }
 
-// TestE2E_User_Register_ValidationErrors verifies AC3: invalid fields return 400
-// with per-field violations.
-func TestE2E_User_Register_ValidationErrors(t *testing.T) {
+// TestE2E_HouseholdUser_Create_ValidationError_Returns400 verifies that missing
+// required fields return 400 with a validation error body.
+func TestE2E_HouseholdUser_Create_ValidationError_Returns400(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
 
-	w := env.do(t, http.MethodPost, "/api/v1/users", map[string]string{
-		"email": "", "display_name": "A", "password": "short",
-	}, "")
+	adminToken, _, householdID := env.bootstrapAdmin(t, ctx, "admin-val@example.com", "Admin", "secret1234")
 
+	w := env.do(t, http.MethodPost, "/api/v1/households/"+householdID+"/users", map[string]string{
+		"display_name": "No Email",
+		// missing email and password
+	}, adminToken)
 	require.Equal(t, http.StatusBadRequest, w.Code)
 	resp := decodeJSON(t, w)
 	fields, ok := resp["fields"].(map[string]any)
@@ -100,28 +221,20 @@ func TestE2E_User_Register_ValidationErrors(t *testing.T) {
 	assert.NotEmpty(t, fields)
 }
 
-// TestE2E_User_Register_EmptyBody verifies edge case: empty body returns 400.
-func TestE2E_User_Register_EmptyBody(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	env := newE2EEnv(t, ctx)
-
-	w := env.do(t, http.MethodPost, "/api/v1/users", nil, "")
-	require.Equal(t, http.StatusBadRequest, w.Code)
-}
+// --- User profile E2E tests (use bootstrapAdmin for setup) ---
 
 // TestE2E_User_GetProfile verifies AC4: authenticated user retrieves profile by ID.
 func TestE2E_User_GetProfile(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
-	token, userID := registerAndLogin(t, env, "bob@example.com", "Bob", "secret1234")
+	token, userID := registerAndLogin(t, env, "bob-get@example.com", "Bob", "secret1234")
 
 	w := env.do(t, http.MethodGet, "/api/v1/users/"+userID, nil, token)
 
 	require.Equal(t, http.StatusOK, w.Code)
 	resp := decodeJSON(t, w)
-	assert.Equal(t, "bob@example.com", resp["email"])
+	assert.Equal(t, "bob-get@example.com", resp["email"])
 	assert.Equal(t, "Bob", resp["display_name"])
 	assert.Equal(t, float64(1), resp["version"])
 }
@@ -131,7 +244,7 @@ func TestE2E_User_GetProfile_NotFound(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
-	token, _ := registerAndLogin(t, env, "x@example.com", "XX", "secret1234")
+	token, _ := registerAndLogin(t, env, "x-notfound@example.com", "X", "secret1234")
 
 	w := env.do(t, http.MethodGet, "/api/v1/users/"+uuid.New().String(), nil, token)
 	require.Equal(t, http.StatusNotFound, w.Code)
@@ -142,7 +255,7 @@ func TestE2E_User_GetProfile_InvalidUUID(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
-	token, _ := registerAndLogin(t, env, "x@example.com", "XX", "secret1234")
+	token, _ := registerAndLogin(t, env, "x-uuid@example.com", "X", "secret1234")
 
 	w := env.do(t, http.MethodGet, "/api/v1/users/not-a-uuid", nil, token)
 	require.Equal(t, http.StatusBadRequest, w.Code)
@@ -154,7 +267,7 @@ func TestE2E_User_UpdateProfile(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
-	token, userID := registerAndLogin(t, env, "carol@example.com", "Carol", "secret1234")
+	token, userID := registerAndLogin(t, env, "carol-upd@example.com", "Carol", "secret1234")
 
 	w := env.do(t, http.MethodPut, "/api/v1/users/"+userID, map[string]any{
 		"display_name": "Carol Updated", "version": 1,
@@ -171,7 +284,7 @@ func TestE2E_User_UpdateProfile_StaleVersion(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
-	token, userID := registerAndLogin(t, env, "dave@example.com", "Dave", "secret1234")
+	token, userID := registerAndLogin(t, env, "dave-stale@example.com", "Dave", "secret1234")
 
 	// First update succeeds (version 1 → 2).
 	w := env.do(t, http.MethodPut, "/api/v1/users/"+userID, map[string]any{
@@ -192,7 +305,7 @@ func TestE2E_User_ChangePassword(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
-	token, userID := registerAndLogin(t, env, "eve@example.com", "Eve", "oldpass1234")
+	token, userID := registerAndLogin(t, env, "eve-pwd@example.com", "Eve", "oldpass1234")
 
 	w := env.do(t, http.MethodPut, "/api/v1/users/"+userID+"/password", map[string]any{
 		"old_password": "oldpass1234", "new_password": "newpass1234", "version": 1,
@@ -201,13 +314,13 @@ func TestE2E_User_ChangePassword(t *testing.T) {
 
 	// Login with new password succeeds.
 	w = env.do(t, http.MethodPost, "/auth/login", map[string]string{
-		"email": "eve@example.com", "password": "newpass1234",
+		"email": "eve-pwd@example.com", "password": "newpass1234",
 	}, "")
 	require.Equal(t, http.StatusOK, w.Code)
 
 	// Login with old password fails.
 	w = env.do(t, http.MethodPost, "/auth/login", map[string]string{
-		"email": "eve@example.com", "password": "oldpass1234",
+		"email": "eve-pwd@example.com", "password": "oldpass1234",
 	}, "")
 	require.Equal(t, http.StatusUnauthorized, w.Code)
 }
@@ -217,7 +330,7 @@ func TestE2E_User_ChangePassword_WrongOldPassword(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
-	token, userID := registerAndLogin(t, env, "frank@example.com", "Frank", "secret1234")
+	token, userID := registerAndLogin(t, env, "frank-pwd@example.com", "Frank", "secret1234")
 
 	w := env.do(t, http.MethodPut, "/api/v1/users/"+userID+"/password", map[string]any{
 		"old_password": "wrongpass", "new_password": "newpass1234", "version": 1,
@@ -231,7 +344,7 @@ func TestE2E_User_Deactivate(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
-	token, userID := registerAndLogin(t, env, "gone@example.com", "Gone", "secret1234")
+	token, userID := registerAndLogin(t, env, "gone-del@example.com", "Gone", "secret1234")
 
 	w := env.do(t, http.MethodDelete, "/api/v1/users/"+userID, nil, token)
 	require.Equal(t, http.StatusNoContent, w.Code)
@@ -246,14 +359,14 @@ func TestE2E_User_Deactivate_CannotLogin(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := newE2EEnv(t, ctx)
-	token, userID := registerAndLogin(t, env, "byebye@example.com", "ByeBye", "secret1234")
+	token, userID := registerAndLogin(t, env, "bye-del@example.com", "ByeBye", "secret1234")
 
 	w := env.do(t, http.MethodDelete, "/api/v1/users/"+userID, nil, token)
 	require.Equal(t, http.StatusNoContent, w.Code)
 
 	// Login attempt fails.
 	w = env.do(t, http.MethodPost, "/auth/login", map[string]string{
-		"email": "byebye@example.com", "password": "secret1234",
+		"email": "bye-del@example.com", "password": "secret1234",
 	}, "")
 	require.Equal(t, http.StatusUnauthorized, w.Code)
 }

--- a/internal/adapter/http/household.go
+++ b/internal/adapter/http/household.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -11,6 +12,7 @@ import (
 	domainhouse "github.com/zambone/pfm-go/internal/domain/household"
 	"github.com/zambone/pfm-go/internal/message"
 	"github.com/zambone/pfm-go/internal/platform/ctxutil"
+	"github.com/zambone/pfm-go/internal/platform/validate"
 	"github.com/zambone/pfm-go/internal/types"
 )
 
@@ -351,6 +353,98 @@ func UpdateHouseholdNameHandler(svc updateHouseholdNameService) http.HandlerFunc
 		}
 
 		WriteJSON(w, http.StatusOK, toHouseholdResponse(h))
+	}
+}
+
+// --- CreateHouseholdUser ---
+
+// createHouseholdUserService is the narrow interface required by CreateHouseholdUserHandler.
+// Structurally satisfied by HouseholdMemberLogic.
+type createHouseholdUserService interface {
+	CreateHouseholdUser(ctx context.Context, householdID uuid.UUID, input domainhouse.NewUserInput, callerID uuid.UUID) (domainhouse.CreatedMember, error)
+}
+
+// createHouseholdUserRequest carries the caller-supplied fields for creating a new user
+// within a household.
+type createHouseholdUserRequest struct {
+	Email       string `json:"email"`
+	DisplayName string `json:"display_name"`
+	Password    string `json:"password"`
+}
+
+// createdHouseholdUserResponse is the JSON representation of a newly created household user.
+// It deliberately omits sensitive fields (PasswordHash) and internal audit fields.
+type createdHouseholdUserResponse struct {
+	ID          string `json:"id"`
+	Email       string `json:"email"`
+	DisplayName string `json:"display_name"`
+}
+
+// CreateHouseholdUserHandler returns an http.HandlerFunc that creates a new user and
+// atomically adds them as a MEMBER of the given household. Requires an authenticated
+// caller who is an admin of the household (enforced by adminGuard middleware upstream).
+// On success it writes a 201 Created response with the new user and a Location header.
+// Panics if svc is nil.
+//
+// @Summary Create a user within a household
+// @Tags households
+// @Accept json
+// @Produce json
+// @Param household_id path string true "Household ID (UUID)"
+// @Param body body createHouseholdUserRequest true "New user input"
+// @Success 201 {object} createdHouseholdUserResponse
+// @Failure 400 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 403 {object} map[string]string
+// @Failure 409 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/v1/households/{household_id}/users [post]
+func CreateHouseholdUserHandler(svc createHouseholdUserService) http.HandlerFunc {
+	if svc == nil {
+		panic("http: CreateHouseholdUserHandler requires non-nil createHouseholdUserService")
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		householdID, err := parseUUID(r.PathValue("household_id"))
+		if err != nil {
+			WriteJSON(w, http.StatusBadRequest, map[string]string{"error": message.MsgAuthzBadRequest})
+			return
+		}
+
+		var req createHouseholdUserRequest
+		if err := DecodeBody(r, &req); err != nil {
+			WriteJSON(w, http.StatusBadRequest, map[string]string{"error": message.MsgBadRequestBody})
+			return
+		}
+
+		v := validate.NewResult()
+		v.Field("email", req.Email, validate.Required)
+		v.Field("password", req.Password, validate.Required)
+		if err := v.Error(); err != nil {
+			var ve *validate.ValidationError
+			if errors.As(err, &ve) {
+				WriteValidationError(w, ve)
+				return
+			}
+		}
+
+		callerID, _ := ctxutil.UserID(r.Context())
+
+		created, err := svc.CreateHouseholdUser(r.Context(), householdID, domainhouse.NewUserInput{
+			Email:       req.Email,
+			DisplayName: req.DisplayName,
+			Password:    req.Password,
+		}, callerID)
+		if err != nil {
+			handleDomainError(w, r, err)
+			return
+		}
+
+		location := fmt.Sprintf("/api/v1/users/%s", created.User.ID)
+		WriteCreated(w, location, createdHouseholdUserResponse{
+			ID:          created.User.ID.String(),
+			Email:       created.User.Email,
+			DisplayName: created.User.DisplayName,
+		})
 	}
 }
 

--- a/internal/adapter/http/household_test.go
+++ b/internal/adapter/http/household_test.go
@@ -3,6 +3,7 @@ package http_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	pfmhttp "github.com/zambone/pfm-go/internal/adapter/http"
 	domainhouse "github.com/zambone/pfm-go/internal/domain/household"
 	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/ctxutil"
 	"github.com/zambone/pfm-go/internal/platform/validate"
 	"github.com/zambone/pfm-go/internal/types"
 )
@@ -514,4 +516,150 @@ func TestDeactivateHouseholdHandler_InvalidUUID_Returns400(t *testing.T) {
 func TestDeactivateHouseholdHandler_NilService_Panics(t *testing.T) {
 	t.Parallel()
 	assert.Panics(t, func() { pfmhttp.DeactivateHouseholdHandler(nil) })
+}
+
+// --- CreateHouseholdUserHandler tests ---
+
+// stubCreateHouseholdUserService is a test double for createHouseholdUserService.
+type stubCreateHouseholdUserService struct {
+	result domainhouse.CreatedMember
+	err    error
+}
+
+func (s *stubCreateHouseholdUserService) CreateHouseholdUser(
+	_ context.Context, _ uuid.UUID, _ domainhouse.NewUserInput, _ uuid.UUID,
+) (domainhouse.CreatedMember, error) {
+	return s.result, s.err
+}
+
+func testCreatedMember() domainhouse.CreatedMember {
+	hid := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	uid := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	return domainhouse.CreatedMember{
+		User: domainhouse.CreatedUser{
+			ID:          uid,
+			Email:       "new@example.com",
+			DisplayName: "New User",
+		},
+		Membership: domainhouse.Membership{
+			HouseholdID: hid,
+			UserID:      uid,
+		},
+	}
+}
+
+// TestCreateHouseholdUserHandler_Returns201 verifies AC: a valid request from a
+// caller with a user in context returns 201 with the new user and Location header.
+func TestCreateHouseholdUserHandler_Returns201(t *testing.T) {
+	t.Parallel()
+
+	callerID := uuid.New()
+	svc := &stubCreateHouseholdUserService{result: testCreatedMember()}
+	handler := pfmhttp.CreateHouseholdUserHandler(svc)
+
+	body := `{"email":"new@example.com","display_name":"New User","password":"secret1234"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/households/"+testCreatedMember().Membership.HouseholdID.String()+"/users", strings.NewReader(body))
+	r.SetPathValue("household_id", testCreatedMember().Membership.HouseholdID.String())
+	r = r.WithContext(ctxutil.WithUserID(r.Context(), callerID))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	assert.Contains(t, w.Header().Get("Location"), testCreatedMember().User.ID.String())
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "new@example.com", resp["email"])
+	assert.Equal(t, "New User", resp["display_name"])
+	assert.NotContains(t, w.Body.String(), "password")
+}
+
+// TestCreateHouseholdUserHandler_EmailTaken_Returns409 verifies 409 on duplicate email.
+func TestCreateHouseholdUserHandler_EmailTaken_Returns409(t *testing.T) {
+	t.Parallel()
+
+	callerID := uuid.New()
+	svc := &stubCreateHouseholdUserService{err: message.ErrUserEmailTaken}
+	handler := pfmhttp.CreateHouseholdUserHandler(svc)
+
+	body := `{"email":"taken@example.com","display_name":"User","password":"secret1234"}`
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	r.SetPathValue("household_id", uuid.New().String())
+	r = r.WithContext(ctxutil.WithUserID(r.Context(), callerID))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+}
+
+// TestCreateHouseholdUserHandler_MissingFields_Returns400 verifies validation.
+func TestCreateHouseholdUserHandler_MissingFields_Returns400(t *testing.T) {
+	t.Parallel()
+
+	callerID := uuid.New()
+	svc := &stubCreateHouseholdUserService{}
+	handler := pfmhttp.CreateHouseholdUserHandler(svc)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"empty body", `{}`},
+		{"missing password", `{"email":"a@b.com","display_name":"A"}`},
+		{"missing email", `{"display_name":"A","password":"secret1234"}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tc.body))
+			r.SetPathValue("household_id", uuid.New().String())
+			r = r.WithContext(ctxutil.WithUserID(r.Context(), callerID))
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, r)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+// TestCreateHouseholdUserHandler_InvalidHouseholdID_Returns400 verifies bad path param.
+func TestCreateHouseholdUserHandler_InvalidHouseholdID_Returns400(t *testing.T) {
+	t.Parallel()
+
+	callerID := uuid.New()
+	svc := &stubCreateHouseholdUserService{}
+	handler := pfmhttp.CreateHouseholdUserHandler(svc)
+
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"email":"a@b.com","display_name":"A","password":"s"}`))
+	r.SetPathValue("household_id", "not-a-uuid")
+	r = r.WithContext(ctxutil.WithUserID(r.Context(), callerID))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestCreateHouseholdUserHandler_InternalError_Returns500 verifies 500 on unexpected errors.
+func TestCreateHouseholdUserHandler_InternalError_Returns500(t *testing.T) {
+	t.Parallel()
+
+	callerID := uuid.New()
+	svc := &stubCreateHouseholdUserService{err: errors.New("unexpected")}
+	handler := pfmhttp.CreateHouseholdUserHandler(svc)
+
+	body := `{"email":"a@b.com","display_name":"A","password":"secret1234"}`
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	r.SetPathValue("household_id", uuid.New().String())
+	r = r.WithContext(ctxutil.WithUserID(r.Context(), callerID))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestCreateHouseholdUserHandler_NilService_Panics verifies the nil guard.
+func TestCreateHouseholdUserHandler_NilService_Panics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { pfmhttp.CreateHouseholdUserHandler(nil) })
 }

--- a/internal/adapter/http/routes.go
+++ b/internal/adapter/http/routes.go
@@ -37,14 +37,14 @@ type RouteDeps struct {
 
 	// User handlers
 	LoginSvc          loginService
-	RegisterSvc       registerService
 	GetUserSvc        getUserService
 	UpdateProfileSvc  updateProfileService
 	ChangePasswordSvc changePasswordService
 	DeactivateUserSvc deactivateUserService
 
 	// Household handlers
-	CreateHouseholdSvc     createHouseholdService
+	CreateHouseholdSvc      createHouseholdService
+	CreateHouseholdUserSvc  createHouseholdUserService
 	GetHouseholdSvc        getHouseholdService
 	ListHouseholdsSvc      listHouseholdsService
 	AddMemberSvc           addMemberService
@@ -94,10 +94,7 @@ func RegisterRoutes(mux *http.ServeMux, d RouteDeps) {
 	// --- Auth (public) ---
 	mux.Handle("POST /auth/login", LoginHandler(d.LoginSvc))
 
-	// --- Users ---
-	// Registration is public (no auth needed to create an account).
-	mux.Handle("POST /api/v1/users", RegisterHandler(d.RegisterSvc))
-	// All other user endpoints require authentication.
+	// --- Users (all require authentication) ---
 	mux.Handle("GET /api/v1/users/{id}", authn(GetUserHandler(d.GetUserSvc)))
 	mux.Handle("PUT /api/v1/users/{id}", authn(UpdateProfileHandler(d.UpdateProfileSvc)))
 	mux.Handle("PUT /api/v1/users/{id}/password", authn(ChangePasswordHandler(d.ChangePasswordSvc)))
@@ -112,7 +109,9 @@ func RegisterRoutes(mux *http.ServeMux, d RouteDeps) {
 	mux.Handle("PUT /api/v1/households/{household_id}", authn(adminGuard(UpdateHouseholdNameHandler(d.UpdateHouseholdNameSvc))))
 	mux.Handle("DELETE /api/v1/households/{household_id}", authn(adminGuard(DeactivateHouseholdHandler(d.DeactivateHouseholdSvc))))
 
-	// --- Members ---
+	// --- Members and household-scoped user creation ---
+	// Creating a user within a household requires auth + admin role.
+	mux.Handle("POST /api/v1/households/{household_id}/users", authn(adminGuard(CreateHouseholdUserHandler(d.CreateHouseholdUserSvc))))
 	mux.Handle("POST /api/v1/households/{household_id}/members", authn(adminGuard(AddMemberHandler(d.AddMemberSvc))))
 	mux.Handle("DELETE /api/v1/households/{household_id}/members/{user_id}", authn(adminGuard(RemoveMemberHandler(d.RemoveMemberSvc))))
 

--- a/internal/adapter/http/routes_test.go
+++ b/internal/adapter/http/routes_test.go
@@ -30,9 +30,6 @@ type allServicesStub struct{}
 func (s *allServicesStub) Login(_ context.Context, _, _ string) (domainuser.LoginResult, error) {
 	return domainuser.LoginResult{}, nil
 }
-func (s *allServicesStub) Register(_ context.Context, _ domainuser.RegisterInput, _ uuid.UUID) (domainuser.User, error) {
-	return domainuser.User{}, nil
-}
 func (s *allServicesStub) FindByID(_ context.Context, _ uuid.UUID) (domainuser.User, error) {
 	return domainuser.User{}, nil
 }
@@ -65,6 +62,9 @@ type householdServiceStub struct{}
 
 func (s *householdServiceStub) Create(_ context.Context, _ domainhouse.CreateInput, _ uuid.UUID) (domainhouse.Household, error) {
 	return domainhouse.Household{}, nil
+}
+func (s *householdServiceStub) CreateHouseholdUser(_ context.Context, _ uuid.UUID, _ domainhouse.NewUserInput, _ uuid.UUID) (domainhouse.CreatedMember, error) {
+	return domainhouse.CreatedMember{}, nil
 }
 func (s *householdServiceStub) FindByID(_ context.Context, _ uuid.UUID) (domainhouse.Household, error) {
 	return domainhouse.Household{}, nil
@@ -158,17 +158,17 @@ func buildTestDeps() pfmhttp.RouteDeps {
 		ShuttingDown:   &shuttingDown,
 		TokenValidator: &tokenValidatorStub{},
 		MembershipFinder: &membershipFinderStub{},
-		LoginSvc:       userSvc,
-		RegisterSvc:    userSvc,
-		GetUserSvc:     userSvc,
+		LoginSvc:            userSvc,
+		GetUserSvc:          userSvc,
 		UpdateProfileSvc:    userSvc,
 		ChangePasswordSvc:   userSvc,
 		DeactivateUserSvc:   userSvc,
-		CreateHouseholdSvc:  houseSvc,
-		GetHouseholdSvc:     houseSvc,
-		ListHouseholdsSvc:   houseSvc,
-		AddMemberSvc:        houseSvc,
-		RemoveMemberSvc:     houseSvc,
+		CreateHouseholdSvc:     houseSvc,
+		CreateHouseholdUserSvc: houseSvc,
+		GetHouseholdSvc:        houseSvc,
+		ListHouseholdsSvc:      houseSvc,
+		AddMemberSvc:           houseSvc,
+		RemoveMemberSvc:        houseSvc,
 		UpdateHouseholdNameSvc:    houseSvc,
 		DeactivateHouseholdSvc:    houseSvc,
 		CreateAccountSvc:          acctSvc,
@@ -214,9 +214,6 @@ func TestRegisterRoutes_EndpointsReachable(t *testing.T) {
 		// Auth (public)
 		{"login", http.MethodPost, "/auth/login", http.StatusBadRequest}, // no body → 400, but route matched
 
-		// Users (public registration)
-		{"register", http.MethodPost, "/api/v1/users", http.StatusBadRequest},
-
 		// Users (authn required → 401 without token)
 		{"get user", http.MethodGet, "/api/v1/users/" + uuid.New().String(), http.StatusUnauthorized},
 		{"update profile", http.MethodPut, "/api/v1/users/" + uuid.New().String(), http.StatusUnauthorized},
@@ -226,6 +223,9 @@ func TestRegisterRoutes_EndpointsReachable(t *testing.T) {
 		// Households (authn required)
 		{"create household", http.MethodPost, "/api/v1/households", http.StatusUnauthorized},
 		{"list households", http.MethodGet, "/api/v1/households", http.StatusUnauthorized},
+
+		// Household-scoped user creation (authn + admin guard)
+		{"create household user", http.MethodPost, "/api/v1/households/" + hid + "/users", http.StatusUnauthorized},
 
 		// Household-scoped (authn + guard)
 		{"get household", http.MethodGet, "/api/v1/households/" + hid, http.StatusUnauthorized},
@@ -313,22 +313,6 @@ func TestRegisterRoutes_WrongMethod_Returns405(t *testing.T) {
 	mux.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
-}
-
-// TestRegisterRoutes_PublicRegistration_NoAuthRequired verifies that POST /api/v1/users
-// does not require authentication (it returns 400 for empty body, not 401).
-func TestRegisterRoutes_PublicRegistration_NoAuthRequired(t *testing.T) {
-	t.Parallel()
-
-	mux := http.NewServeMux()
-	pfmhttp.RegisterRoutes(mux, buildTestDeps())
-
-	r := httptest.NewRequest(http.MethodPost, "/api/v1/users", nil)
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, r)
-
-	// 400 (bad body), not 401 — proves no authn middleware on this route
-	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 // placeholder to use time import (used in stubs)

--- a/internal/adapter/http/user.go
+++ b/internal/adapter/http/user.go
@@ -69,62 +69,6 @@ func parseUUID(value string) (uuid.UUID, error) {
 	return id, nil
 }
 
-// --- Register ---
-
-// registerService is the subset of UserLogic required by RegisterHandler.
-type registerService interface {
-	Register(ctx context.Context, input domainuser.RegisterInput, callerID uuid.UUID) (domainuser.User, error)
-}
-
-type registerRequest struct {
-	Email       string `json:"email"`
-	DisplayName string `json:"display_name"`
-	Password    string `json:"password"`
-}
-
-// RegisterHandler returns an http.HandlerFunc that handles user registration.
-// On success it writes a 201 Created response with the new user and a Location header.
-// Panics if svc is nil.
-//
-// @Summary Register a new user
-// @Tags users
-// @Accept json
-// @Produce json
-// @Param body body registerRequest true "Registration input"
-// @Success 201 {object} userResponse
-// @Failure 400 {object} map[string]string
-// @Failure 409 {object} map[string]string
-// @Router /api/v1/users [post]
-func RegisterHandler(svc registerService) http.HandlerFunc {
-	if svc == nil {
-		panic("http: RegisterHandler requires non-nil registerService")
-	}
-	return func(w http.ResponseWriter, r *http.Request) {
-		var req registerRequest
-		if err := DecodeBody(r, &req); err != nil {
-			WriteJSON(w, http.StatusBadRequest, map[string]string{"error": message.MsgBadRequestBody})
-			return
-		}
-
-		// callerID: for self-registration there is no authenticated user yet,
-		// so we use uuid.Nil as a sentinel meaning "self-created".
-		callerID, _ := ctxutil.UserID(r.Context())
-
-		u, err := svc.Register(r.Context(), domainuser.RegisterInput{
-			Email:       req.Email,
-			DisplayName: req.DisplayName,
-			Password:    req.Password,
-		}, callerID)
-		if err != nil {
-			handleDomainError(w, r, err)
-			return
-		}
-
-		location := fmt.Sprintf("/api/v1/users/%s", u.ID)
-		WriteCreated(w, location, toUserResponse(u))
-	}
-}
-
 // --- GetUser ---
 
 // getUserService is the subset of UserLogic required by GetUserHandler.

--- a/internal/adapter/http/user_test.go
+++ b/internal/adapter/http/user_test.go
@@ -22,16 +22,6 @@ import (
 
 // --- Stubs ---
 
-// stubRegisterService is a test double for the registerService interface.
-type stubRegisterService struct {
-	user domainuser.User
-	err  error
-}
-
-func (s *stubRegisterService) Register(_ context.Context, _ domainuser.RegisterInput, _ uuid.UUID) (domainuser.User, error) {
-	return s.user, s.err
-}
-
 // testUser returns a User with all fields populated for test assertions.
 func testUser() domainuser.User {
 	return domainuser.User{
@@ -50,117 +40,6 @@ func testUser() domainuser.User {
 // authenticated request that has passed through the authn middleware.
 func ctxWithUser(id uuid.UUID) context.Context {
 	return ctxutil.WithUserID(context.Background(), id)
-}
-
-// --- RegisterHandler tests ---
-
-// TestRegisterHandler_ValidRequest_Returns201 verifies AC1: a valid registration
-// request returns 201 Created with the new user and a Location header.
-func TestRegisterHandler_ValidRequest_Returns201(t *testing.T) {
-	t.Parallel()
-
-	svc := &stubRegisterService{user: testUser()}
-	handler := pfmhttp.RegisterHandler(svc)
-
-	body := `{"email":"alice@example.com","display_name":"Alice","password":"secret123"}`
-	r := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(body))
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
-
-	require.Equal(t, http.StatusCreated, w.Code)
-	assert.Contains(t, w.Header().Get("Location"), testUser().ID.String())
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
-
-	var resp map[string]any
-	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-	assert.Equal(t, "alice@example.com", resp["email"])
-	assert.Equal(t, "Alice", resp["display_name"])
-	// PasswordHash must NEVER appear in the response
-	assert.NotContains(t, w.Body.String(), "password_hash")
-}
-
-// TestRegisterHandler_EmailTaken_Returns409 verifies AC2: duplicate email
-// returns 409 Conflict.
-func TestRegisterHandler_EmailTaken_Returns409(t *testing.T) {
-	t.Parallel()
-
-	svc := &stubRegisterService{err: message.ErrUserEmailTaken}
-	handler := pfmhttp.RegisterHandler(svc)
-
-	body := `{"email":"taken@example.com","display_name":"Bob","password":"secret123"}`
-	r := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(body))
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
-
-	require.Equal(t, http.StatusConflict, w.Code)
-}
-
-// TestRegisterHandler_MissingFields_Returns400 verifies AC10: missing required
-// fields return 400 with per-field validation details.
-func TestRegisterHandler_MissingFields_Returns400(t *testing.T) {
-	t.Parallel()
-
-	svc := &stubRegisterService{}
-	handler := pfmhttp.RegisterHandler(svc)
-
-	// All fields empty — domain logic returns ValidationError
-	svc.err = &validate.ValidationError{
-		Violations: []validate.Violation{
-			{Field: "email", Message: "is required"},
-			{Field: "display_name", Message: "is required"},
-			{Field: "password", Message: "is required"},
-		},
-	}
-
-	body := `{"email":"","display_name":"","password":""}`
-	r := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(body))
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
-
-	require.Equal(t, http.StatusBadRequest, w.Code)
-	var resp map[string]any
-	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-	assert.Equal(t, message.MsgValidationFailed, resp["error"])
-	fields, ok := resp["fields"].(map[string]any)
-	require.True(t, ok)
-	assert.Len(t, fields, 3)
-}
-
-// TestRegisterHandler_MalformedJSON_Returns400 verifies edge case: unparseable
-// body returns 400, not 500.
-func TestRegisterHandler_MalformedJSON_Returns400(t *testing.T) {
-	t.Parallel()
-
-	svc := &stubRegisterService{}
-	handler := pfmhttp.RegisterHandler(svc)
-
-	r := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader("{bad"))
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
-
-	require.Equal(t, http.StatusBadRequest, w.Code)
-}
-
-// TestRegisterHandler_InternalError_Returns500 verifies AC6 (from #122):
-// unexpected errors return 500 with generic message.
-func TestRegisterHandler_InternalError_Returns500(t *testing.T) {
-	t.Parallel()
-
-	svc := &stubRegisterService{err: assert.AnError}
-	handler := pfmhttp.RegisterHandler(svc)
-
-	body := `{"email":"a@b.com","display_name":"X","password":"secret123"}`
-	r := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(body))
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
-
-	require.Equal(t, http.StatusInternalServerError, w.Code)
-}
-
-// TestRegisterHandler_NilService_Panics verifies the nil guard fires at wiring time.
-func TestRegisterHandler_NilService_Panics(t *testing.T) {
-	t.Parallel()
-	assert.Panics(t, func() { pfmhttp.RegisterHandler(nil) })
 }
 
 // --- GetUserHandler tests ---

--- a/internal/adapter/postgres/fake_household_repo.go
+++ b/internal/adapter/postgres/fake_household_repo.go
@@ -42,6 +42,35 @@ func NewFakeHouseholdRepository() *FakeHouseholdRepository {
 	}
 }
 
+// AddHousehold seeds a household with the given ID directly into the in-memory store.
+// Use this in tests to set up preconditions without going through the domain Create method.
+func (f *FakeHouseholdRepository) AddHousehold(id uuid.UUID, callerID uuid.UUID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.byID[id] = household.Household{
+		ID:        id,
+		Name:      "test household",
+		Status:    "ACTIVE",
+		Version:   1,
+		CreatedBy: callerID,
+		UpdatedBy: callerID,
+	}
+}
+
+// AddMemberDirect seeds a membership directly into the in-memory store.
+// Use this in tests to set up preconditions (e.g. to trigger ErrHouseholdMemberExists).
+func (f *FakeHouseholdRepository) AddMemberDirect(householdID, userID, inviterID uuid.UUID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := memberKey{HouseholdID: householdID, UserID: userID}
+	f.members[key] = household.Membership{
+		HouseholdID: householdID,
+		UserID:      userID,
+		Role:        "MEMBER",
+		InvitedBy:   inviterID,
+	}
+}
+
 // SetError configures every subsequent method call to return err.
 // Pass nil to clear the injected error.
 func (f *FakeHouseholdRepository) SetError(err error) {

--- a/internal/domain/household/household.go
+++ b/internal/domain/household/household.go
@@ -91,3 +91,33 @@ type Repository interface {
 	HouseholdReader
 	HouseholdWriter
 }
+
+// NewUserInput carries the registration details for creating a new user within a household.
+// The household domain defines this type independently so it never imports domain/user.
+type NewUserInput struct {
+	Email       string
+	DisplayName string
+	Password    string
+}
+
+// CreatedUser holds the minimal user record returned after user creation.
+// It contains only the fields the household domain needs to build a membership.
+type CreatedUser struct {
+	ID          uuid.UUID
+	Email       string
+	DisplayName string
+}
+
+// CreatedMember is the result of CreateHouseholdUser — the new user and their membership
+// within the target household, created atomically in a single transaction.
+type CreatedMember struct {
+	User       CreatedUser
+	Membership Membership
+}
+
+// userCreator is the narrow interface the household domain uses to create users.
+// It is defined at the consumer (household domain), not at the provider (user domain).
+// Structurally satisfied by an adapter in cmd/pfm/main.go that wraps UserLogic.
+type userCreator interface {
+	Create(ctx context.Context, input NewUserInput, callerID uuid.UUID) (CreatedUser, error)
+}

--- a/internal/domain/household/member_logic.go
+++ b/internal/domain/household/member_logic.go
@@ -1,0 +1,71 @@
+package household
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/types"
+)
+
+// HouseholdMemberLogic handles atomic user-creation-within-a-household operations.
+// It is separate from HouseholdLogic so that its constructor can accept a
+// userCreator without altering the existing HouseholdLogic constructor signature.
+type HouseholdMemberLogic struct {
+	repo  Repository
+	users userCreator
+	tx    transactor
+	cl    clocker
+}
+
+// NewHouseholdMemberLogic creates a HouseholdMemberLogic. Panics if any dependency is nil.
+func NewHouseholdMemberLogic(repo Repository, users userCreator, tx transactor, cl clocker) *HouseholdMemberLogic {
+	if repo == nil {
+		panic("household: NewHouseholdMemberLogic requires non-nil Repository")
+	}
+	if users == nil {
+		panic("household: NewHouseholdMemberLogic requires non-nil userCreator")
+	}
+	if tx == nil {
+		panic("household: NewHouseholdMemberLogic requires non-nil transactor")
+	}
+	if cl == nil {
+		panic("household: NewHouseholdMemberLogic requires non-nil clocker")
+	}
+	return &HouseholdMemberLogic{repo: repo, users: users, tx: tx, cl: cl}
+}
+
+// CreateHouseholdUser creates a new user and immediately adds them as a MEMBER of
+// the given household. Both writes happen inside a single database transaction —
+// if either fails, both are rolled back.
+//
+// The callerID must be an admin of the target household; this is enforced by the
+// adminGuard middleware before the request reaches this method.
+func (l *HouseholdMemberLogic) CreateHouseholdUser(ctx context.Context, householdID uuid.UUID, input NewUserInput, callerID uuid.UUID) (CreatedMember, error) {
+	var result CreatedMember
+
+	if err := l.tx.RunAtomic(ctx, func(txCtx context.Context) error {
+		// Step 1 — create the user (validation + hashing happen inside the adapter).
+		created, err := l.users.Create(txCtx, input, callerID)
+		if err != nil {
+			return err
+		}
+
+		// Step 2 — add the new user as a MEMBER of the household.
+		membership, err := l.repo.AddMember(txCtx, householdID, AddMemberInput{
+			UserID: created.ID,
+			Role:   types.RoleMember,
+		}, callerID)
+		if err != nil {
+			return err
+		}
+
+		result = CreatedMember{User: created, Membership: membership}
+		return nil
+	}); err != nil {
+		return CreatedMember{}, fmt.Errorf(message.ErrHouseholdLogicCreateUser, err)
+	}
+	return result, nil
+}

--- a/internal/domain/household/member_logic_test.go
+++ b/internal/domain/household/member_logic_test.go
@@ -1,0 +1,244 @@
+package household_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zambone/pfm-go/internal/adapter/postgres"
+	"github.com/zambone/pfm-go/internal/domain/household"
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/clock"
+	"github.com/zambone/pfm-go/internal/platform/database"
+)
+
+// compile-time type checks — fail to compile if the types don't exist.
+var (
+	_ = household.NewUserInput{}
+	_ = household.CreatedUser{}
+	_ = household.CreatedMember{}
+)
+
+// --- Test helpers ---
+
+// fakeUserCreator is a test double for the household.userCreator interface.
+type fakeUserCreator struct {
+	result household.CreatedUser
+	err    error
+}
+
+func (f *fakeUserCreator) Create(_ context.Context, _ household.NewUserInput, _ uuid.UUID) (household.CreatedUser, error) {
+	return f.result, f.err
+}
+
+var testTime = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func newMemberLogicEnv() (
+	repo *postgres.FakeHouseholdRepository,
+	users *fakeUserCreator,
+	logic *household.HouseholdMemberLogic,
+) {
+	repo = postgres.NewFakeHouseholdRepository()
+	users = &fakeUserCreator{}
+	tx := database.NewFakeTransactor()
+	cl := clock.NewFakeClock(testTime)
+	logic = household.NewHouseholdMemberLogic(repo, users, tx, cl)
+	return repo, users, logic
+}
+
+// --- Constructor guard tests ---
+
+func TestNewHouseholdMemberLogic_NilRepo_Panics(t *testing.T) {
+	t.Parallel()
+	cl := clock.NewFakeClock(testTime)
+	tx := database.NewFakeTransactor()
+	assert.Panics(t, func() {
+		household.NewHouseholdMemberLogic(nil, &fakeUserCreator{}, tx, cl)
+	})
+}
+
+func TestNewHouseholdMemberLogic_NilUserCreator_Panics(t *testing.T) {
+	t.Parallel()
+	cl := clock.NewFakeClock(testTime)
+	tx := database.NewFakeTransactor()
+	assert.Panics(t, func() {
+		household.NewHouseholdMemberLogic(postgres.NewFakeHouseholdRepository(), nil, tx, cl)
+	})
+}
+
+func TestNewHouseholdMemberLogic_NilTransactor_Panics(t *testing.T) {
+	t.Parallel()
+	cl := clock.NewFakeClock(testTime)
+	assert.Panics(t, func() {
+		household.NewHouseholdMemberLogic(postgres.NewFakeHouseholdRepository(), &fakeUserCreator{}, nil, cl)
+	})
+}
+
+func TestNewHouseholdMemberLogic_NilClock_Panics(t *testing.T) {
+	t.Parallel()
+	tx := database.NewFakeTransactor()
+	assert.Panics(t, func() {
+		household.NewHouseholdMemberLogic(postgres.NewFakeHouseholdRepository(), &fakeUserCreator{}, tx, nil)
+	})
+}
+
+// --- CreateHouseholdUser tests ---
+
+// TestCreateHouseholdUser_Success verifies the happy path: a new user is created
+// and a MEMBER membership is added. The returned CreatedMember carries the user
+// info and the membership with the correct household and user IDs.
+func TestCreateHouseholdUser_Success(t *testing.T) {
+	t.Parallel()
+
+	repo, users, logic := newMemberLogicEnv()
+
+	callerID := uuid.New()
+	householdID := uuid.New()
+	repo.AddHousehold(householdID, callerID)
+
+	newUserID := uuid.New()
+	users.result = household.CreatedUser{
+		ID:          newUserID,
+		Email:       "new@example.com",
+		DisplayName: "New User",
+	}
+
+	input := household.NewUserInput{
+		Email:       "new@example.com",
+		DisplayName: "New User",
+		Password:    "secret1234",
+	}
+
+	got, err := logic.CreateHouseholdUser(context.Background(), householdID, input, callerID)
+
+	require.NoError(t, err)
+	assert.Equal(t, newUserID, got.User.ID)
+	assert.Equal(t, "new@example.com", got.User.Email)
+	assert.Equal(t, "New User", got.User.DisplayName)
+	assert.Equal(t, householdID, got.Membership.HouseholdID)
+	assert.Equal(t, newUserID, got.Membership.UserID)
+}
+
+// TestCreateHouseholdUser_EmailTaken verifies that when userCreator returns
+// ErrUserEmailTaken the error propagates and no membership is written.
+func TestCreateHouseholdUser_EmailTaken(t *testing.T) {
+	t.Parallel()
+
+	repo, users, logic := newMemberLogicEnv()
+	callerID := uuid.New()
+	householdID := uuid.New()
+	repo.AddHousehold(householdID, callerID)
+
+	users.err = message.ErrUserEmailTaken
+
+	_, err := logic.CreateHouseholdUser(context.Background(), householdID, household.NewUserInput{
+		Email:    "taken@example.com",
+		Password: "secret1234",
+	}, callerID)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, message.ErrUserEmailTaken)
+}
+
+// TestCreateHouseholdUser_UserCreatorError verifies that a generic user creation
+// failure propagates and the operation is aborted.
+func TestCreateHouseholdUser_UserCreatorError(t *testing.T) {
+	t.Parallel()
+
+	repo, users, logic := newMemberLogicEnv()
+	callerID := uuid.New()
+	householdID := uuid.New()
+	repo.AddHousehold(householdID, callerID)
+
+	users.err = errors.New("db connection lost")
+
+	_, err := logic.CreateHouseholdUser(context.Background(), householdID, household.NewUserInput{
+		Email:    "x@example.com",
+		Password: "secret1234",
+	}, callerID)
+
+	require.Error(t, err)
+}
+
+// TestCreateHouseholdUser_MembershipAddFails verifies that when AddMember fails
+// (user already a member), the error propagates.
+func TestCreateHouseholdUser_MembershipAddFails(t *testing.T) {
+	t.Parallel()
+
+	repo, users, logic := newMemberLogicEnv()
+	callerID := uuid.New()
+	householdID := uuid.New()
+	repo.AddHousehold(householdID, callerID)
+
+	newUserID := uuid.New()
+	users.result = household.CreatedUser{ID: newUserID}
+	// Pre-seed the membership so AddMember returns ErrHouseholdMemberExists.
+	repo.AddMemberDirect(householdID, newUserID, callerID)
+
+	_, err := logic.CreateHouseholdUser(context.Background(), householdID, household.NewUserInput{
+		Email:    "x@example.com",
+		Password: "secret1234",
+	}, callerID)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, message.ErrHouseholdMemberExists)
+}
+
+// TestCreateHouseholdUser_Rollback_WhenMembershipFails verifies AC6: when user
+// creation succeeds but AddMember fails, the transactor records a rollback (not a
+// commit), meaning neither write persists in a real DB transaction.
+func TestCreateHouseholdUser_Rollback_WhenMembershipFails(t *testing.T) {
+	t.Parallel()
+
+	repo := postgres.NewFakeHouseholdRepository()
+	users := &fakeUserCreator{}
+	tx := database.NewFakeTransactor()
+	cl := clock.NewFakeClock(testTime)
+	logic := household.NewHouseholdMemberLogic(repo, users, tx, cl)
+
+	callerID := uuid.New()
+	householdID := uuid.New()
+	repo.AddHousehold(householdID, callerID)
+
+	newUserID := uuid.New()
+	users.result = household.CreatedUser{ID: newUserID}
+	// Pre-seed membership to force AddMember to fail after user creation succeeds.
+	repo.AddMemberDirect(householdID, newUserID, callerID)
+
+	_, err := logic.CreateHouseholdUser(context.Background(), householdID, household.NewUserInput{
+		Email:    "rollback@example.com",
+		Password: "secret1234",
+	}, callerID)
+
+	require.Error(t, err)
+	assert.False(t, tx.CommittedLastCall(), "transaction must not commit when AddMember fails")
+}
+
+// TestCreateHouseholdUser_Rollback_WhenUserCreationFails verifies AC7: when user
+// creation itself fails, the transactor records a rollback — no partial write occurs.
+func TestCreateHouseholdUser_Rollback_WhenUserCreationFails(t *testing.T) {
+	t.Parallel()
+
+	repo := postgres.NewFakeHouseholdRepository()
+	users := &fakeUserCreator{err: errors.New("db unavailable")}
+	tx := database.NewFakeTransactor()
+	cl := clock.NewFakeClock(testTime)
+	logic := household.NewHouseholdMemberLogic(repo, users, tx, cl)
+
+	callerID := uuid.New()
+	householdID := uuid.New()
+	repo.AddHousehold(householdID, callerID)
+
+	_, err := logic.CreateHouseholdUser(context.Background(), householdID, household.NewUserInput{
+		Email:    "never@example.com",
+		Password: "secret1234",
+	}, callerID)
+
+	require.Error(t, err)
+	assert.False(t, tx.CommittedLastCall(), "transaction must not commit when user creation fails")
+}

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -220,6 +220,7 @@ const (
 	ErrHouseholdLogicRemoveMember = "household logic: remove member: %w"
 	ErrHouseholdLogicUpdateName   = "household logic: update name: %w"
 	ErrHouseholdLogicDeactivate   = "household logic: deactivate: %w"
+	ErrHouseholdLogicCreateUser   = "household logic: create household user: %w"
 )
 
 // Account repository errors.


### PR DESCRIPTION
## Summary
- Removes the open `POST /api/v1/users` registration endpoint (now 404); users can only be created within a household by an admin
- Adds `POST /api/v1/households/{id}/users` protected by `authn + adminGuard`; creates user and MEMBER membership atomically via `Transactor.RunAtomic`
- Introduces `HouseholdMemberLogic` and a `householdUserCreator` adapter in the composition root to bridge `domain/household` and `domain/user` without an import cycle
- Upgrades Go 1.26.1 → 1.26.2 to resolve stdlib `crypto/tls` and `crypto/x509` CVEs flagged by govulncheck

## Test plan
- [ ] `make ci` passes (lint + test -race + build)
- [ ] `/project:verify-issue` verdict: PASS
- [ ] `/project:review` verdict: PASS (all 9 categories)
- [ ] Integration tests pass with testcontainers
- [ ] Rollback tests assert `tx.CommittedLastCall() == false` on partial failure (AC6/AC7)
- [ ] Password boundary tests: 8 chars → 201, 7 chars → 400
- [ ] Non-existent household → 403 (adminGuard prevents enumeration)