### PR TITLE
chore(settings): consolidate Claude Code permissions to tracked settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(go:*)",
+      "Bash(make:*)",
+      "Bash(golangci-lint:*)",
+      "Bash(goose:*)",
+      "Bash(sqlc:*)",
+      "Bash(gh:*)",
+      "Bash(curl:*)",
+      "Bash(grep:*)",
+      "Bash(ls:*)",
+      "Bash(govulncheck:*)",
+      "Bash(python3:*)",
+      "Bash(podman:*)",
+      "Bash(/opt/podman/bin/podman:*)",
+      "Bash(docker:*)",
+      "Bash(fly:*)",
+      "Bash(brew:*)",
+      "Bash(TESTCONTAINERS_RYUK_DISABLED=true go test:*)",
+      "Bash(TESTCONTAINERS_RYUK_DISABLED=true make:*)",
+      "Read(//Users/fzambone/**)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:pfm-go-api.zambone.dev)",
+      "WebSearch",
+      "mcp__plugin_context-mode_context-mode__ctx_execute",
+      "mcp__plugin_context-mode_context-mode__ctx_execute_file"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Consolidate 112-line `settings.local.json` (87 permissions) into 25 glob-pattern permissions in tracked `settings.json`
- Remove one-off session approvals, wrong-repo entries, and dangerous commands (`sudo rm`, `sh`)
- Consolidate tool-specific variants (`fly`, `docker`, `brew`) into single glob patterns
- Update MCP tool names and API domain to current values
- Clear `settings.local.json` for future local-only overrides

## Workspace Issue
Implements fzambone/pfm-workspace#2

## Verification
- [x] Acceptance criteria: PASS (25 entries, all tools covered, security audit clean)
- [x] Target repo CI gate: N/A (config-only change, no code affected)
- [x] `/project:review`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)