### PR TITLE
fix(docker): bump builder image to golang:1.26.2-alpine

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.1-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary
- `go.mod` requires `go >= 1.26.2` (bumped previously to resolve govulncheck stdlib vulns)
- Dockerfile builder stage was still pinned to `golang:1.26.1-alpine`
- Deploy failed with: `go: go.mod requires go >= 1.26.2 (running go 1.26.1; GOTOOLCHAIN=local)`

## Test plan
- [x] One-line change, no logic affected
- [ ] CI quality-gate passes
- [ ] Deploy workflow succeeds after merge