### PR TITLE
feat(seed): add seed tool to bootstrap first user and household atomically

### DIFF
--- a/cmd/pfm-seed/config.go
+++ b/cmd/pfm-seed/config.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/config"
+	"github.com/zambone/pfm-go/internal/platform/validate"
+)
+
+// seedConfig holds all settings required by the seed tool, loaded from environment variables.
+// Validated in full before any database connection is opened.
+type seedConfig struct {
+	// Email is the seed user's login email. Env: SEED_EMAIL.
+	Email string
+	// DisplayName is the seed user's display name. Env: SEED_DISPLAY_NAME.
+	DisplayName string
+	// Password is the seed user's plaintext password (hashed before storage). Env: SEED_PASSWORD.
+	Password string
+	// HouseholdName is the name of the seed household. Env: SEED_HOUSEHOLD_NAME.
+	HouseholdName string
+	// DatabaseURL is the full PostgreSQL connection URL. Env: DATABASE_URL.
+	DatabaseURL string
+	// DatabaseSSLMode is the PostgreSQL SSL mode. Env: DATABASE_SSL_MODE. Default: "disable".
+	DatabaseSSLMode string
+}
+
+// loadSeedConfig reads seed configuration from environment variables and validates all fields.
+// Returns a ValidationError if any required field is missing or invalid — before any DB connection.
+func loadSeedConfig() (*seedConfig, error) {
+	cfg := &seedConfig{
+		Email:           os.Getenv("SEED_EMAIL"),
+		DisplayName:     os.Getenv("SEED_DISPLAY_NAME"),
+		Password:        os.Getenv("SEED_PASSWORD"),
+		HouseholdName:   os.Getenv("SEED_HOUSEHOLD_NAME"),
+		DatabaseURL:     os.Getenv("DATABASE_URL"),
+		DatabaseSSLMode: envStrDefault("DATABASE_SSL_MODE", "disable"),
+	}
+
+	r := validate.NewResult()
+	r.Field("email", cfg.Email, validate.Required, validate.Email)
+	r.Field("display_name", cfg.DisplayName, validate.Required)
+	r.Field("password", cfg.Password, validate.Required, validate.MinLen(8))
+	r.Field("household_name", cfg.HouseholdName, validate.Required)
+	r.Field("database_url", cfg.DatabaseURL, validate.Required)
+
+	if err := r.Error(); err != nil {
+		return nil, fmt.Errorf(message.ErrSeedConfig, err)
+	}
+
+	return cfg, nil
+}
+
+// platformCfg maps a seedConfig to the platform config struct that database.Open
+// and database.NewPool expect. Only the DB-related fields are populated.
+func platformCfg(cfg *seedConfig) *config.Config {
+	return &config.Config{
+		DatabaseURL:            cfg.DatabaseURL,
+		DatabaseSSLMode:        cfg.DatabaseSSLMode,
+		DBConnectTimeoutSec:    5,
+		DBStartupRetries:       3,
+		DBStartupRetryDelaySec: 2,
+		DBMaxOpenConns:         5,
+		DBMaxIdleConns:         2,
+		DBConnMaxLifetimeSec:   300,
+		DBConnMaxIdleTimeSec:   60,
+	}
+}
+
+func envStrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/cmd/pfm-seed/config_test.go
+++ b/cmd/pfm-seed/config_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zambone/pfm-go/internal/platform/validate"
+)
+
+func TestLoadSeedConfig_WhenAllEnvVarsSet_ReturnsConfig(t *testing.T) {
+	t.Setenv("SEED_EMAIL", "alice@example.com")
+	t.Setenv("SEED_DISPLAY_NAME", "Alice")
+	t.Setenv("SEED_PASSWORD", "secret1234")
+	t.Setenv("SEED_HOUSEHOLD_NAME", "Alice's Household")
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/db")
+
+	cfg, err := loadSeedConfig()
+
+	require.NoError(t, err)
+	assert.Equal(t, "alice@example.com", cfg.Email)
+	assert.Equal(t, "Alice", cfg.DisplayName)
+	assert.Equal(t, "secret1234", cfg.Password)
+	assert.Equal(t, "Alice's Household", cfg.HouseholdName)
+	assert.Equal(t, "postgres://user:pass@localhost/db", cfg.DatabaseURL)
+}
+
+func TestLoadSeedConfig_WhenMissingEmail_ReturnsValidationError(t *testing.T) {
+	t.Setenv("SEED_EMAIL", "")
+	t.Setenv("SEED_DISPLAY_NAME", "Alice")
+	t.Setenv("SEED_PASSWORD", "secret1234")
+	t.Setenv("SEED_HOUSEHOLD_NAME", "Alice's Household")
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/db")
+
+	_, err := loadSeedConfig()
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	require.True(t, errors.As(err, &ve), "expected ValidationError, got %T: %v", err, err)
+	assertFieldViolated(t, ve, "email")
+}
+
+func TestLoadSeedConfig_WhenMissingDisplayName_ReturnsValidationError(t *testing.T) {
+	t.Setenv("SEED_EMAIL", "alice@example.com")
+	t.Setenv("SEED_DISPLAY_NAME", "")
+	t.Setenv("SEED_PASSWORD", "secret1234")
+	t.Setenv("SEED_HOUSEHOLD_NAME", "Alice's Household")
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/db")
+
+	_, err := loadSeedConfig()
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	require.True(t, errors.As(err, &ve))
+	assertFieldViolated(t, ve, "display_name")
+}
+
+func TestLoadSeedConfig_WhenPasswordTooShort_ReturnsValidationError(t *testing.T) {
+	t.Setenv("SEED_EMAIL", "alice@example.com")
+	t.Setenv("SEED_DISPLAY_NAME", "Alice")
+	t.Setenv("SEED_PASSWORD", "short")
+	t.Setenv("SEED_HOUSEHOLD_NAME", "Alice's Household")
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/db")
+
+	_, err := loadSeedConfig()
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	require.True(t, errors.As(err, &ve))
+	assertFieldViolated(t, ve, "password")
+}
+
+func TestLoadSeedConfig_WhenHouseholdNameEmpty_ReturnsValidationError(t *testing.T) {
+	t.Setenv("SEED_EMAIL", "alice@example.com")
+	t.Setenv("SEED_DISPLAY_NAME", "Alice")
+	t.Setenv("SEED_PASSWORD", "secret1234")
+	t.Setenv("SEED_HOUSEHOLD_NAME", "")
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/db")
+
+	_, err := loadSeedConfig()
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	require.True(t, errors.As(err, &ve))
+	assertFieldViolated(t, ve, "household_name")
+}
+
+func TestLoadSeedConfig_WhenDatabaseURLMissing_ReturnsValidationError(t *testing.T) {
+	t.Setenv("SEED_EMAIL", "alice@example.com")
+	t.Setenv("SEED_DISPLAY_NAME", "Alice")
+	t.Setenv("SEED_PASSWORD", "secret1234")
+	t.Setenv("SEED_HOUSEHOLD_NAME", "Alice's Household")
+	t.Setenv("DATABASE_URL", "")
+
+	_, err := loadSeedConfig()
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	require.True(t, errors.As(err, &ve))
+	assertFieldViolated(t, ve, "database_url")
+}
+
+func TestLoadSeedConfig_WhenEmailInvalid_ReturnsValidationError(t *testing.T) {
+	t.Setenv("SEED_EMAIL", "notanemail")
+	t.Setenv("SEED_DISPLAY_NAME", "Alice")
+	t.Setenv("SEED_PASSWORD", "secret1234")
+	t.Setenv("SEED_HOUSEHOLD_NAME", "Alice's Household")
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/db")
+
+	_, err := loadSeedConfig()
+
+	require.Error(t, err)
+	var ve *validate.ValidationError
+	require.True(t, errors.As(err, &ve))
+	assertFieldViolated(t, ve, "email")
+}
+
+// assertFieldViolated is a test helper that checks at least one violation targets the given field.
+func assertFieldViolated(t *testing.T, ve *validate.ValidationError, field string) {
+	t.Helper()
+	for _, v := range ve.Violations {
+		if v.Field == field {
+			return
+		}
+	}
+	t.Errorf("expected violation for field %q but got %v", field, ve.Violations)
+}

