### PR TITLE
chore(deploy): point smoke test at custom domain and document it in fly.toml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,16 +44,17 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Smoke test
-        # Probe /health/ready on the live Fly.io URL to confirm the deployed
-        # binary is actually healthy. flyctl deploy --wait-timeout already waited
-        # for Fly.io's internal health check to pass, so the first attempt will
-        # almost always succeed. The 10-retry window (50 s total) absorbs edge
-        # cases: DNS propagation delay or a transient network blip between the
-        # GitHub Actions runner and Fly.io.
+        # Probe /health/ready through the custom domain to confirm the deployed
+        # binary is healthy AND the full Cloudflare → Fly.io path is functioning.
+        # flyctl deploy --wait-timeout already waited for Fly.io's internal health
+        # check to pass, so the first attempt will almost always succeed. The
+        # 10-retry window (50 s total) absorbs edge cases: Cloudflare propagation
+        # delay or a transient network blip between the GitHub Actions runner and
+        # Cloudflare.
         id: smoke
         run: |
           for i in $(seq 1 10); do
-            if curl -sf --max-time 10 https://pfm-go-api.fly.dev/health/ready; then
+            if curl -sf --max-time 10 https://pfm-go-api.zambone.dev/health/ready; then
               echo "Smoke test passed on attempt $i"
               exit 0
             fi

--- a/fly.toml
+++ b/fly.toml
@@ -13,6 +13,8 @@ primary_region = 'gru'
   auto_stop_machines = 'stop'
   auto_start_machines = true
   min_machines_running = 0
+  # Custom domain: pfm-go-api.zambone.dev — registered via `flyctl certs add` (pfm-infra#4).
+  # Cloudflare proxies all client traffic through this domain to the Fly.io origin.
 
   [[http_service.checks]]
     grace_period = '10s'


### PR DESCRIPTION
## Summary
- Update smoke test `curl` target from `pfm-go-api.fly.dev` to `pfm-go-api.zambone.dev` — every deploy now validates the full Cloudflare → Fly.io path
- Add comment under `[http_service]` in `fly.toml` documenting the registered custom domain and its Cloudflare proxy relationship

## Test plan
- [x] `make ci` passes (lint + test -race + build)
- [x] `/project:verify-issue` verdict: PASS
- [x] `/project:review` verdict: PASS
- [x] Depends on pfm-infra#4 (CLOSED — cert active, domain live)