### PR TITLE
feat(skills): add /project:openapi-check and wire into make ci

### DIFF
--- a/.claude/commands/project:openapi-check.md
+++ b/.claude/commands/project:openapi-check.md
@@ -1,0 +1,89 @@
+# Check OpenAPI Contract Consistency
+
+Run after modifying HTTP handlers or route annotations. Verifies that `api/swagger.yaml`
+matches the current handler annotations and flags any breaking changes in the diff.
+
+---
+
+## Phase 1 — Detect Drift
+
+Run the spec check against a temp directory (non-destructive — never modifies `api/swagger.yaml`):
+
+```
+make check-openapi
+```
+
+If the output is `OpenAPI spec is up to date.` → report:
+
+```
+OpenAPI contract: CLEAN
+No API changes detected on this branch.
+```
+
+Stop here. Nothing more to do.
+
+---
+
+## Phase 2 — Analyze the Diff
+
+If `make check-openapi` exits non-zero, it prints a unified diff directly to stdout.
+Read that diff output and classify each hunk:
+
+### Breaking changes (flag explicitly)
+
+| Pattern in diff | Classification |
+|---|---|
+| `-  /some/path:` (removed path block) | **BREAKING — endpoint removed** |
+| `-    delete:` / `-    get:` / etc. under an existing path | **BREAKING — HTTP method removed** |
+| `-      required:` entry removed or field removed from `required:` list | **BREAKING — required field removed** |
+| Property removed from a `definitions` block (`-        fieldName:`) | **BREAKING — response field removed** |
+| `type:` line changed (`-        type: string` → `+        type: integer`) | **BREAKING — field type changed** |
+| Parameter removed from `parameters:` block | **BREAKING — request parameter removed** |
+
+### Non-breaking changes (note, don't flag)
+
+| Pattern in diff | Classification |
+|---|---|
+| New path added | Non-breaking — new endpoint |
+| New property added to a definition | Non-breaking — additive field |
+| Description or summary text changed | Non-breaking — docs only |
+| New parameter added with no `required: true` | Non-breaking — optional param |
+
+---
+
+## Phase 3 — Report
+
+Produce a structured report:
+
+```
+OpenAPI contract: DRIFT DETECTED
+Branch: <current branch>
+
+Breaking changes:
+  [BREAKING] <path or definition> — <what changed>
+  ...
+
+Non-breaking changes:
+  [ADDED]   <path or field> — <description>
+  ...
+
+Action required:
+  If these changes are intentional: commit api/swagger.yaml alongside the handler change.
+  If not intentional: revert the handler annotation or run `make generate` to sync.
+
+Run `make generate` to regenerate api/swagger.yaml from current annotations.
+```
+
+If there are breaking changes, end with:
+
+```
+WARNING: This branch introduces breaking API changes. Coordinate with consumers before merging.
+```
+
+---
+
+## Rules
+
+- Never modify `api/swagger.yaml` directly — it is generated output.
+- Never run `make generate` on behalf of the user — report and let them decide.
+- The spec must be committed alongside the handler change that caused it.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help up down logs ps clean db-shell db-logs otel-logs build-docker test test-integration coverage vuln lint build generate ci
+.PHONY: help up down logs ps clean db-shell db-logs otel-logs build-docker test test-integration coverage vuln lint build generate check-openapi ci
 
 # GOBIN resolves to the user's GOPATH bin directory where tools like govulncheck and sqlc live.
 # Install govulncheck once with: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -81,6 +81,20 @@ generate: ## Regenerate sqlc Go code and OpenAPI spec from handler annotations
 	$(GOBIN)/sqlc generate
 	$(GOBIN)/swag init -g cmd/pfm/main.go --output api/ --outputTypes yaml
 
+check-openapi: ## Verify OpenAPI spec matches handler annotations (non-destructive — uses a temp dir)
+	@TMPDIR=$$(mktemp -d) && \
+	$(GOBIN)/swag init -g cmd/pfm/main.go --output $$TMPDIR --outputTypes yaml --quiet > /dev/null 2>&1; \
+	if diff -q api/swagger.yaml $$TMPDIR/swagger.yaml > /dev/null 2>&1; then \
+		printf 'OpenAPI spec is up to date.\n'; \
+		rm -rf $$TMPDIR; \
+	else \
+		printf 'FAIL: OpenAPI spec has drifted from handler annotations.\n'; \
+		printf 'Run '\''make generate'\'' to update api/swagger.yaml, then commit the result.\n\n'; \
+		diff api/swagger.yaml $$TMPDIR/swagger.yaml || true; \
+		rm -rf $$TMPDIR; \
+		exit 1; \
+	fi
+
 vuln: ## Run govulncheck vulnerability scan
 	$(GOBIN)/govulncheck ./...
 
@@ -99,11 +113,13 @@ ci: ## Run full CI gate (lint + coverage + vuln + integration tests + build) —
 	$(MAKE) vuln             > .ci-logs/vuln.log          2>&1 & p3=$$!; \
 	$(MAKE) build            > .ci-logs/build.log         2>&1 & p4=$$!; \
 	$(MAKE) test-integration > .ci-logs/integration.log   2>&1 & p5=$$!; \
+	$(MAKE) check-openapi    > .ci-logs/openapi.log       2>&1 & p6=$$!; \
 	wait $$p1 && printf '  lint         ✓\n' || { printf '  lint         ✗\n'; FAILED=1; }; \
 	wait $$p2 && printf '  coverage     ✓\n' || { printf '  coverage     ✗\n'; FAILED=1; }; \
 	wait $$p3 && printf '  vuln         ✓\n' || { printf '  vuln         ✗\n'; FAILED=1; }; \
 	wait $$p4 && printf '  build        ✓\n' || { printf '  build        ✗\n'; FAILED=1; }; \
 	wait $$p5 && printf '  integration  ✓\n' || { printf '  integration  ✗\n'; FAILED=1; }; \
+	wait $$p6 && printf '  openapi      ✓\n' || { printf '  openapi      ✗\n'; FAILED=1; }; \
 	if [ $$FAILED -ne 0 ]; then \
 		printf '\nCI FAILED. Logs:\n'; \
 		for f in .ci-logs/*.log; do printf '\n── %s ──\n' "$$f"; cat "$$f"; done; \


### PR DESCRIPTION
## Summary
- Add `check-openapi` Makefile target: non-destructive swag run into a temp dir, diffs against committed `api/swagger.yaml`, exits non-zero on drift
- Wire `check-openapi` as parallel job `p6` in `make ci` (alongside lint/coverage/vuln/build/integration)
- Add `/project:openapi-check` skill: detects drift, annotates diff with breaking vs non-breaking classifications, short-circuits with "no API changes detected" on a clean spec

## Workspace Issue
Implements fzambone/pfm-workspace#11

## Verification
- [x] Acceptance criteria: PASS (all 4 REQs covered)
- [x] `make check-openapi` tested standalone — exits non-zero on real spec drift, clean output
- [x] `make help` lists `check-openapi` ✓
- [x] `/project:review`: PASS
- [x] `/project:verify-issue`: PASS