--- a/cmd/pfm-seed/main.go
+++ b/cmd/pfm-seed/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+
+	authadapter "github.com/zambone/pfm-go/internal/adapter/auth"
+	pgadapter "github.com/zambone/pfm-go/internal/adapter/postgres"
+	"github.com/zambone/pfm-go/internal/message"
+	"github.com/zambone/pfm-go/internal/platform/database"
+	pfmdb "github.com/zambone/pfm-go/db"
+)
+
+func main() {
+	if err := run(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+
+	cfg, err := loadSeedConfig()
+	if err != nil {
+		return fmt.Errorf(message.ErrSeedConfig, err)
+	}
+
+	slog.InfoContext(ctx, message.MsgSeedStarting)
+
+	db, err := database.Open(ctx, platformCfg(cfg))
+	if err != nil {
+		return fmt.Errorf(message.ErrRunOpenDB, err)
+	}
+	defer func() { _ = db.Close() }() // best-effort: already committed or rolled back
+
+	migrationsFS, err := fs.Sub(pfmdb.Migrations, "migrations")
+	if err != nil {
+		return fmt.Errorf(message.ErrMigrateSubFS, err)
+	}
+	if err := database.Migrate(ctx, db, migrationsFS); err != nil {
+		return fmt.Errorf(message.ErrRunMigrate, err)
+	}
+
+	pool, err := database.NewPool(ctx, platformCfg(cfg))
+	if err != nil {
+		return fmt.Errorf(message.ErrDBNewPool, err)
+	}
+	defer pool.Close()
+
+	hasher := authadapter.NewArgon2idHasher(authadapter.DefaultArgon2idParams())
+	userRepo := pgadapter.NewUserRepo(pool)
+	householdRepo := pgadapter.NewHouseholdRepo(pool)
+	tx := database.NewPostgresTransactor(pool)
+
+	s := newSeeder(hasher, userRepo, userRepo, householdRepo, tx)
+
+	result, err := s.Run(ctx, seedInput{
+		Email:         cfg.Email,
+		DisplayName:   cfg.DisplayName,
+		Password:      cfg.Password,
+		HouseholdName: cfg.HouseholdName,
+	})
+	if err != nil {
+		return fmt.Errorf(message.ErrSeedTransaction, err)
+	}
+
+	if result.AlreadySeeded {
+		slog.InfoContext(ctx, message.MsgSeedAlreadySeeded)
+		return nil
+	}
+
+	slog.InfoContext(ctx, message.MsgSeedSuccess,
+		"user_id", result.UserID,
+		"household_id", result.HouseholdID,
+	)
+	return nil
+}

--- a/cmd/pfm-seed/seeder.go
+++ b/cmd/pfm-seed/seeder.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	domainhousehold "github.com/zambone/pfm-go/internal/domain/household"
+	domainuser "github.com/zambone/pfm-go/internal/domain/user"
+	"github.com/zambone/pfm-go/internal/message"
+)
+
+// passwordHasher hashes a plaintext password. Structurally satisfied by authadapter.Argon2idHasher.
+type passwordHasher interface {
+	Hash(ctx context.Context, password string) (string, error)
+}
+
+// existenceChecker reports whether any active user row exists. Structurally satisfied by postgres.UserRepo.
+type existenceChecker interface {
+	AnyExists(ctx context.Context) (bool, error)
+}
+
+// userCreator inserts a new user row. Structurally satisfied by postgres.UserRepo.
+type userCreator interface {
+	Create(ctx context.Context, input domainuser.RegisterInput, passwordHash string, callerID uuid.UUID) (domainuser.User, error)
+}
+
+// householdCreator inserts a new household row and its founding ADMIN membership atomically.
+// The callerID is used as both created_by and the founding member's user_id.
+// Structurally satisfied by postgres.HouseholdRepo.
+type householdCreator interface {
+	Create(ctx context.Context, input domainhousehold.CreateInput, callerID uuid.UUID) (domainhousehold.Household, error)
+}
+
+// seederTransactor runs a function inside a database transaction.
+// Structurally satisfied by database.PostgresTransactor.
+type seederTransactor interface {
+	RunAtomic(ctx context.Context, fn func(context.Context) error) error
+}
+
+// seedInput carries the validated credentials and household name for the bootstrap operation.
+type seedInput struct {
+	Email         string
+	DisplayName   string
+	Password      string // plaintext — hashed inside Run before any DB write
+	HouseholdName string
+}
+
+// seedResult distinguishes "newly created" from "already seeded" (idempotent exit).
+type seedResult struct {
+	// AlreadySeeded is true when users already existed; no writes were performed.
+	AlreadySeeded bool
+	// UserID is the ID of the newly created seed user. Zero if AlreadySeeded.
+	UserID uuid.UUID
+	// HouseholdID is the ID of the newly created seed household. Zero if AlreadySeeded.
+	HouseholdID uuid.UUID
+}
+
+// seeder orchestrates the atomic bootstrap of the first user and household.
+type seeder struct {
+	hasher     passwordHasher
+	checker    existenceChecker
+	users      userCreator
+	households householdCreator
+	tx         seederTransactor
+}
+
+// newSeeder constructs a seeder. Panics if any dependency is nil.
+func newSeeder(
+	hasher passwordHasher,
+	checker existenceChecker,
+	users userCreator,
+	households householdCreator,
+	tx seederTransactor,
+) *seeder {
+	if hasher == nil {
+		panic("seed: newSeeder requires non-nil passwordHasher")
+	}
+	if checker == nil {
+		panic("seed: newSeeder requires non-nil existenceChecker")
+	}
+	if users == nil {
+		panic("seed: newSeeder requires non-nil userCreator")
+	}
+	if households == nil {
+		panic("seed: newSeeder requires non-nil householdCreator")
+	}
+	if tx == nil {
+		panic("seed: newSeeder requires non-nil seederTransactor")
+	}
+	return &seeder{
+		hasher:     hasher,
+		checker:    checker,
+		users:      users,
+		households: households,
+		tx:         tx,
+	}
+}
+
+// Run executes the bootstrap sequence. It is idempotent: if any user already exists,
+// it returns seedResult{AlreadySeeded: true} without modifying the database.
+//
+// On success, the created user and household are linked via an ADMIN membership, all within
+// a single database transaction. A failure at any step rolls back all writes.
+func (s *seeder) Run(ctx context.Context, input seedInput) (seedResult, error) {
+	exists, err := s.checker.AnyExists(ctx)
+	if err != nil {
+		return seedResult{}, fmt.Errorf(message.ErrSeedCheckExists, err)
+	}
+	if exists {
+		return seedResult{AlreadySeeded: true}, nil
+	}
+
+	passwordHash, err := s.hasher.Hash(ctx, input.Password)
+	if err != nil {
+		return seedResult{}, fmt.Errorf(message.ErrSeedHashPassword, err)
+	}
+
+	var result seedResult
+
+	if err := s.tx.RunAtomic(ctx, func(txCtx context.Context) error {
+		user, err := s.users.Create(txCtx, domainuser.RegisterInput{
+			Email:       input.Email,
+			DisplayName: input.DisplayName,
+		}, passwordHash, uuid.Nil)
+		if err != nil {
+			return fmt.Errorf(message.ErrSeedCreateUser, err)
+		}
+
+		// HouseholdRepo.Create inserts both the household row and the founding ADMIN
+		// membership in one operation — no separate AddMember call needed.
+		household, err := s.households.Create(txCtx, domainhousehold.CreateInput{
+			Name: input.HouseholdName,
+		}, user.ID)
+		if err != nil {
+			return fmt.Errorf(message.ErrSeedCreateHousehold, err)
+		}
+
+		result = seedResult{UserID: user.ID, HouseholdID: household.ID}
+		return nil
+	}); err != nil {
+		return seedResult{}, fmt.Errorf(message.ErrSeedTransaction, err)
+	}
+
+	return result, nil
+}

