### PR TITLE
fix(http): use NULL for bootstrap user created_by/updated_by to avoid FK violation

### DIFF
--- a/internal/adapter/http/e2e_integration_test.go
+++ b/internal/adapter/http/e2e_integration_test.go
@@ -163,10 +163,12 @@ func (e *e2eEnv) bootstrapAdmin(t *testing.T, ctx context.Context, email, displa
 	require.NoError(t, err, "bootstrap: hash password")
 
 	// Insert admin user directly into the DB.
+	// created_by and updated_by are nullable FKs — NULL is correct for a seed user
+	// that has no creator (mirrors what the production seed binary will do, see #182).
 	var uid string
 	err = e.pool.QueryRow(ctx, `
 		INSERT INTO users (email, display_name, password_hash, created_by, updated_by)
-		VALUES ($1, $2, $3, gen_random_uuid(), gen_random_uuid())
+		VALUES ($1, $2, $3, NULL, NULL)
 		RETURNING id::text
 	`, email, displayName, hash).Scan(&uid)
 	require.NoError(t, err, "bootstrap: insert user")


### PR DESCRIPTION
## Summary
- `bootstrapAdmin` was inserting `gen_random_uuid()` for `created_by`/`updated_by`, producing UUIDs that don't exist in the `users` table
- `users.created_by` and `users.updated_by` are nullable FKs — `NULL` is the correct value for a seed user that has no creator
- Failure only surfaced on CI (real Postgres via testcontainers); local runs hit the Podman bridge-network issue and couldn't run integration tests

## Test plan
- [ ] Integration tests pass on CI (no FK violation on bootstrap insert)