### PR TITLE
feat(hooks): add branch guard to block Edit/Write on main

### DIFF
--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Branch Guard — blocks Edit/Write on the main branch.
+# Used as a PreToolUse hook in Claude Code settings.json.
+
+# Consume stdin (hook protocol sends JSON with tool_name and tool_input)
+cat > /dev/null
+
+# Not a git repo — allow the edit
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+  exit 0
+fi
+
+# Detached HEAD (e.g., during rebase) — allow the edit
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+if [ $? -ne 0 ]; then
+  exit 0
+fi
+
+# Block on main
+if [ "$BRANCH" = "main" ]; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Branch Guard: Cannot edit files on main. Create a feature branch first:\\n  git checkout -b feat/<scope>-<description>-<N>"}}'
+  exit 0
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/branch-guard.sh"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(git:*)",


### PR DESCRIPTION
## Summary
- Add PreToolUse hook that denies Edit and Write tool calls when on the `main` branch
- Hook script at `.claude/hooks/branch-guard.sh` handles edge cases: detached HEAD, non-git dirs, subdirectories
- Deny message instructs user to create a feature branch with the correct naming format

## Workspace Issue
Implements fzambone/pfm-workspace#3

## Verification
- [x] Acceptance criteria: PASS (all 4 criteria + 3 edge cases verified)
- [x] Target repo CI gate: N/A (config-only change)
- [x] `/project:review`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)