--- a/cmd/pfm-seed/seeder_integration_test.go
+++ b/cmd/pfm-seed/seeder_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authadapter "github.com/zambone/pfm-go/internal/adapter/auth"
+	pgadapter "github.com/zambone/pfm-go/internal/adapter/postgres"
+	"github.com/zambone/pfm-go/internal/platform/database"
+	"github.com/zambone/pfm-go/internal/testutil/dbtest"
+)
+
+var sharedDB *dbtest.SharedDB
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	var cleanup func()
+	sharedDB, cleanup = dbtest.Setup(ctx)
+	defer cleanup()
+	sharedDB.PrepareTemplate(ctx)
+	os.Exit(m.Run())
+}
+
+// newSeedEnv wires a real seeder against a per-test isolated Postgres database.
+func newSeedEnv(t *testing.T, ctx context.Context) *seeder {
+	t.Helper()
+
+	pool := sharedDB.NewPool(t, ctx)
+	hasher := authadapter.NewArgon2idHasher(authadapter.DefaultArgon2idParams())
+	userRepo := pgadapter.NewUserRepo(pool)
+	householdRepo := pgadapter.NewHouseholdRepo(pool)
+	tx := database.NewPostgresTransactor(pool)
+
+	return newSeeder(hasher, userRepo, userRepo, householdRepo, tx)
+}
+
+// TestSeeder_Integration_BootstrapsFirstUser verifies AC1: running the seeder against an
+// empty database creates one user, one household, and one ADMIN membership atomically.
+func TestSeeder_Integration_BootstrapsFirstUser(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := newSeedEnv(t, ctx)
+
+	result, err := s.Run(ctx, seedInput{
+		Email:         "alice@example.com",
+		DisplayName:   "Alice",
+		Password:      "secret1234",
+		HouseholdName: "Alice's Household",
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.AlreadySeeded, "first run must not report already seeded")
+	assert.NotEmpty(t, result.UserID, "result must carry the created user ID")
+	assert.NotEmpty(t, result.HouseholdID, "result must carry the created household ID")
+}
+
+// TestSeeder_Integration_IsIdempotent verifies AC2: a second run against a database
+// that already contains users exits cleanly with AlreadySeeded=true.
+func TestSeeder_Integration_IsIdempotent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := newSeedEnv(t, ctx)
+
+	input := seedInput{
+		Email:         "bob@example.com",
+		DisplayName:   "Bob",
+		Password:      "secret1234",
+		HouseholdName: "Bob's Household",
+	}
+
+	first, err := s.Run(ctx, input)
+	require.NoError(t, err)
+	require.False(t, first.AlreadySeeded)
+
+	second, err := s.Run(ctx, input)
+	require.NoError(t, err)
+	assert.True(t, second.AlreadySeeded, "second run must report already seeded")
+}
+
+// alwaysFreshChecker is a test-only existenceChecker that always reports no users exist.
+// It forces the seeder to enter the transaction path even when a user is already in the DB,
+// allowing integration tests to exercise mid-transaction rollback behaviour.
+type alwaysFreshChecker struct{}
+
+func (alwaysFreshChecker) AnyExists(_ context.Context) (bool, error) { return false, nil }
+
+// TestSeeder_Integration_RollbackOnFailure verifies AC5: when the user insert fails
+// mid-transaction (duplicate email unique constraint), the transaction is rolled back and
+// no household row persists.
+func TestSeeder_Integration_RollbackOnFailure(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pool := sharedDB.NewPool(t, ctx)
+	hasher := authadapter.NewArgon2idHasher(authadapter.DefaultArgon2idParams())
+	userRepo := pgadapter.NewUserRepo(pool)
+	householdRepo := pgadapter.NewHouseholdRepo(pool)
+	tx := database.NewPostgresTransactor(pool)
+
+	// Use a fake checker that bypasses the idempotency guard so the seeder always
+	// enters the transaction, even when a user already exists.
+	s := newSeeder(hasher, alwaysFreshChecker{}, userRepo, householdRepo, tx)
+
+	// Pre-insert a user with the target email directly — outside any seeder transaction.
+	// When the seeder tries to create the same email inside the transaction, the unique
+	// constraint fires and the transaction is aborted.
+	_, err := pool.Exec(ctx,
+		`INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3)`,
+		"dave@example.com", "somehash", "Dave",
+	)
+	require.NoError(t, err, "pre-insert must succeed")
+
+	_, err = s.Run(ctx, seedInput{
+		Email:         "dave@example.com",
+		DisplayName:   "Dave",
+		Password:      "secret1234",
+		HouseholdName: "Dave's Household",
+	})
+
+	require.Error(t, err, "seeder must fail on duplicate email")
+
+	// Confirm no household row was created — the transaction rolled back completely.
+	var count int
+	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM households WHERE name = $1`, "Dave's Household").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "household must not persist after transaction rollback")
+}
+
+// TestSeeder_Integration_CreatedUserCanLogin verifies AC4: after seeding, the created
+// user's email and password hash are valid — the login path can authenticate them.
+func TestSeeder_Integration_CreatedUserCanLogin(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pool := sharedDB.NewPool(t, ctx)
+	hasher := authadapter.NewArgon2idHasher(authadapter.DefaultArgon2idParams())
+	userRepo := pgadapter.NewUserRepo(pool)
+	householdRepo := pgadapter.NewHouseholdRepo(pool)
+	tx := database.NewPostgresTransactor(pool)
+	s := newSeeder(hasher, userRepo, userRepo, householdRepo, tx)
+
+	const password = "secret1234"
+	_, err := s.Run(ctx, seedInput{
+		Email:         "carol@example.com",
+		DisplayName:   "Carol",
+		Password:      password,
+		HouseholdName: "Carol's Household",
+	})
+	require.NoError(t, err)
+
+	// Verify the stored hash authenticates with the original plaintext password.
+	found, err := userRepo.FindByEmail(ctx, "carol@example.com")
+	require.NoError(t, err)
+
+	ok, err := hasher.Verify(ctx, password, found.PasswordHash)
+	require.NoError(t, err)
+	assert.True(t, ok, "stored hash must verify against the original password")
+}

--- a/cmd/pfm-seed/seeder_test.go
+++ b/cmd/pfm-seed/seeder_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	domainhousehold "github.com/zambone/pfm-go/internal/domain/household"
+	domainuser "github.com/zambone/pfm-go/internal/domain/user"
+)
+
+// fakeHasher implements passwordHasher for tests.
+type fakeHasher struct {
+	hash string
+	err  error
+}
+
+func (f *fakeHasher) Hash(_ context.Context, _ string) (string, error) {
+	return f.hash, f.err
+}
+
+// fakeExistenceChecker implements existenceChecker for tests.
+type fakeExistenceChecker struct {
+	exists bool
+	err    error
+}
+
+func (f *fakeExistenceChecker) AnyExists(_ context.Context) (bool, error) {
+	return f.exists, f.err
+}
+
+// fakeUserCreator implements userCreator for tests.
+type fakeUserCreator struct {
+	user domainuser.User
+	err  error
+}
+
+func (f *fakeUserCreator) Create(_ context.Context, _ domainuser.RegisterInput, _ string, _ uuid.UUID) (domainuser.User, error) {
+	return f.user, f.err
+}
+
+// fakeHouseholdCreator implements householdCreator for tests.
+type fakeHouseholdCreator struct {
+	household domainhousehold.Household
+	err       error
+}
+
+func (f *fakeHouseholdCreator) Create(_ context.Context, _ domainhousehold.CreateInput, _ uuid.UUID) (domainhousehold.Household, error) {
+	return f.household, f.err
+}
+
+// fakeTransactor implements seederTransactor for tests. It executes fn inline (no real DB).
+type fakeTransactor struct {
+	err error // if non-nil, RunAtomic returns this error without calling fn
+}
+
+func (f *fakeTransactor) RunAtomic(ctx context.Context, fn func(context.Context) error) error {
+	if f.err != nil {
+		return f.err
+	}
+	return fn(ctx)
+}
+
+// seedTestEnv builds a Seeder with all fakes pre-wired for happy-path defaults.
+func seedTestEnv() (*seeder, *fakeExistenceChecker, *fakeUserCreator, *fakeHouseholdCreator) {
+	checker := &fakeExistenceChecker{exists: false}
+	hasher := &fakeHasher{hash: "hashed-password"}
+	userID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	hhID := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	creator := &fakeUserCreator{user: domainuser.User{ID: userID, Email: "alice@example.com"}}
+	hhCreator := &fakeHouseholdCreator{household: domainhousehold.Household{ID: hhID, Name: "Test HH"}}
+	tx := &fakeTransactor{}
+
+	s := newSeeder(hasher, checker, creator, hhCreator, tx)
+	return s, checker, creator, hhCreator
+}
+
+// TestSeeder_Run_Success verifies the happy path: all three writes occur and the result
+// carries the created user and household IDs.
+func TestSeeder_Run_Success(t *testing.T) {
+	s, _, _, _ := seedTestEnv()
+
+	result, err := s.Run(context.Background(), seedInput{
+		Email:         "alice@example.com",
+		DisplayName:   "Alice",
+		Password:      "secret1234",
+		HouseholdName: "Test HH",
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.AlreadySeeded)
+	assert.NotEqual(t, uuid.Nil, result.UserID)
+	assert.NotEqual(t, uuid.Nil, result.HouseholdID)
+}
+
+// TestSeeder_Run_WhenAlreadySeeded verifies AC2: when users already exist, Run returns
+// AlreadySeeded=true and makes no DB writes.
+func TestSeeder_Run_WhenAlreadySeeded(t *testing.T) {
+	s, checker, creator, hhCreator := seedTestEnv()
+	checker.exists = true
+
+	// Force errors on write operations to confirm they are never called.
+	creator.err = errors.New("should not be called")
+	hhCreator.err = errors.New("should not be called")
+
+	result, err := s.Run(context.Background(), seedInput{
+		Email:         "alice@example.com",
+		DisplayName:   "Alice",
+		Password:      "secret1234",
+		HouseholdName: "Test HH",
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.AlreadySeeded)
+	assert.Equal(t, uuid.Nil, result.UserID)
+	assert.Equal(t, uuid.Nil, result.HouseholdID)
+}
+
+// TestSeeder_Run_WhenExistenceCheckFails verifies that a DB error on the existence check
+// is propagated immediately.
+func TestSeeder_Run_WhenExistenceCheckFails(t *testing.T) {
+	s, checker, _, _ := seedTestEnv()
+	checker.err = errors.New("connection refused")
+
+	_, err := s.Run(context.Background(), seedInput{
+		Email:         "alice@example.com",
+		DisplayName:   "Alice",
+		Password:      "secret1234",
+		HouseholdName: "Test HH",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+// TestSeeder_Run_WhenUserCreateFails verifies AC5: a failure inside the transaction
+// causes RunAtomic to roll back. The error is propagated to the caller.
+func TestSeeder_Run_WhenUserCreateFails(t *testing.T) {
+	s, _, creator, _ := seedTestEnv()
+	creator.err = errors.New("unique constraint violation")
+
+	_, err := s.Run(context.Background(), seedInput{
+		Email:         "alice@example.com",
+		DisplayName:   "Alice",
+		Password:      "secret1234",
+		HouseholdName: "Test HH",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unique constraint violation")
+}
+
+// TestSeeder_Run_WhenHouseholdCreateFails verifies AC5: a household creation failure
+// rolls back the entire transaction (user row must not persist).
+func TestSeeder_Run_WhenHouseholdCreateFails(t *testing.T) {
+	s, _, _, hhCreator := seedTestEnv()
+	hhCreator.err = errors.New("household insert error")
+
+	_, err := s.Run(context.Background(), seedInput{
+		Email:         "alice@example.com",
+		DisplayName:   "Alice",
+		Password:      "secret1234",
+		HouseholdName: "Test HH",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "household insert error")
+}
+

--- a/db/queries/users.sql
+++ b/db/queries/users.sql
@@ -50,3 +50,6 @@ SET deleted_at = NOW(),
     updated_by = sqlc.arg('updated_by')
 WHERE id       = sqlc.arg('id')
   AND deleted_at IS NULL;
+
+-- name: AnyUserExists :one
+SELECT EXISTS(SELECT 1 FROM users WHERE deleted_at IS NULL) AS exists;

--- a/internal/adapter/postgres/user_repo.go
+++ b/internal/adapter/postgres/user_repo.go
@@ -255,6 +255,25 @@ func (r *UserRepo) ChangePassword(ctx context.Context, id uuid.UUID, newHash str
 	}, nil
 }
 
+// AnyExists reports whether at least one active (non-deleted) user row exists in the database.
+// Used by the seed tool to detect an already-bootstrapped environment.
+func (r *UserRepo) AnyExists(ctx context.Context) (bool, error) {
+	ctx, span := otel.Tracer("postgres").Start(ctx, "UserRepo.AnyExists")
+	defer span.End()
+
+	db := database.DBTXFromContext(ctx, r.pool)
+	exists, err := New(db).AnyUserExists(ctx)
+	if err != nil {
+		err = fmt.Errorf("user: any exists: %w", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return false, err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return exists, nil
+}
+
 // Deactivate soft-deletes the user. Idempotent — deactivating an already-deactivated
 // or non-existent user is not an error.
 func (r *UserRepo) Deactivate(ctx context.Context, id uuid.UUID, callerID uuid.UUID) error {

--- a/internal/adapter/postgres/user_repo_integration_test.go
+++ b/internal/adapter/postgres/user_repo_integration_test.go
@@ -358,3 +358,37 @@ func TestUserRepo_Deactivate_IsIdempotent(t *testing.T) {
 	require.NoError(t, repo.Deactivate(ctx, created.ID, integCallerID))
 	assert.NoError(t, repo.Deactivate(ctx, created.ID, integCallerID), "second deactivate must not error")
 }
+
+// AnyExists
+// ---------------------------------------------------------------------------
+
+// TestUserRepo_AnyExists_ReturnsFalseOnEmptyDB verifies that an empty database
+// reports no existing users.
+func TestUserRepo_AnyExists_ReturnsFalseOnEmptyDB(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pool := sharedDB.NewPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	exists, err := repo.AnyExists(ctx)
+
+	require.NoError(t, err)
+	assert.False(t, exists, "empty database must have no users")
+}
+
+// TestUserRepo_AnyExists_ReturnsTrueAfterCreate verifies that creating a user
+// causes AnyExists to return true.
+func TestUserRepo_AnyExists_ReturnsTrueAfterCreate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pool := sharedDB.NewPool(t, ctx)
+	repo := postgres.NewUserRepo(pool)
+
+	_, err := repo.Create(ctx, integRegisterInput("any-exists@example.com"), integTestPasswordHash, integCallerID)
+	require.NoError(t, err)
+
+	exists, err := repo.AnyExists(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, exists, "database with a user must report exists=true")
+}

--- a/internal/adapter/postgres/users.sql.go
+++ b/internal/adapter/postgres/users.sql.go
@@ -12,6 +12,17 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const anyUserExists = `-- name: AnyUserExists :one
+SELECT EXISTS(SELECT 1 FROM users WHERE deleted_at IS NULL) AS exists
+`
+
+func (q *Queries) AnyUserExists(ctx context.Context) (bool, error) {
+	row := q.db.QueryRow(ctx, anyUserExists)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const changeUserPassword = `-- name: ChangeUserPassword :one
 UPDATE users
 SET password_hash = $1,

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -21,6 +21,7 @@ const (
 	MsgOneOf       = "must be one of %v"
 	MsgPositive    = "must be positive"
 	MsgNonNegative = "must not be negative"
+	MsgEmail       = "must be a valid email address"
 )
 
 // Config errors.
@@ -328,4 +329,18 @@ const (
 	ErrRunOpenDB     = "open database: %w"
 	ErrRunMigrate    = "run migrations: %w"
 	ErrRunTokenKey   = "init token service: %w"
+)
+
+// Seed tool messages and errors (used by cmd/pfm-seed).
+const (
+	MsgSeedStarting        = "starting seed tool"
+	MsgSeedAlreadySeeded   = "database already contains users — skipping seed"
+	MsgSeedSuccess         = "seed complete"
+	ErrSeedConfig          = "seed config: %w"
+	ErrSeedCheckExists     = "seed: check existing users: %w"
+	ErrSeedHashPassword    = "seed: hash password: %w"
+	ErrSeedCreateUser      = "seed: create user: %w"
+	ErrSeedCreateHousehold = "seed: create household: %w"
+	ErrSeedAddMember       = "seed: add admin member: %w"
+	ErrSeedTransaction     = "seed: transaction: %w"
 )

--- a/internal/platform/validate/rules.go
+++ b/internal/platform/validate/rules.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/zambone/pfm-go/internal/message"
 )
