### PR TITLE
fix(household): wrap errors in CreateHouseholdUser closure and add AC-7 test

### DIFF
--- a/cmd/pfm-seed/main.go
+++ b/cmd/pfm-seed/main.go
@@ -65,7 +65,7 @@ func run() error {
 		HouseholdName: cfg.HouseholdName,
 	})
 	if err != nil {
-		return fmt.Errorf(message.ErrSeedTransaction, err)
+		return fmt.Errorf(message.ErrRunSeed, err)
 	}
 
 	if result.AlreadySeeded {

--- a/internal/adapter/http/e2e_user_test.go
+++ b/internal/adapter/http/e2e_user_test.go
@@ -56,7 +56,17 @@ func TestE2E_HouseholdUser_Create_Success(t *testing.T) {
 	}, "")
 	require.Equal(t, http.StatusOK, w.Code, "login new user: %s", w.Body.String())
 	login := decodeJSON(t, w)
-	assert.NotEmpty(t, login["token"])
+	newUserToken := login["token"].(string)
+	assert.NotEmpty(t, newUserToken)
+
+	// The new user can access their own household.
+	w = env.do(t, http.MethodGet, "/api/v1/households/"+householdID, nil, newUserToken)
+	assert.Equal(t, http.StatusOK, w.Code, "new user should access own household: %s", w.Body.String())
+
+	// The new user cannot access a different household.
+	_, _, otherHouseholdID := env.bootstrapAdmin(t, ctx, "other-admin@example.com", "Other Admin", "secret1234")
+	w = env.do(t, http.MethodGet, "/api/v1/households/"+otherHouseholdID, nil, newUserToken)
+	assert.Equal(t, http.StatusForbidden, w.Code, "new user should not access another household")
 }
 
 // TestE2E_HouseholdUser_Create_NoToken_Returns401 verifies that an unauthenticated

--- a/internal/domain/household/member_logic.go
+++ b/internal/domain/household/member_logic.go
@@ -50,7 +50,7 @@ func (l *HouseholdMemberLogic) CreateHouseholdUser(ctx context.Context, househol
 		// Step 1 — create the user (validation + hashing happen inside the adapter).
 		created, err := l.users.Create(txCtx, input, callerID)
 		if err != nil {
-			return err
+			return fmt.Errorf(message.ErrHouseholdLogicCreateUserStep, err)
 		}
 
 		// Step 2 — add the new user as a MEMBER of the household.
@@ -59,7 +59,7 @@ func (l *HouseholdMemberLogic) CreateHouseholdUser(ctx context.Context, househol
 			Role:   types.RoleMember,
 		}, callerID)
 		if err != nil {
-			return err
+			return fmt.Errorf(message.ErrHouseholdLogicAddMemberStep, err)
 		}
 
 		result = CreatedMember{User: created, Membership: membership}

--- a/internal/message/errors.go
+++ b/internal/message/errors.go
@@ -221,7 +221,9 @@ const (
 	ErrHouseholdLogicRemoveMember = "household logic: remove member: %w"
 	ErrHouseholdLogicUpdateName   = "household logic: update name: %w"
 	ErrHouseholdLogicDeactivate   = "household logic: deactivate: %w"
-	ErrHouseholdLogicCreateUser   = "household logic: create household user: %w"
+	ErrHouseholdLogicCreateUser        = "household logic: create household user: %w"
+	ErrHouseholdLogicCreateUserStep    = "household logic: create user step: %w"
+	ErrHouseholdLogicAddMemberStep     = "household logic: add member step: %w"
 )
 
 // Account repository errors.
@@ -324,6 +326,7 @@ const (
 // Startup errors (used by cmd/pfm/main.go composition root).
 const (
 	ErrRunLoadConfig = "load config: %w"
+	ErrRunSeed       = "run seed: %w"
 	ErrRunLogLevel   = "parse log level %q: %w"
 	ErrRunTracerInit = "init tracer: %w"
 	ErrRunOpenDB     = "open database: %w"


### PR DESCRIPTION
## Summary
- Wrap user-creation and add-member steps inside `RunAtomic` closure with named error constants — bare `return err` violated the always-wrap policy
- Replace incorrect `ErrSeedTransaction` wrap in seed `main.go` with `ErrRunSeed` to fix double-wrapping and wrong context on non-transaction failures
- Add `ErrRunSeed`, `ErrHouseholdLogicCreateUserStep`, `ErrHouseholdLogicAddMemberStep` to `message/errors.go`
- Extend `TestE2E_HouseholdUser_Create_Success` to verify created user can access their own household (200) and is denied another household (403), closing AC-7 of epic #180

## Test plan
- [x] `make ci` passes (lint + test -race + build)
- [x] `/project:verify-issue` verdict: PASS
- [x] `/project:review` verdict: PASS (all categories)
- [x] Integration tests pass with testcontainers