### PR TITLE
refactor(test): rename stub* test doubles to Fake* per naming convention

### DIFF
--- a/internal/adapter/http/account_test.go
+++ b/internal/adapter/http/account_test.go
@@ -47,12 +47,12 @@ func testAccount() domainacct.Account {
 
 // --- CreateAccountHandler tests ---
 
-type stubCreateAccountService struct {
+type FakeCreateAccountService struct {
 	account domainacct.Account
 	err     error
 }
 
-func (s *stubCreateAccountService) Create(_ context.Context, _ uuid.UUID, _ domainacct.CreateInput, _ uuid.UUID) (domainacct.Account, error) {
+func (s *FakeCreateAccountService) Create(_ context.Context, _ uuid.UUID, _ domainacct.CreateInput, _ uuid.UUID) (domainacct.Account, error) {
 	return s.account, s.err
 }
 
@@ -60,7 +60,7 @@ func (s *stubCreateAccountService) Create(_ context.Context, _ uuid.UUID, _ doma
 func TestCreateAccountHandler_ValidRequest_Returns201(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubCreateAccountService{account: testAccount()}
+	svc := &FakeCreateAccountService{account: testAccount()}
 	handler := pfmhttp.CreateAccountHandler(svc)
 
 	body := `{"name":"Checking","account_type":"CHECKING","currency_code":"BRL"}`
@@ -84,7 +84,7 @@ func TestCreateAccountHandler_ValidRequest_Returns201(t *testing.T) {
 func TestCreateAccountHandler_NameTaken_Returns409(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubCreateAccountService{err: message.ErrAccountNameTaken}
+	svc := &FakeCreateAccountService{err: message.ErrAccountNameTaken}
 	handler := pfmhttp.CreateAccountHandler(svc)
 
 	body := `{"name":"Dup","account_type":"CHECKING","currency_code":"BRL"}`
@@ -101,7 +101,7 @@ func TestCreateAccountHandler_NameTaken_Returns409(t *testing.T) {
 func TestCreateAccountHandler_ValidationError_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubCreateAccountService{
+	svc := &FakeCreateAccountService{
 		err: &validate.ValidationError{
 			Violations: []validate.Violation{{Field: "name", Message: "is required"}},
 		},
@@ -122,7 +122,7 @@ func TestCreateAccountHandler_ValidationError_Returns400(t *testing.T) {
 func TestCreateAccountHandler_MalformedJSON_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubCreateAccountService{}
+	svc := &FakeCreateAccountService{}
 	handler := pfmhttp.CreateAccountHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/households/"+acctHouseID.String()+"/accounts", strings.NewReader("{bad"))
@@ -141,12 +141,12 @@ func TestCreateAccountHandler_NilService_Panics(t *testing.T) {
 
 // --- GetAccountHandler tests ---
 
-type stubGetAccountService struct {
+type FakeGetAccountService struct {
 	account domainacct.Account
 	err     error
 }
 
-func (s *stubGetAccountService) FindByID(_ context.Context, _ uuid.UUID) (domainacct.Account, error) {
+func (s *FakeGetAccountService) FindByID(_ context.Context, _ uuid.UUID) (domainacct.Account, error) {
 	return s.account, s.err
 }
 
@@ -154,7 +154,7 @@ func (s *stubGetAccountService) FindByID(_ context.Context, _ uuid.UUID) (domain
 func TestGetAccountHandler_ValidID_Returns200(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetAccountService{account: testAccount()}
+	svc := &FakeGetAccountService{account: testAccount()}
 	handler := pfmhttp.GetAccountHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/households/"+acctHouseID.String()+"/accounts/"+acctID.String(), nil)
@@ -172,7 +172,7 @@ func TestGetAccountHandler_ValidID_Returns200(t *testing.T) {
 func TestGetAccountHandler_NotFound_Returns404(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetAccountService{err: message.ErrAccountNotFound}
+	svc := &FakeGetAccountService{err: message.ErrAccountNotFound}
 	handler := pfmhttp.GetAccountHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -187,7 +187,7 @@ func TestGetAccountHandler_NotFound_Returns404(t *testing.T) {
 func TestGetAccountHandler_InvalidUUID_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetAccountService{}
+	svc := &FakeGetAccountService{}
 	handler := pfmhttp.GetAccountHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -206,12 +206,12 @@ func TestGetAccountHandler_NilService_Panics(t *testing.T) {
 
 // --- ListAccountsHandler tests ---
 
-type stubListAccountsService struct {
+type FakeListAccountsService struct {
 	accounts []domainacct.Account
 	err      error
 }
 
-func (s *stubListAccountsService) ListForHousehold(_ context.Context, _ uuid.UUID) ([]domainacct.Account, error) {
+func (s *FakeListAccountsService) ListForHousehold(_ context.Context, _ uuid.UUID) ([]domainacct.Account, error) {
 	return s.accounts, s.err
 }
 
@@ -219,7 +219,7 @@ func (s *stubListAccountsService) ListForHousehold(_ context.Context, _ uuid.UUI
 func TestListAccountsHandler_ReturnsArray(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubListAccountsService{accounts: []domainacct.Account{testAccount()}}
+	svc := &FakeListAccountsService{accounts: []domainacct.Account{testAccount()}}
 	handler := pfmhttp.ListAccountsHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -237,7 +237,7 @@ func TestListAccountsHandler_ReturnsArray(t *testing.T) {
 func TestListAccountsHandler_EmptyList_ReturnsEmptyArray(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubListAccountsService{accounts: []domainacct.Account{}}
+	svc := &FakeListAccountsService{accounts: []domainacct.Account{}}
 	handler := pfmhttp.ListAccountsHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -257,12 +257,12 @@ func TestListAccountsHandler_NilService_Panics(t *testing.T) {
 
 // --- UpdateAccountNameHandler tests ---
 
-type stubUpdateAccountNameService struct {
+type FakeUpdateAccountNameService struct {
 	account domainacct.Account
 	err     error
 }
 
-func (s *stubUpdateAccountNameService) UpdateName(_ context.Context, _ uuid.UUID, _ domainacct.UpdateNameInput, _ int, _ uuid.UUID) (domainacct.Account, error) {
+func (s *FakeUpdateAccountNameService) UpdateName(_ context.Context, _ uuid.UUID, _ domainacct.UpdateNameInput, _ int, _ uuid.UUID) (domainacct.Account, error) {
 	return s.account, s.err
 }
 
@@ -272,7 +272,7 @@ func TestUpdateAccountNameHandler_ValidRequest_Returns200(t *testing.T) {
 
 	updated := testAccount()
 	updated.Name = "Savings"
-	svc := &stubUpdateAccountNameService{account: updated}
+	svc := &FakeUpdateAccountNameService{account: updated}
 	handler := pfmhttp.UpdateAccountNameHandler(svc)
 
 	body := `{"name":"Savings","version":1}`
@@ -292,7 +292,7 @@ func TestUpdateAccountNameHandler_ValidRequest_Returns200(t *testing.T) {
 func TestUpdateAccountNameHandler_VersionConflict_Returns409(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubUpdateAccountNameService{err: message.ErrAccountVersionConflict}
+	svc := &FakeUpdateAccountNameService{err: message.ErrAccountVersionConflict}
 	handler := pfmhttp.UpdateAccountNameHandler(svc)
 
 	body := `{"name":"X","version":1}`
@@ -309,7 +309,7 @@ func TestUpdateAccountNameHandler_VersionConflict_Returns409(t *testing.T) {
 func TestUpdateAccountNameHandler_MalformedJSON_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubUpdateAccountNameService{}
+	svc := &FakeUpdateAccountNameService{}
 	handler := pfmhttp.UpdateAccountNameHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPut, "/", strings.NewReader("{bad"))
@@ -328,12 +328,12 @@ func TestUpdateAccountNameHandler_NilService_Panics(t *testing.T) {
 
 // --- UpdateAccountBalanceHandler tests ---
 
-type stubUpdateAccountBalanceService struct {
+type FakeUpdateAccountBalanceService struct {
 	account domainacct.Account
 	err     error
 }
 
-func (s *stubUpdateAccountBalanceService) UpdateBalance(_ context.Context, _ uuid.UUID, _ domainacct.UpdateBalanceInput, _ int, _ uuid.UUID) (domainacct.Account, error) {
+func (s *FakeUpdateAccountBalanceService) UpdateBalance(_ context.Context, _ uuid.UUID, _ domainacct.UpdateBalanceInput, _ int, _ uuid.UUID) (domainacct.Account, error) {
 	return s.account, s.err
 }
 
@@ -343,7 +343,7 @@ func TestUpdateAccountBalanceHandler_ValidRequest_Returns200(t *testing.T) {
 
 	updated := testAccount()
 	updated.Balance = 50000
-	svc := &stubUpdateAccountBalanceService{account: updated}
+	svc := &FakeUpdateAccountBalanceService{account: updated}
 	handler := pfmhttp.UpdateAccountBalanceHandler(svc)
 
 	body := `{"balance":50000,"version":1}`
@@ -363,7 +363,7 @@ func TestUpdateAccountBalanceHandler_ValidRequest_Returns200(t *testing.T) {
 func TestUpdateAccountBalanceHandler_MalformedJSON_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubUpdateAccountBalanceService{}
+	svc := &FakeUpdateAccountBalanceService{}
 	handler := pfmhttp.UpdateAccountBalanceHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPut, "/", strings.NewReader("{bad"))
@@ -382,11 +382,11 @@ func TestUpdateAccountBalanceHandler_NilService_Panics(t *testing.T) {
 
 // --- DeactivateAccountHandler tests ---
 
-type stubDeactivateAccountService struct {
+type FakeDeactivateAccountService struct {
 	err error
 }
 
-func (s *stubDeactivateAccountService) Deactivate(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+func (s *FakeDeactivateAccountService) Deactivate(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
 	return s.err
 }
 
@@ -394,7 +394,7 @@ func (s *stubDeactivateAccountService) Deactivate(_ context.Context, _ uuid.UUID
 func TestDeactivateAccountHandler_Success_Returns204(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubDeactivateAccountService{}
+	svc := &FakeDeactivateAccountService{}
 	handler := pfmhttp.DeactivateAccountHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/", nil)
@@ -411,7 +411,7 @@ func TestDeactivateAccountHandler_Success_Returns204(t *testing.T) {
 func TestDeactivateAccountHandler_BalanceNotZero_ReturnsConflict(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubDeactivateAccountService{err: message.ErrAccountBalanceNotZero}
+	svc := &FakeDeactivateAccountService{err: message.ErrAccountBalanceNotZero}
 	handler := pfmhttp.DeactivateAccountHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/", nil)
@@ -427,7 +427,7 @@ func TestDeactivateAccountHandler_BalanceNotZero_ReturnsConflict(t *testing.T) {
 func TestDeactivateAccountHandler_NotFound_Returns404(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubDeactivateAccountService{err: message.ErrAccountNotFound}
+	svc := &FakeDeactivateAccountService{err: message.ErrAccountNotFound}
 	handler := pfmhttp.DeactivateAccountHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/", nil)

--- a/internal/adapter/http/auth_test.go
+++ b/internal/adapter/http/auth_test.go
@@ -20,14 +20,14 @@ import (
 	"github.com/zambone/pfm-go/internal/message"
 )
 
-// stubLoginService is a test double for the loginService interface.
+// FakeLoginService is a test double for the loginService interface.
 // It returns whatever result/error is configured.
-type stubLoginService struct {
+type FakeLoginService struct {
 	result domainuser.LoginResult
 	err    error
 }
 
-func (s *stubLoginService) Login(_ context.Context, _, _ string) (domainuser.LoginResult, error) {
+func (s *FakeLoginService) Login(_ context.Context, _, _ string) (domainuser.LoginResult, error) {
 	return s.result, s.err
 }
 
@@ -50,7 +50,7 @@ var fixedExpiry = time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
 // TestLoginHandler_ValidCredentials_Returns200 verifies AC1:
 // a successful login returns 200 with token and expires_at in the body.
 func TestLoginHandler_ValidCredentials_Returns200(t *testing.T) {
-	svc := &stubLoginService{result: domainuser.LoginResult{Token: "tok123", ExpiresAt: fixedExpiry}}
+	svc := &FakeLoginService{result: domainuser.LoginResult{Token: "tok123", ExpiresAt: fixedExpiry}}
 	handler := pfmhttp.LoginHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPost, "/auth/login", loginBody("u@example.com", "pass"))
@@ -66,7 +66,7 @@ func TestLoginHandler_ValidCredentials_Returns200(t *testing.T) {
 // TestLoginHandler_InvalidCredentials_Returns401 verifies AC2 and AC3:
 // ErrLoginInvalidCredentials from the service produces a 401 with a generic message.
 func TestLoginHandler_InvalidCredentials_Returns401(t *testing.T) {
-	svc := &stubLoginService{
+	svc := &FakeLoginService{
 		err: fmt.Errorf("login: find user: %w", message.ErrLoginInvalidCredentials),
 	}
 	handler := pfmhttp.LoginHandler(svc)
@@ -83,7 +83,7 @@ func TestLoginHandler_InvalidCredentials_Returns401(t *testing.T) {
 // TestLoginHandler_EmptyEmail_Returns400 verifies that validation happens at the
 // handler boundary — an empty email is rejected with 400 before calling the service.
 func TestLoginHandler_EmptyEmail_Returns400(t *testing.T) {
-	svc := &stubLoginService{} // must not be called
+	svc := &FakeLoginService{} // must not be called
 	handler := pfmhttp.LoginHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPost, "/auth/login", loginBody("", "pass"))
@@ -101,7 +101,7 @@ func TestLoginHandler_EmptyEmail_Returns400(t *testing.T) {
 // TestLoginHandler_EmptyPassword_Returns400 verifies that an empty password
 // is rejected at the handler boundary with 400.
 func TestLoginHandler_EmptyPassword_Returns400(t *testing.T) {
-	svc := &stubLoginService{} // must not be called
+	svc := &FakeLoginService{} // must not be called
 	handler := pfmhttp.LoginHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPost, "/auth/login", loginBody("u@example.com", ""))
@@ -119,7 +119,7 @@ func TestLoginHandler_EmptyPassword_Returns400(t *testing.T) {
 // TestLoginHandler_BothFieldsEmpty_Returns400WithTwoViolations verifies that
 // validation collects all violations in a single pass (fail-all, not fail-fast).
 func TestLoginHandler_BothFieldsEmpty_Returns400WithTwoViolations(t *testing.T) {
-	svc := &stubLoginService{} // must not be called
+	svc := &FakeLoginService{} // must not be called
 	handler := pfmhttp.LoginHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPost, "/auth/login", loginBody("", ""))
@@ -136,7 +136,7 @@ func TestLoginHandler_BothFieldsEmpty_Returns400WithTwoViolations(t *testing.T) 
 // TestLoginHandler_MalformedJSON_Returns400 verifies that an unparseable body
 // is rejected with 400 before the service is called.
 func TestLoginHandler_MalformedJSON_Returns400(t *testing.T) {
-	svc := &stubLoginService{}
+	svc := &FakeLoginService{}
 	handler := pfmhttp.LoginHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPost, "/auth/login", strings.NewReader("{bad json}"))
@@ -151,7 +151,7 @@ func TestLoginHandler_MalformedJSON_Returns400(t *testing.T) {
 // TestLoginHandler_InfraError_Returns500 verifies that an unexpected infrastructure
 // error (DB down, token service failure) returns 500 with a generic server error.
 func TestLoginHandler_InfraError_Returns500(t *testing.T) {
-	svc := &stubLoginService{err: errors.New("connection refused")}
+	svc := &FakeLoginService{err: errors.New("connection refused")}
 	handler := pfmhttp.LoginHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPost, "/auth/login", loginBody("u@example.com", "pass"))
@@ -173,7 +173,7 @@ func TestLoginHandler_NilService_Panics(t *testing.T) {
 // BenchmarkLoginHandler_ValidRequest measures the per-request cost of the handler
 // on the happy path — JSON decode + validation + service call + JSON encode.
 func BenchmarkLoginHandler_ValidRequest(b *testing.B) {
-	svc := &stubLoginService{result: domainuser.LoginResult{Token: "tok", ExpiresAt: fixedExpiry}}
+	svc := &FakeLoginService{result: domainuser.LoginResult{Token: "tok", ExpiresAt: fixedExpiry}}
 	handler := pfmhttp.LoginHandler(svc)
 	body := loginBody("u@example.com", "pass")
 

--- a/internal/adapter/http/creditcard_test.go
+++ b/internal/adapter/http/creditcard_test.go
@@ -44,12 +44,12 @@ func testSettings() domaincc.Settings {
 
 // --- CreateCreditCardSettingsHandler tests ---
 
-type stubCreateCCSettingsService struct {
+type FakeCreateCCSettingsService struct {
 	settings domaincc.Settings
 	err      error
 }
 
-func (s *stubCreateCCSettingsService) Create(_ context.Context, _ uuid.UUID, _ domaincc.CreateInput, _ uuid.UUID) (domaincc.Settings, error) {
+func (s *FakeCreateCCSettingsService) Create(_ context.Context, _ uuid.UUID, _ domaincc.CreateInput, _ uuid.UUID) (domaincc.Settings, error) {
 	return s.settings, s.err
 }
 
@@ -57,7 +57,7 @@ func (s *stubCreateCCSettingsService) Create(_ context.Context, _ uuid.UUID, _ d
 func TestCreateCCSettingsHandler_ValidRequest_Returns201(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubCreateCCSettingsService{settings: testSettings()}
+	svc := &FakeCreateCCSettingsService{settings: testSettings()}
 	handler := pfmhttp.CreateCreditCardSettingsHandler(svc)
 
 	body := `{"closing_day":15,"due_day":25,"limit_amount":500000}`
@@ -79,7 +79,7 @@ func TestCreateCCSettingsHandler_ValidRequest_Returns201(t *testing.T) {
 func TestCreateCCSettingsHandler_NotCreditCard_ReturnsConflict(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubCreateCCSettingsService{err: message.ErrCreditCardSettingsNotCreditCard}
+	svc := &FakeCreateCCSettingsService{err: message.ErrCreditCardSettingsNotCreditCard}
 	handler := pfmhttp.CreateCreditCardSettingsHandler(svc)
 
 	body := `{"closing_day":15,"due_day":25,"limit_amount":500000}`
@@ -96,7 +96,7 @@ func TestCreateCCSettingsHandler_NotCreditCard_ReturnsConflict(t *testing.T) {
 func TestCreateCCSettingsHandler_AlreadyExists_Returns409(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubCreateCCSettingsService{err: message.ErrCreditCardSettingsExists}
+	svc := &FakeCreateCCSettingsService{err: message.ErrCreditCardSettingsExists}
 	handler := pfmhttp.CreateCreditCardSettingsHandler(svc)
 
 	body := `{"closing_day":15,"due_day":25,"limit_amount":500000}`
@@ -113,7 +113,7 @@ func TestCreateCCSettingsHandler_AlreadyExists_Returns409(t *testing.T) {
 func TestCreateCCSettingsHandler_ValidationError_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubCreateCCSettingsService{
+	svc := &FakeCreateCCSettingsService{
 		err: &validate.ValidationError{
 			Violations: []validate.Violation{{Field: "closing_day", Message: "must be between 1 and 31"}},
 		},
@@ -134,7 +134,7 @@ func TestCreateCCSettingsHandler_ValidationError_Returns400(t *testing.T) {
 func TestCreateCCSettingsHandler_MalformedJSON_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubCreateCCSettingsService{}
+	svc := &FakeCreateCCSettingsService{}
 	handler := pfmhttp.CreateCreditCardSettingsHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{bad"))
@@ -153,12 +153,12 @@ func TestCreateCCSettingsHandler_NilService_Panics(t *testing.T) {
 
 // --- GetCreditCardSettingsHandler tests ---
 
-type stubGetCCSettingsService struct {
+type FakeGetCCSettingsService struct {
 	settings domaincc.Settings
 	err      error
 }
 
-func (s *stubGetCCSettingsService) FindByAccountID(_ context.Context, _ uuid.UUID) (domaincc.Settings, error) {
+func (s *FakeGetCCSettingsService) FindByAccountID(_ context.Context, _ uuid.UUID) (domaincc.Settings, error) {
 	return s.settings, s.err
 }
 
@@ -166,7 +166,7 @@ func (s *stubGetCCSettingsService) FindByAccountID(_ context.Context, _ uuid.UUI
 func TestGetCCSettingsHandler_ValidID_Returns200(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetCCSettingsService{settings: testSettings()}
+	svc := &FakeGetCCSettingsService{settings: testSettings()}
 	handler := pfmhttp.GetCreditCardSettingsHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -184,7 +184,7 @@ func TestGetCCSettingsHandler_ValidID_Returns200(t *testing.T) {
 func TestGetCCSettingsHandler_NotFound_Returns404(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetCCSettingsService{err: message.ErrCreditCardSettingsNotFound}
+	svc := &FakeGetCCSettingsService{err: message.ErrCreditCardSettingsNotFound}
 	handler := pfmhttp.GetCreditCardSettingsHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -203,12 +203,12 @@ func TestGetCCSettingsHandler_NilService_Panics(t *testing.T) {
 
 // --- UpdateClosingDayHandler tests ---
 
-type stubUpdateClosingDayService struct {
+type FakeUpdateClosingDayService struct {
 	settings domaincc.Settings
 	err      error
 }
 
-func (s *stubUpdateClosingDayService) UpdateClosingDay(_ context.Context, _ uuid.UUID, _ domaincc.UpdateClosingDayInput, _ int, _ uuid.UUID) (domaincc.Settings, error) {
+func (s *FakeUpdateClosingDayService) UpdateClosingDay(_ context.Context, _ uuid.UUID, _ domaincc.UpdateClosingDayInput, _ int, _ uuid.UUID) (domaincc.Settings, error) {
 	return s.settings, s.err
 }
 
@@ -218,7 +218,7 @@ func TestUpdateClosingDayHandler_ValidRequest_Returns200(t *testing.T) {
 
 	updated := testSettings()
 	updated.ClosingDay = 20
-	svc := &stubUpdateClosingDayService{settings: updated}
+	svc := &FakeUpdateClosingDayService{settings: updated}
 	handler := pfmhttp.UpdateClosingDayHandler(svc)
 
 	body := `{"closing_day":20,"version":1}`
@@ -238,7 +238,7 @@ func TestUpdateClosingDayHandler_ValidRequest_Returns200(t *testing.T) {
 func TestUpdateClosingDayHandler_VersionConflict_Returns409(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubUpdateClosingDayService{err: message.ErrCreditCardSettingsVersionConflict}
+	svc := &FakeUpdateClosingDayService{err: message.ErrCreditCardSettingsVersionConflict}
 	handler := pfmhttp.UpdateClosingDayHandler(svc)
 
 	body := `{"closing_day":20,"version":1}`
@@ -259,12 +259,12 @@ func TestUpdateClosingDayHandler_NilService_Panics(t *testing.T) {
 
 // --- UpdateDueDayHandler tests ---
 
-type stubUpdateDueDayService struct {
+type FakeUpdateDueDayService struct {
 	settings domaincc.Settings
 	err      error
 }
 
-func (s *stubUpdateDueDayService) UpdateDueDay(_ context.Context, _ uuid.UUID, _ domaincc.UpdateDueDayInput, _ int, _ uuid.UUID) (domaincc.Settings, error) {
+func (s *FakeUpdateDueDayService) UpdateDueDay(_ context.Context, _ uuid.UUID, _ domaincc.UpdateDueDayInput, _ int, _ uuid.UUID) (domaincc.Settings, error) {
 	return s.settings, s.err
 }
 
@@ -274,7 +274,7 @@ func TestUpdateDueDayHandler_ValidRequest_Returns200(t *testing.T) {
 
 	updated := testSettings()
 	updated.DueDay = 10
-	svc := &stubUpdateDueDayService{settings: updated}
+	svc := &FakeUpdateDueDayService{settings: updated}
 	handler := pfmhttp.UpdateDueDayHandler(svc)
 
 	body := `{"due_day":10,"version":1}`
@@ -298,12 +298,12 @@ func TestUpdateDueDayHandler_NilService_Panics(t *testing.T) {
 
 // --- UpdateCreditLimitHandler tests ---
 
-type stubUpdateCreditLimitService struct {
+type FakeUpdateCreditLimitService struct {
 	settings domaincc.Settings
 	err      error
 }
 
-func (s *stubUpdateCreditLimitService) UpdateLimit(_ context.Context, _ uuid.UUID, _ domaincc.UpdateLimitInput, _ int, _ uuid.UUID) (domaincc.Settings, error) {
+func (s *FakeUpdateCreditLimitService) UpdateLimit(_ context.Context, _ uuid.UUID, _ domaincc.UpdateLimitInput, _ int, _ uuid.UUID) (domaincc.Settings, error) {
 	return s.settings, s.err
 }
 
@@ -313,7 +313,7 @@ func TestUpdateCreditLimitHandler_ValidRequest_Returns200(t *testing.T) {
 
 	updated := testSettings()
 	updated.LimitAmount = 1000000
-	svc := &stubUpdateCreditLimitService{settings: updated}
+	svc := &FakeUpdateCreditLimitService{settings: updated}
 	handler := pfmhttp.UpdateCreditLimitHandler(svc)
 
 	body := `{"limit_amount":1000000,"version":1}`
@@ -337,11 +337,11 @@ func TestUpdateCreditLimitHandler_NilService_Panics(t *testing.T) {
 
 // --- DeleteCreditCardSettingsHandler tests ---
 
-type stubDeleteCCSettingsService struct {
+type FakeDeleteCCSettingsService struct {
 	err error
 }
 
-func (s *stubDeleteCCSettingsService) Delete(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+func (s *FakeDeleteCCSettingsService) Delete(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
 	return s.err
 }
 
@@ -349,7 +349,7 @@ func (s *stubDeleteCCSettingsService) Delete(_ context.Context, _ uuid.UUID, _ u
 func TestDeleteCCSettingsHandler_Success_Returns204(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubDeleteCCSettingsService{}
+	svc := &FakeDeleteCCSettingsService{}
 	handler := pfmhttp.DeleteCreditCardSettingsHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/", nil)
@@ -366,7 +366,7 @@ func TestDeleteCCSettingsHandler_Success_Returns204(t *testing.T) {
 func TestDeleteCCSettingsHandler_NotFound_Returns404(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubDeleteCCSettingsService{err: message.ErrCreditCardSettingsNotFound}
+	svc := &FakeDeleteCCSettingsService{err: message.ErrCreditCardSettingsNotFound}
 	handler := pfmhttp.DeleteCreditCardSettingsHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/", nil)

--- a/internal/adapter/http/household_test.go
+++ b/internal/adapter/http/household_test.go
@@ -55,12 +55,12 @@ func testMembership() domainhouse.Membership {
 
 // --- CreateHouseholdHandler tests ---
 
-type stubCreateHouseholdService struct {
+type FakeCreateHouseholdService struct {
 	household domainhouse.Household
 	err       error
 }
 
-func (s *stubCreateHouseholdService) Create(_ context.Context, _ domainhouse.CreateInput, _ uuid.UUID) (domainhouse.Household, error) {
+func (s *FakeCreateHouseholdService) Create(_ context.Context, _ domainhouse.CreateInput, _ uuid.UUID) (domainhouse.Household, error) {
 	return s.household, s.err
 }
 
@@ -69,7 +69,7 @@ func (s *stubCreateHouseholdService) Create(_ context.Context, _ domainhouse.Cre
 func TestCreateHouseholdHandler_ValidRequest_Returns201(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubCreateHouseholdService{household: testHousehold()}
+	svc := &FakeCreateHouseholdService{household: testHousehold()}
 	handler := pfmhttp.CreateHouseholdHandler(svc)
 
 	body := `{"name":"Test House"}`
@@ -90,7 +90,7 @@ func TestCreateHouseholdHandler_ValidRequest_Returns201(t *testing.T) {
 func TestCreateHouseholdHandler_ValidationError_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubCreateHouseholdService{
+	svc := &FakeCreateHouseholdService{
 		err: &validate.ValidationError{
 			Violations: []validate.Violation{{Field: "name", Message: "is required"}},
 		},
@@ -110,7 +110,7 @@ func TestCreateHouseholdHandler_ValidationError_Returns400(t *testing.T) {
 func TestCreateHouseholdHandler_MalformedJSON_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubCreateHouseholdService{}
+	svc := &FakeCreateHouseholdService{}
 	handler := pfmhttp.CreateHouseholdHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/households", strings.NewReader("{bad"))
@@ -128,12 +128,12 @@ func TestCreateHouseholdHandler_NilService_Panics(t *testing.T) {
 
 // --- GetHouseholdHandler tests ---
 
-type stubGetHouseholdService struct {
+type FakeGetHouseholdService struct {
 	household domainhouse.Household
 	err       error
 }
 
-func (s *stubGetHouseholdService) FindByID(_ context.Context, _ uuid.UUID) (domainhouse.Household, error) {
+func (s *FakeGetHouseholdService) FindByID(_ context.Context, _ uuid.UUID) (domainhouse.Household, error) {
 	return s.household, s.err
 }
 
@@ -141,7 +141,7 @@ func (s *stubGetHouseholdService) FindByID(_ context.Context, _ uuid.UUID) (doma
 func TestGetHouseholdHandler_ValidID_Returns200(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetHouseholdService{household: testHousehold()}
+	svc := &FakeGetHouseholdService{household: testHousehold()}
 	handler := pfmhttp.GetHouseholdHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/households/"+houseID.String(), nil)
@@ -159,7 +159,7 @@ func TestGetHouseholdHandler_ValidID_Returns200(t *testing.T) {
 func TestGetHouseholdHandler_NotFound_Returns404(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetHouseholdService{err: message.ErrHouseholdNotFound}
+	svc := &FakeGetHouseholdService{err: message.ErrHouseholdNotFound}
 	handler := pfmhttp.GetHouseholdHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/households/"+uuid.Nil.String(), nil)
@@ -174,7 +174,7 @@ func TestGetHouseholdHandler_NotFound_Returns404(t *testing.T) {
 func TestGetHouseholdHandler_InvalidUUID_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetHouseholdService{}
+	svc := &FakeGetHouseholdService{}
 	handler := pfmhttp.GetHouseholdHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/households/bad", nil)
@@ -193,12 +193,12 @@ func TestGetHouseholdHandler_NilService_Panics(t *testing.T) {
 
 // --- ListHouseholdsHandler tests ---
 
-type stubListHouseholdsService struct {
+type FakeListHouseholdsService struct {
 	households []domainhouse.Household
 	err        error
 }
 
-func (s *stubListHouseholdsService) ListForUser(_ context.Context, _ uuid.UUID) ([]domainhouse.Household, error) {
+func (s *FakeListHouseholdsService) ListForUser(_ context.Context, _ uuid.UUID) ([]domainhouse.Household, error) {
 	return s.households, s.err
 }
 
@@ -206,7 +206,7 @@ func (s *stubListHouseholdsService) ListForUser(_ context.Context, _ uuid.UUID) 
 func TestListHouseholdsHandler_ReturnsArray(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubListHouseholdsService{households: []domainhouse.Household{testHousehold()}}
+	svc := &FakeListHouseholdsService{households: []domainhouse.Household{testHousehold()}}
 	handler := pfmhttp.ListHouseholdsHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/households", nil)
@@ -226,7 +226,7 @@ func TestListHouseholdsHandler_ReturnsArray(t *testing.T) {
 func TestListHouseholdsHandler_EmptyList_ReturnsEmptyArray(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubListHouseholdsService{households: []domainhouse.Household{}}
+	svc := &FakeListHouseholdsService{households: []domainhouse.Household{}}
 	handler := pfmhttp.ListHouseholdsHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/households", nil)
@@ -247,12 +247,12 @@ func TestListHouseholdsHandler_NilService_Panics(t *testing.T) {
 
 // --- AddMemberHandler tests ---
 
-type stubAddMemberService struct {
+type FakeAddMemberService struct {
 	membership domainhouse.Membership
 	err        error
 }
 
-func (s *stubAddMemberService) AddMember(_ context.Context, _ uuid.UUID, _ domainhouse.AddMemberInput, _ uuid.UUID) (domainhouse.Membership, error) {
+func (s *FakeAddMemberService) AddMember(_ context.Context, _ uuid.UUID, _ domainhouse.AddMemberInput, _ uuid.UUID) (domainhouse.Membership, error) {
 	return s.membership, s.err
 }
 
@@ -260,7 +260,7 @@ func (s *stubAddMemberService) AddMember(_ context.Context, _ uuid.UUID, _ domai
 func TestAddMemberHandler_ValidRequest_Returns201(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubAddMemberService{membership: testMembership()}
+	svc := &FakeAddMemberService{membership: testMembership()}
 	handler := pfmhttp.AddMemberHandler(svc)
 
 	body := `{"user_id":"00000000-0000-0000-0000-000000000020","role":"MEMBER"}`
@@ -281,7 +281,7 @@ func TestAddMemberHandler_ValidRequest_Returns201(t *testing.T) {
 func TestAddMemberHandler_AlreadyMember_Returns409(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubAddMemberService{err: message.ErrHouseholdMemberExists}
+	svc := &FakeAddMemberService{err: message.ErrHouseholdMemberExists}
 	handler := pfmhttp.AddMemberHandler(svc)
 
 	body := `{"user_id":"00000000-0000-0000-0000-000000000020","role":"MEMBER"}`
@@ -298,7 +298,7 @@ func TestAddMemberHandler_AlreadyMember_Returns409(t *testing.T) {
 func TestAddMemberHandler_MalformedJSON_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubAddMemberService{}
+	svc := &FakeAddMemberService{}
 	handler := pfmhttp.AddMemberHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/households/"+houseID.String()+"/members", strings.NewReader("{bad"))
@@ -317,11 +317,11 @@ func TestAddMemberHandler_NilService_Panics(t *testing.T) {
 
 // --- RemoveMemberHandler tests ---
 
-type stubRemoveMemberService struct {
+type FakeRemoveMemberService struct {
 	err error
 }
 
-func (s *stubRemoveMemberService) RemoveMember(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ uuid.UUID) error {
+func (s *FakeRemoveMemberService) RemoveMember(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ uuid.UUID) error {
 	return s.err
 }
 
@@ -329,7 +329,7 @@ func (s *stubRemoveMemberService) RemoveMember(_ context.Context, _ uuid.UUID, _
 func TestRemoveMemberHandler_Success_Returns204(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubRemoveMemberService{}
+	svc := &FakeRemoveMemberService{}
 	handler := pfmhttp.RemoveMemberHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/api/v1/households/"+houseID.String()+"/members/"+memberID.String(), nil)
@@ -347,7 +347,7 @@ func TestRemoveMemberHandler_Success_Returns204(t *testing.T) {
 func TestRemoveMemberHandler_LastAdmin_ReturnsConflict(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubRemoveMemberService{err: message.ErrHouseholdLastAdmin}
+	svc := &FakeRemoveMemberService{err: message.ErrHouseholdLastAdmin}
 	handler := pfmhttp.RemoveMemberHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/api/v1/households/"+houseID.String()+"/members/"+callerID.String(), nil)
@@ -364,7 +364,7 @@ func TestRemoveMemberHandler_LastAdmin_ReturnsConflict(t *testing.T) {
 func TestRemoveMemberHandler_MemberNotFound_Returns404(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubRemoveMemberService{err: message.ErrHouseholdMemberNotFound}
+	svc := &FakeRemoveMemberService{err: message.ErrHouseholdMemberNotFound}
 	handler := pfmhttp.RemoveMemberHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/api/v1/households/"+houseID.String()+"/members/"+uuid.Nil.String(), nil)
@@ -385,12 +385,12 @@ func TestRemoveMemberHandler_NilService_Panics(t *testing.T) {
 
 // --- UpdateHouseholdNameHandler tests ---
 
-type stubUpdateHouseholdNameService struct {
+type FakeUpdateHouseholdNameService struct {
 	household domainhouse.Household
 	err       error
 }
 
-func (s *stubUpdateHouseholdNameService) UpdateName(_ context.Context, _ uuid.UUID, _ domainhouse.UpdateNameInput, _ int, _ uuid.UUID) (domainhouse.Household, error) {
+func (s *FakeUpdateHouseholdNameService) UpdateName(_ context.Context, _ uuid.UUID, _ domainhouse.UpdateNameInput, _ int, _ uuid.UUID) (domainhouse.Household, error) {
 	return s.household, s.err
 }
 
@@ -400,7 +400,7 @@ func TestUpdateHouseholdNameHandler_ValidRequest_Returns200(t *testing.T) {
 
 	updated := testHousehold()
 	updated.Name = "New Name"
-	svc := &stubUpdateHouseholdNameService{household: updated}
+	svc := &FakeUpdateHouseholdNameService{household: updated}
 	handler := pfmhttp.UpdateHouseholdNameHandler(svc)
 
 	body := `{"name":"New Name","version":1}`
@@ -420,7 +420,7 @@ func TestUpdateHouseholdNameHandler_ValidRequest_Returns200(t *testing.T) {
 func TestUpdateHouseholdNameHandler_StaleVersion_Returns409(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubUpdateHouseholdNameService{err: message.ErrHouseholdVersionConflict}
+	svc := &FakeUpdateHouseholdNameService{err: message.ErrHouseholdVersionConflict}
 	handler := pfmhttp.UpdateHouseholdNameHandler(svc)
 
 	body := `{"name":"New Name","version":1}`
@@ -437,7 +437,7 @@ func TestUpdateHouseholdNameHandler_StaleVersion_Returns409(t *testing.T) {
 func TestUpdateHouseholdNameHandler_MalformedJSON_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubUpdateHouseholdNameService{}
+	svc := &FakeUpdateHouseholdNameService{}
 	handler := pfmhttp.UpdateHouseholdNameHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPut, "/api/v1/households/"+houseID.String(), strings.NewReader("{bad"))
@@ -456,11 +456,11 @@ func TestUpdateHouseholdNameHandler_NilService_Panics(t *testing.T) {
 
 // --- DeactivateHouseholdHandler tests ---
 
-type stubDeactivateHouseholdService struct {
+type FakeDeactivateHouseholdService struct {
 	err error
 }
 
-func (s *stubDeactivateHouseholdService) Deactivate(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+func (s *FakeDeactivateHouseholdService) Deactivate(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
 	return s.err
 }
 
@@ -468,7 +468,7 @@ func (s *stubDeactivateHouseholdService) Deactivate(_ context.Context, _ uuid.UU
 func TestDeactivateHouseholdHandler_Success_Returns204(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubDeactivateHouseholdService{}
+	svc := &FakeDeactivateHouseholdService{}
 	handler := pfmhttp.DeactivateHouseholdHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/api/v1/households/"+houseID.String(), nil)
@@ -485,7 +485,7 @@ func TestDeactivateHouseholdHandler_Success_Returns204(t *testing.T) {
 func TestDeactivateHouseholdHandler_NotFound_Returns404(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubDeactivateHouseholdService{err: message.ErrHouseholdNotFound}
+	svc := &FakeDeactivateHouseholdService{err: message.ErrHouseholdNotFound}
 	handler := pfmhttp.DeactivateHouseholdHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/api/v1/households/"+uuid.Nil.String(), nil)
@@ -501,7 +501,7 @@ func TestDeactivateHouseholdHandler_NotFound_Returns404(t *testing.T) {
 func TestDeactivateHouseholdHandler_InvalidUUID_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubDeactivateHouseholdService{}
+	svc := &FakeDeactivateHouseholdService{}
 	handler := pfmhttp.DeactivateHouseholdHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/api/v1/households/bad", nil)
@@ -520,13 +520,13 @@ func TestDeactivateHouseholdHandler_NilService_Panics(t *testing.T) {
 
 // --- CreateHouseholdUserHandler tests ---
 
-// stubCreateHouseholdUserService is a test double for createHouseholdUserService.
-type stubCreateHouseholdUserService struct {
+// FakeCreateHouseholdUserService is a test double for createHouseholdUserService.
+type FakeCreateHouseholdUserService struct {
 	result domainhouse.CreatedMember
 	err    error
 }
 
-func (s *stubCreateHouseholdUserService) CreateHouseholdUser(
+func (s *FakeCreateHouseholdUserService) CreateHouseholdUser(
 	_ context.Context, _ uuid.UUID, _ domainhouse.NewUserInput, _ uuid.UUID,
 ) (domainhouse.CreatedMember, error) {
 	return s.result, s.err
@@ -554,7 +554,7 @@ func TestCreateHouseholdUserHandler_Returns201(t *testing.T) {
 	t.Parallel()
 
 	callerID := uuid.New()
-	svc := &stubCreateHouseholdUserService{result: testCreatedMember()}
+	svc := &FakeCreateHouseholdUserService{result: testCreatedMember()}
 	handler := pfmhttp.CreateHouseholdUserHandler(svc)
 
 	body := `{"email":"new@example.com","display_name":"New User","password":"secret1234"}`
@@ -580,7 +580,7 @@ func TestCreateHouseholdUserHandler_EmailTaken_Returns409(t *testing.T) {
 	t.Parallel()
 
 	callerID := uuid.New()
-	svc := &stubCreateHouseholdUserService{err: message.ErrUserEmailTaken}
+	svc := &FakeCreateHouseholdUserService{err: message.ErrUserEmailTaken}
 	handler := pfmhttp.CreateHouseholdUserHandler(svc)
 
 	body := `{"email":"taken@example.com","display_name":"User","password":"secret1234"}`
@@ -598,7 +598,7 @@ func TestCreateHouseholdUserHandler_MissingFields_Returns400(t *testing.T) {
 	t.Parallel()
 
 	callerID := uuid.New()
-	svc := &stubCreateHouseholdUserService{}
+	svc := &FakeCreateHouseholdUserService{}
 	handler := pfmhttp.CreateHouseholdUserHandler(svc)
 
 	tests := []struct {
@@ -628,7 +628,7 @@ func TestCreateHouseholdUserHandler_InvalidHouseholdID_Returns400(t *testing.T) 
 	t.Parallel()
 
 	callerID := uuid.New()
-	svc := &stubCreateHouseholdUserService{}
+	svc := &FakeCreateHouseholdUserService{}
 	handler := pfmhttp.CreateHouseholdUserHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"email":"a@b.com","display_name":"A","password":"s"}`))
@@ -645,7 +645,7 @@ func TestCreateHouseholdUserHandler_InternalError_Returns500(t *testing.T) {
 	t.Parallel()
 
 	callerID := uuid.New()
-	svc := &stubCreateHouseholdUserService{err: errors.New("unexpected")}
+	svc := &FakeCreateHouseholdUserService{err: errors.New("unexpected")}
 	handler := pfmhttp.CreateHouseholdUserHandler(svc)
 
 	body := `{"email":"a@b.com","display_name":"A","password":"secret1234"}`

--- a/internal/adapter/http/ledger_test.go
+++ b/internal/adapter/http/ledger_test.go
@@ -64,13 +64,13 @@ func testEntries() []domainledger.Entry {
 
 // --- PostTransactionHandler tests ---
 
-type stubPostTransactionService struct {
+type FakePostTransactionService struct {
 	txn     domainledger.Transaction
 	entries []domainledger.Entry
 	err     error
 }
 
-func (s *stubPostTransactionService) PostTransaction(_ context.Context, _ uuid.UUID, _ domainledger.PostTransactionInput, _ uuid.UUID) (domainledger.Transaction, []domainledger.Entry, error) {
+func (s *FakePostTransactionService) PostTransaction(_ context.Context, _ uuid.UUID, _ domainledger.PostTransactionInput, _ uuid.UUID) (domainledger.Transaction, []domainledger.Entry, error) {
 	return s.txn, s.entries, s.err
 }
 
@@ -78,7 +78,7 @@ func (s *stubPostTransactionService) PostTransaction(_ context.Context, _ uuid.U
 func TestPostTransactionHandler_ValidRequest_Returns201(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubPostTransactionService{txn: testTransaction(), entries: testEntries()}
+	svc := &FakePostTransactionService{txn: testTransaction(), entries: testEntries()}
 	handler := pfmhttp.PostTransactionHandler(svc)
 
 	body := `{
@@ -109,7 +109,7 @@ func TestPostTransactionHandler_ValidRequest_Returns201(t *testing.T) {
 func TestPostTransactionHandler_Unbalanced_Returns422(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubPostTransactionService{err: message.ErrLedgerUnbalanced}
+	svc := &FakePostTransactionService{err: message.ErrLedgerUnbalanced}
 	handler := pfmhttp.PostTransactionHandler(svc)
 
 	body := `{
@@ -132,7 +132,7 @@ func TestPostTransactionHandler_Unbalanced_Returns422(t *testing.T) {
 func TestPostTransactionHandler_ValidationError_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubPostTransactionService{
+	svc := &FakePostTransactionService{
 		err: &validate.ValidationError{
 			Violations: []validate.Violation{{Field: "description", Message: "is required"}},
 		},
@@ -153,7 +153,7 @@ func TestPostTransactionHandler_ValidationError_Returns400(t *testing.T) {
 func TestPostTransactionHandler_MalformedJSON_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubPostTransactionService{}
+	svc := &FakePostTransactionService{}
 	handler := pfmhttp.PostTransactionHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{bad"))
@@ -172,12 +172,12 @@ func TestPostTransactionHandler_NilService_Panics(t *testing.T) {
 
 // --- GetBalanceHandler tests ---
 
-type stubGetBalanceService struct {
+type FakeGetBalanceService struct {
 	balance int64
 	err     error
 }
 
-func (s *stubGetBalanceService) GetBalance(_ context.Context, _ uuid.UUID) (int64, error) {
+func (s *FakeGetBalanceService) GetBalance(_ context.Context, _ uuid.UUID) (int64, error) {
 	return s.balance, s.err
 }
 
@@ -185,7 +185,7 @@ func (s *stubGetBalanceService) GetBalance(_ context.Context, _ uuid.UUID) (int6
 func TestGetBalanceHandler_ValidID_Returns200(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetBalanceService{balance: 15000}
+	svc := &FakeGetBalanceService{balance: 15000}
 	handler := pfmhttp.GetBalanceHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -205,7 +205,7 @@ func TestGetBalanceHandler_ValidID_Returns200(t *testing.T) {
 func TestGetBalanceHandler_ZeroBalance_Returns200(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetBalanceService{balance: 0}
+	svc := &FakeGetBalanceService{balance: 0}
 	handler := pfmhttp.GetBalanceHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -223,7 +223,7 @@ func TestGetBalanceHandler_ZeroBalance_Returns200(t *testing.T) {
 func TestGetBalanceHandler_NotFound_Returns404(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetBalanceService{err: message.ErrAccountNotFound}
+	svc := &FakeGetBalanceService{err: message.ErrAccountNotFound}
 	handler := pfmhttp.GetBalanceHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -238,7 +238,7 @@ func TestGetBalanceHandler_NotFound_Returns404(t *testing.T) {
 func TestGetBalanceHandler_InvalidUUID_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetBalanceService{}
+	svc := &FakeGetBalanceService{}
 	handler := pfmhttp.GetBalanceHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -257,12 +257,12 @@ func TestGetBalanceHandler_NilService_Panics(t *testing.T) {
 
 // --- GetTransactionHistoryHandler tests ---
 
-type stubGetHistoryService struct {
+type FakeGetHistoryService struct {
 	history []domainledger.TransactionWithEntries
 	err     error
 }
 
-func (s *stubGetHistoryService) GetTransactionHistory(_ context.Context, _ uuid.UUID, _ domainledger.HistoryQuery) ([]domainledger.TransactionWithEntries, error) {
+func (s *FakeGetHistoryService) GetTransactionHistory(_ context.Context, _ uuid.UUID, _ domainledger.HistoryQuery) ([]domainledger.TransactionWithEntries, error) {
 	return s.history, s.err
 }
 
@@ -270,7 +270,7 @@ func (s *stubGetHistoryService) GetTransactionHistory(_ context.Context, _ uuid.
 func TestGetHistoryHandler_ReturnsArray(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetHistoryService{
+	svc := &FakeGetHistoryService{
 		history: []domainledger.TransactionWithEntries{
 			{Transaction: testTransaction(), Entries: testEntries()},
 		},
@@ -293,7 +293,7 @@ func TestGetHistoryHandler_ReturnsArray(t *testing.T) {
 func TestGetHistoryHandler_EmptyList_ReturnsEmptyArray(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetHistoryService{history: []domainledger.TransactionWithEntries{}}
+	svc := &FakeGetHistoryService{history: []domainledger.TransactionWithEntries{}}
 	handler := pfmhttp.GetTransactionHistoryHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -309,7 +309,7 @@ func TestGetHistoryHandler_EmptyList_ReturnsEmptyArray(t *testing.T) {
 func TestGetHistoryHandler_WithQueryParams(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetHistoryService{history: []domainledger.TransactionWithEntries{}}
+	svc := &FakeGetHistoryService{history: []domainledger.TransactionWithEntries{}}
 	handler := pfmhttp.GetTransactionHistoryHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/?account_id="+ledgerAcctID.String()+"&limit=10&offset=5", nil)

--- a/internal/adapter/http/user_test.go
+++ b/internal/adapter/http/user_test.go
@@ -44,13 +44,13 @@ func ctxWithUser(id uuid.UUID) context.Context {
 
 // --- GetUserHandler tests ---
 
-// stubGetUserService is a test double for the getUserService interface.
-type stubGetUserService struct {
+// FakeGetUserService is a test double for the getUserService interface.
+type FakeGetUserService struct {
 	user domainuser.User
 	err  error
 }
 
-func (s *stubGetUserService) FindByID(_ context.Context, _ uuid.UUID) (domainuser.User, error) {
+func (s *FakeGetUserService) FindByID(_ context.Context, _ uuid.UUID) (domainuser.User, error) {
 	return s.user, s.err
 }
 
@@ -59,7 +59,7 @@ func (s *stubGetUserService) FindByID(_ context.Context, _ uuid.UUID) (domainuse
 func TestGetUserHandler_ValidID_Returns200(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetUserService{user: testUser()}
+	svc := &FakeGetUserService{user: testUser()}
 	handler := pfmhttp.GetUserHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/users/"+testUser().ID.String(), nil)
@@ -79,7 +79,7 @@ func TestGetUserHandler_ValidID_Returns200(t *testing.T) {
 func TestGetUserHandler_NotFound_Returns404(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetUserService{err: message.ErrUserNotFound}
+	svc := &FakeGetUserService{err: message.ErrUserNotFound}
 	handler := pfmhttp.GetUserHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/users/"+uuid.Nil.String(), nil)
@@ -95,7 +95,7 @@ func TestGetUserHandler_NotFound_Returns404(t *testing.T) {
 func TestGetUserHandler_InvalidUUID_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubGetUserService{}
+	svc := &FakeGetUserService{}
 	handler := pfmhttp.GetUserHandler(svc)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/users/not-a-uuid", nil)
@@ -114,13 +114,13 @@ func TestGetUserHandler_NilService_Panics(t *testing.T) {
 
 // --- UpdateProfileHandler tests ---
 
-// stubUpdateProfileService is a test double for the updateProfileService interface.
-type stubUpdateProfileService struct {
+// FakeUpdateProfileService is a test double for the updateProfileService interface.
+type FakeUpdateProfileService struct {
 	user domainuser.User
 	err  error
 }
 
-func (s *stubUpdateProfileService) UpdateProfile(_ context.Context, _ uuid.UUID, _ domainuser.UpdateProfileInput, _ int, _ uuid.UUID) (domainuser.User, error) {
+func (s *FakeUpdateProfileService) UpdateProfile(_ context.Context, _ uuid.UUID, _ domainuser.UpdateProfileInput, _ int, _ uuid.UUID) (domainuser.User, error) {
 	return s.user, s.err
 }
 
@@ -131,7 +131,7 @@ func TestUpdateProfileHandler_ValidRequest_Returns200(t *testing.T) {
 
 	updated := testUser()
 	updated.DisplayName = "Alice Updated"
-	svc := &stubUpdateProfileService{user: updated}
+	svc := &FakeUpdateProfileService{user: updated}
 	handler := pfmhttp.UpdateProfileHandler(svc)
 
 	body := `{"display_name":"Alice Updated","version":1}`
@@ -152,7 +152,7 @@ func TestUpdateProfileHandler_ValidRequest_Returns200(t *testing.T) {
 func TestUpdateProfileHandler_StaleVersion_Returns409(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubUpdateProfileService{err: message.ErrUserVersionConflict}
+	svc := &FakeUpdateProfileService{err: message.ErrUserVersionConflict}
 	handler := pfmhttp.UpdateProfileHandler(svc)
 
 	body := `{"display_name":"New Name","version":1}`
@@ -170,7 +170,7 @@ func TestUpdateProfileHandler_StaleVersion_Returns409(t *testing.T) {
 func TestUpdateProfileHandler_ValidationError_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubUpdateProfileService{
+	svc := &FakeUpdateProfileService{
 		err: &validate.ValidationError{
 			Violations: []validate.Violation{{Field: "display_name", Message: "is required"}},
 		},
@@ -191,7 +191,7 @@ func TestUpdateProfileHandler_ValidationError_Returns400(t *testing.T) {
 func TestUpdateProfileHandler_MalformedJSON_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubUpdateProfileService{}
+	svc := &FakeUpdateProfileService{}
 	handler := pfmhttp.UpdateProfileHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPut, "/api/v1/users/"+testUser().ID.String(), strings.NewReader("{bad"))
@@ -210,13 +210,13 @@ func TestUpdateProfileHandler_NilService_Panics(t *testing.T) {
 
 // --- ChangePasswordHandler tests ---
 
-// stubChangePasswordService is a test double for the changePasswordService interface.
-type stubChangePasswordService struct {
+// FakeChangePasswordService is a test double for the changePasswordService interface.
+type FakeChangePasswordService struct {
 	user domainuser.User
 	err  error
 }
 
-func (s *stubChangePasswordService) ChangePassword(_ context.Context, _ uuid.UUID, _ domainuser.ChangePasswordInput, _ int, _ uuid.UUID) (domainuser.User, error) {
+func (s *FakeChangePasswordService) ChangePassword(_ context.Context, _ uuid.UUID, _ domainuser.ChangePasswordInput, _ int, _ uuid.UUID) (domainuser.User, error) {
 	return s.user, s.err
 }
 
@@ -225,7 +225,7 @@ func (s *stubChangePasswordService) ChangePassword(_ context.Context, _ uuid.UUI
 func TestChangePasswordHandler_ValidRequest_Returns200(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubChangePasswordService{user: testUser()}
+	svc := &FakeChangePasswordService{user: testUser()}
 	handler := pfmhttp.ChangePasswordHandler(svc)
 
 	body := `{"old_password":"oldpass123","new_password":"newpass123","version":1}`
@@ -246,7 +246,7 @@ func TestChangePasswordHandler_ValidRequest_Returns200(t *testing.T) {
 func TestChangePasswordHandler_WrongPassword_Returns401(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubChangePasswordService{err: message.ErrLoginInvalidCredentials}
+	svc := &FakeChangePasswordService{err: message.ErrLoginInvalidCredentials}
 	handler := pfmhttp.ChangePasswordHandler(svc)
 
 	body := `{"old_password":"wrong","new_password":"newpass123","version":1}`
@@ -264,7 +264,7 @@ func TestChangePasswordHandler_WrongPassword_Returns401(t *testing.T) {
 func TestChangePasswordHandler_ValidationError_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubChangePasswordService{
+	svc := &FakeChangePasswordService{
 		err: &validate.ValidationError{
 			Violations: []validate.Violation{
 				{Field: "old_password", Message: "is required"},
@@ -288,7 +288,7 @@ func TestChangePasswordHandler_ValidationError_Returns400(t *testing.T) {
 func TestChangePasswordHandler_MalformedJSON_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubChangePasswordService{}
+	svc := &FakeChangePasswordService{}
 	handler := pfmhttp.ChangePasswordHandler(svc)
 
 	r := httptest.NewRequest(http.MethodPut, "/api/v1/users/"+testUser().ID.String()+"/password", strings.NewReader("{bad"))
@@ -307,12 +307,12 @@ func TestChangePasswordHandler_NilService_Panics(t *testing.T) {
 
 // --- DeactivateUserHandler tests ---
 
-// stubDeactivateUserService is a test double for the deactivateUserService interface.
-type stubDeactivateUserService struct {
+// FakeDeactivateUserService is a test double for the deactivateUserService interface.
+type FakeDeactivateUserService struct {
 	err error
 }
 
-func (s *stubDeactivateUserService) Deactivate(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+func (s *FakeDeactivateUserService) Deactivate(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
 	return s.err
 }
 
@@ -321,7 +321,7 @@ func (s *stubDeactivateUserService) Deactivate(_ context.Context, _ uuid.UUID, _
 func TestDeactivateUserHandler_Success_Returns204(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubDeactivateUserService{}
+	svc := &FakeDeactivateUserService{}
 	handler := pfmhttp.DeactivateUserHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+testUser().ID.String(), nil)
@@ -339,7 +339,7 @@ func TestDeactivateUserHandler_Success_Returns204(t *testing.T) {
 func TestDeactivateUserHandler_NotFound_Returns404(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubDeactivateUserService{err: message.ErrUserNotFound}
+	svc := &FakeDeactivateUserService{err: message.ErrUserNotFound}
 	handler := pfmhttp.DeactivateUserHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+uuid.Nil.String(), nil)
@@ -355,7 +355,7 @@ func TestDeactivateUserHandler_NotFound_Returns404(t *testing.T) {
 func TestDeactivateUserHandler_InvalidUUID_Returns400(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubDeactivateUserService{}
+	svc := &FakeDeactivateUserService{}
 	handler := pfmhttp.DeactivateUserHandler(svc)
 
 	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/not-a-uuid", nil)

--- a/internal/domain/user/login_logic_test.go
+++ b/internal/domain/user/login_logic_test.go
@@ -112,17 +112,17 @@ func TestLoginLogic_RepoInfraError_PropagatesError(t *testing.T) {
 	assert.False(t, errors.Is(err, message.ErrLoginInvalidCredentials))
 }
 
-// stubHasher and stubTokenIssuer are minimal test doubles for error injection.
+// FakeHasher and FakeTokenIssuer are minimal test doubles for error injection.
 // They are unexported and scoped to this test file only.
-type stubHasher struct{ err error }
+type FakeHasher struct{ err error }
 
-func (s *stubHasher) Verify(_ context.Context, _, _ string) (bool, error) {
+func (s *FakeHasher) Verify(_ context.Context, _, _ string) (bool, error) {
 	return false, s.err
 }
 
-type stubTokenIssuer struct{ err error }
+type FakeTokenIssuer struct{ err error }
 
-func (s *stubTokenIssuer) Issue(_ context.Context, _ uuid.UUID, _ time.Time) (string, error) {
+func (s *FakeTokenIssuer) Issue(_ context.Context, _ uuid.UUID, _ time.Time) (string, error) {
 	return "", s.err
 }
 
@@ -133,7 +133,7 @@ func TestLoginLogic_HasherError_PropagatesError(t *testing.T) {
 	repo := postgres.NewFakeUserRepository()
 	tokens := auth.NewFakeTokenService(clk)
 	hasherErr := errors.New("argon2: internal error")
-	hasher := &stubHasher{err: hasherErr}
+	hasher := &FakeHasher{err: hasherErr}
 
 	hash := "fake:" + testPassword
 	repo.Add(domainuser.User{ID: testUserID, Email: testEmail, PasswordHash: hash})
@@ -152,7 +152,7 @@ func TestLoginLogic_TokenIssueError_PropagatesError(t *testing.T) {
 	repo := postgres.NewFakeUserRepository()
 	hasher := auth.NewFakeHasher()
 	tokenErr := errors.New("paseto: key error")
-	tokens := &stubTokenIssuer{err: tokenErr}
+	tokens := &FakeTokenIssuer{err: tokenErr}
 
 	hash, err := hasher.Hash(context.Background(), testPassword)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- 29 test-double types in `adapter/http` and `domain/user` used a `stub` prefix
- `CLAUDE.md` mandates `Fake<Interface>` naming for all test doubles
- Pure rename, no logic changes — 7 files affected

## Test plan
- [x] `go build ./...` passes
- [x] Affected unit tests pass (`adapter/http`, `domain/user`)
- [ ] CI quality-gate passes