@@ -110,6 +111,25 @@ func NonNegative(value any) string {
 		if v < 0 {
 			return message.MsgNonNegative
 		}
+	}
+	return ""
+}
+
+// Email rejects strings that do not contain exactly one '@' with a non-empty
+// local part and a non-empty domain containing at least one '.'.
+// This is a lightweight structural check — not full RFC 5322 compliance.
+func Email(value any) string {
+	s, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	at := strings.LastIndex(s, "@")
+	if at <= 0 {
+		return message.MsgEmail
+	}
+	domain := s[at+1:]
+	if domain == "" || !strings.Contains(domain, ".") {
+		return message.MsgEmail
 	}
 	return ""
 }

--- a/internal/platform/validate/validate_test.go
+++ b/internal/platform/validate/validate_test.go
@@ -131,3 +131,31 @@ func TestRules_SafeOnUnexpectedTypes(t *testing.T) {
 		r.Field("g", 123, validate.OneOf("a", "b"))
 	})
 }
+
+func TestField_Email_AcceptsValidAddresses(t *testing.T) {
+	cases := []string{
+		"user@example.com",
+		"user+tag@example.co.uk",
+		"first.last@subdomain.example.com",
+	}
+	for _, addr := range cases {
+		r := validate.NewResult()
+		r.Field("email", addr, validate.Email)
+		assert.False(t, r.HasViolations(), "expected %q to be valid", addr)
+	}
+}
+
+func TestField_Email_RejectsInvalidAddresses(t *testing.T) {
+	cases := []string{
+		"notanemail",
+		"missing-at-sign",
+		"@nodomain",
+		"nolocal@",
+		"",
+	}
+	for _, addr := range cases {
+		r := validate.NewResult()
+		r.Field("email", addr, validate.Email)
+		assert.True(t, r.HasViolations(), "expected %q to be invalid", addr)
+	}
+}


### PR DESCRIPTION
## Summary
- Introduces `cmd/pfm-seed` CLI binary — no HTTP surface, invoked once manually after first production deploy
- Creates first user + household + ADMIN membership atomically in a single `RunAtomic` transaction
- Full pre-flight validation of all env vars (email format, password length, required fields) before any DB connection is opened
- Idempotent: second run detects existing users via `UserRepo.AnyExists` and exits cleanly with no writes
- Adds `validate.Email` rule to `internal/platform/validate` for reusable structural email checks
- Integration tests cover: bootstrap, idempotency, login credential verification, and rollback on mid-transaction failure

## Test plan
- [x] `make ci` passes (lint + coverage + vuln + build + integration tests)
- [x] `/project:verify-issue` verdict: PASS (all AC + edge cases COVERED)
- [x] `/project:review` verdict: PASS (all 10 categories)
- [x] Integration tests pass with testcontainers (OrbStack): AC1 bootstrap, AC2 idempotency, AC4 login, AC5 rollback